### PR TITLE
Auto level offsets

### DIFF
--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -187,7 +187,7 @@ class Controller:
                 self.log.put((Controller.MSG_ERROR, str(sys.exc_info()[1])))
 
     # ----------------------------------------------------------------------
-    def autoCommand(self, margin=False, zprobe=False, zprobe_abs=False, leveling=False, goto_origin=False, z_probe_offset_x=0, z_probe_offset_y=0, i=3, j=3, h=5, buffer=False):
+    def autoCommand(self, margin=False, zprobe=False, zprobe_abs=False, leveling=False, goto_origin=False, z_probe_offset_x=0, z_probe_offset_y=0, i=3, j=3, h=5, buffer=False, auto_level_offsets = [0,0,0,0]):
         if not (margin or zprobe or leveling or goto_origin):
             return
         if abs(CNC.vars['xmin']) > CNC.vars['worksize_x'] or abs(CNC.vars['ymin']) > CNC.vars['worksize_y']:
@@ -195,13 +195,16 @@ class Controller:
         cmd = "M495 X%gY%g" % (CNC.vars['xmin'], CNC.vars['ymin'])
         if margin:
             cmd = cmd + "C%gD%g" % (CNC.vars['xmax'], CNC.vars['ymax'])
-        if zprobe:
-            if zprobe_abs:
+            self.executeCommand(cmd) #run margin command. Has to be two seperate commands to offset the start of the autolevel process
+        cmd = "M495 X%gY%g" % (CNC.vars['xmin'] + auto_level_offsets[0], CNC.vars['ymin'] + auto_level_offsets[2]) #reinitialize command with any autolevel offsets
+        if zprobe: 
+            if zprobe_abs: 
+                cmd = "M495 X%gY%g" % (CNC.vars['xmin'], CNC.vars['ymin']) #reset command for 4th axis
                 cmd = cmd + "O0"
-            else:
+            else: 
                 cmd = cmd + "O%gF%g" % (z_probe_offset_x, z_probe_offset_y)
         if leveling:
-            cmd = cmd + "A%gB%gI%dJ%dH%d" % (CNC.vars['xmax'] - CNC.vars['xmin'], CNC.vars['ymax'] - CNC.vars['ymin'], i, j, h)
+            cmd = cmd + "A%gB%gI%dJ%dH%d" % (CNC.vars['xmax'] - (CNC.vars['xmin']+auto_level_offsets[1]+ auto_level_offsets[0]) , CNC.vars['ymax'] - (CNC.vars['ymin']+auto_level_offsets[3] + auto_level_offsets[2]), i, j, h)
         if goto_origin:
             cmd = cmd + "P1"
         cmd = cmd + "\n"

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1745,9 +1745,9 @@
         GridLayout:
             spacing: '3dp'
             size_hint_y: None
-            height: '110dp'
+            height: '240dp'
             cols: 5
-            rows: 4
+            rows: 8
             # row1
             Label:
                 size_hint_x: 0.2
@@ -1812,6 +1812,77 @@
                 on_text:
                     root.init()
 
