### PR TITLE
Reversed a axis and feed rate scaling range fixes

### DIFF
--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -292,7 +292,7 @@ class CNC:
 
             elif c == "A":
                 self.has_4axis = True
-                self.aval = value * self.unit
+                self.aval = value * self.unit * -1  # Correct rotation
                 if not self.absolute:
                     self.aval += self.a
                 self.da = self.aval - self.a

--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -292,7 +292,7 @@ class CNC:
 
             elif c == "A":
                 self.has_4axis = True
-                self.aval = value * self.unit * -1  # Correct rotation
+                self.aval = value * self.unit * -1  # Right Hand Rule rotation. A+ movement when looking at rotary jaws is CCW rotation
                 if not self.absolute:
                     self.aval += self.a
                 self.da = self.aval - self.a

--- a/carveracontroller/Utils.py
+++ b/carveracontroller/Utils.py
@@ -51,7 +51,6 @@ icons     = {}
 images     = {}
 config    = ConfigParser.ConfigParser()
 toolconfig = ConfigParser.ConfigParser()
-print("new-config", __name__, config) #This is here to debug the fact that config is sometimes instantiated twice
 language  = ""
 
 _errorReport = True

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -509,8 +509,8 @@
                     pos: self.pos
                     size: self.size
             id: scale_slider
-            min: 50
-            max: 200
+            min: 10
+            max: 300
             value: 100
             step: 10
             set_flag: False


### PR DESCRIPTION
- Fixes the A axis rotation in the 3d viewer
- Increase the feed rate scaling range from 50-200 to 10-300. The stepping is still 10%