### PR TITLE
Config file load exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[Unreleased]
+- Fix: Exception handling for loading machine config file into controller
+
 [0.5.2]
 - Fix: Upload-and-select fails to load local gcode file when machine supports .lz compression
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 [Unreleased]
-- Fix: Exception handling for loading machine config file into controller
+- Fix: Exception handling for loading machine config file into controller. If the config can't be parsed correctly it will be skipped and a warning message shown on screen.
 
 [0.5.2]
 - Fix: Upload-and-select fails to load local gcode file when machine supports .lz compression

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -2136,7 +2136,10 @@ class Makera(RelativeLayout):
             setting_config.read_string(config_string)
             for section_name in setting_config.sections():
                 for (key, value) in setting_config.items(section_name):
-                    self.setting_list[key.strip()] = value.strip()
+                    try:
+                        self.setting_list[key.strip()] = value.strip()
+                    except AttributeError:
+                        print('Invalid setting key/value encountered, skipping')
             self.load_coordinates()
             self.load_laser_offsets()
             self.setting_change_list = {}

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -2139,7 +2139,8 @@ class Makera(RelativeLayout):
                     try:
                         self.setting_list[key.strip()] = value.strip()
                     except AttributeError:
-                        print('Invalid setting key/value encountered, skipping')
+                        Clock.schedule_once(partial(self.load_error, tr._('Error loading machine config setting. Possibly malformed value.\nSkipping setting key: ') + str(key)), 0)
+            
             self.load_coordinates()
             self.load_laser_offsets()
             self.setting_change_list = {}


### PR DESCRIPTION
Handle malformed config file config files by skipping the config item. Resolves #92 