+            #empty row
+            Label:
+                size_hint_x: 0.2
+            Label:
+                
+            Label:
+                
+            Label:
+                
+            Label:
+                
+
+            # row5 new section
+            Label:
+                size_hint_x: 0.2
+            Label:
+            Label:
+                id: lb_height
+                text: tr._('Offsets:   ')
+            MCQCheckBox:
+                id: cbx_autolevelOffsets
+            Label:
+            # row6
+            Label:
+                size_hint_x: 0.2
+            Label:
+                text: tr._('Left X-')
+            Label:
+                text: tr._('Right X+')
+            Label:
+                text: tr._('Front Y-')
+            Label:
+                text: tr._('Back Y+')
+            # row7
+
+            Label:
+                size_hint_x: 0.2
+            TextInput:
+                id: txt_auto_xn_offset
+                hint_text: tr._('Enter -X Offset')
+                multiline: False
+                text: '5'
+                input_type: 'number'
+                input_filter: 'float'
+                disabled: not cbx_autolevelOffsets.active
+            TextInput:
+                id: txt_auto_xp_offset
+                hint_text: tr._('Enter +X Offset')
+                multiline: False
+                text: '5'
+                input_type: 'number'
+                input_filter: 'float'
+                disabled: not cbx_autolevelOffsets.active
+            TextInput:
+                id: txt_auto_yn_offset
+                hint_text: tr._('Enter -Y Offset')
+                multiline: False
+                text: '5'
+                input_type: 'number'
+                input_filter: 'float'
+                disabled: not cbx_autolevelOffsets.active
+            TextInput:
+                id: txt_auto_yp_offset
+                hint_text: tr._('Enter +Y Offset')
+                multiline: False
+                text: '5'
+                input_type: 'number'
+                input_filter: 'float'
+                disabled: not cbx_autolevelOffsets.active
+
+
         BoxLayout:
             id: empty
         BoxLayout:
@@ -1829,6 +1900,13 @@
                     root.coord_popup.set_config('leveling', 'height', int(sp_height.text))
                     root.coord_popup.set_config('leveling', 'x_points', int(sp_x_points.text))
                     root.coord_popup.set_config('leveling', 'y_points', int(sp_y_points.text))
+                    root.coord_popup.set_config('leveling', 'xn_offset', float(txt_auto_xn_offset.text) if cbx_autolevelOffsets.active and txt_auto_xn_offset.text.strip() and txt_auto_xn_offset.text != '.' else 0.0)
+                    root.coord_popup.set_config('leveling', 'xp_offset', float(txt_auto_xp_offset.text) if cbx_autolevelOffsets.active and txt_auto_xp_offset.text.strip() and txt_auto_xp_offset.text != '.' else 0.0)
+                    root.coord_popup.set_config('leveling', 'yn_offset', float(txt_auto_yn_offset.text) if cbx_autolevelOffsets.active and txt_auto_yn_offset.text.strip() and txt_auto_yn_offset.text != '.' else 0.0)
+                    root.coord_popup.set_config('leveling', 'yp_offset', float(txt_auto_yp_offset.text) if cbx_autolevelOffsets.active and txt_auto_yp_offset.text.strip() and txt_auto_yp_offset.text != '.' else 0.0)
+                    if cbx_autolevelOffsets.active: root.coord_popup.set_config('zprobe', 'x_offset', float(txt_auto_xn_offset.text) if txt_auto_xn_offset.text.strip() and txt_auto_xn_offset.text != '.' else 0.0)
+                    if cbx_autolevelOffsets.active: root.coord_popup.set_config('zprobe', 'y_offset', float(txt_auto_yn_offset.text) if txt_auto_yn_offset.text.strip() and txt_auto_yn_offset.text != '.' else 0.0)
+
                     root.coord_popup.load_leveling_label()
                     if root.execute: app.root.execute_autolevel(int(sp_x_points.text), int(sp_y_points.text), False)
                     root.dismiss()
@@ -2730,7 +2808,7 @@
                 Label:
                     id: lb_leveling
                     size_hint_y: None
-                    height: '25dp'
+                    height: '50dp'
                     text: tr._(" X Points: 10, Y Points: 10, Height: 5")
                     disabled:  (root.mode != 'Run' and root.mode != 'Leveling') or app.has_4axis
                     halign: "left"


### PR DESCRIPTION
Add in graphical autolevel offsets that allow the user to inset the auto leveling inside the machining boundary. solution to issue #23.

I have tested the probing with margin turned on and off, and probed the 4th axis to make sure no shenanigans occur with that different method of probing. 

A video tutorial is in the works and will be posted to the community youtube page once it has been edited.

![image](https://github.com/user-attachments/assets/3885bd25-4b22-4082-9677-2b6716186788)
