### PR TITLE
Add run.sh script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+cd ..
+
+poetry sync
+poetry run python -m carveracontroller


### PR DESCRIPTION
I always end up forgetting the exact incantation to run various projects, so prefer to have a generic `run` script that runs what you need to run the vast majority of the time.

This adds a basic run script that calls `poetry sync` to ensure the dependencies are up to date with the `poetry.lock` file, and then calls the `poetry run python -m carveracontroller` as described in the `README`.

If desired, I could also add a check for `which poetry` and suggest checking your `$PATH` is set correctly and/or running `curl -sSL https://install.python-poetry.org | python3 -` if it is not found