### PR TITLE
Bugfix: Fixing Tooltip Box Size And Persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Enhancement: The ability to reduce the size of the autolevel probe area. This enables the ability to avoid probing the stock where there might be obstacles preventing probing.
 -Enhancement: tooltip support. See https://github.com/Carvera-Community/Carvera_Controller/pull/143 for more information
 - Enhancement: support copy keyboard shortcut from MDI window
+-Bugfix: tooltips no longer persist when the parent object is unfocoused
+-Bugfix: tooltips no longer cut off certain longer strings of text
 
 [0.7.1]
 - Fix: Set a default for the A axis microsteps per degree config option

--- a/carveracontroller/addons/tooltips/Tooltips.kv
+++ b/carveracontroller/addons/tooltips/Tooltips.kv
@@ -3,8 +3,6 @@
 
 <ToolTipDropDown>:
 
-<ToolTipLabel>:
-
 <Tooltip>:
     size_hint: None, None
     width: max(tooltip_label.texture_size[0] + 20, tooltip_image.width + 20)
@@ -17,13 +15,13 @@
         Color:
             rgba: 0.1, 0.1, 0.1, 0.9
         Rectangle:
-            size: self.size
+            size: self.size[0]+10,self.size[1]
             pos: self.pos
         Color:
             rgba: 0.8, 0.8, 0.8, 1  # Light grey border
         Line:
             width: 1.5
-            rectangle: (*self.pos, *self.size) 
+            rectangle: (self.pos[0],self.pos[1], self.size[0] + 10 ,self.size [1]) 
 
     BoxLayout:
         size_hint: None, None

--- a/carveracontroller/addons/tooltips/Tooltips.py
+++ b/carveracontroller/addons/tooltips/Tooltips.py
@@ -55,8 +55,8 @@ class ToolTipButton(Button):
 
         image_widget = self._tooltip.ids.tooltip_image
         image_widget.bind(texture_size=self._update_image_size)
-        self._update_tooltip()
         self._update_image()
+        self._update_tooltip()
 
     def _update_tooltip(self, *largs):
         txt = self.tooltip_txt
@@ -103,12 +103,15 @@ class ToolTipButton(Button):
 
     def on_mouse_pos(self, *args):
         if not self.get_root_window():
+            self.close_tooltip()
             return
         
         if not self.tooltip_txt and not self.tooltip_image:
+            self.close_tooltip()
             return
         
         if self.disabled:
+            self.close_tooltip()
             return
         
     
@@ -185,8 +188,8 @@ class ToolTipDropDown(DropDown):
 
         image_widget = self._tooltip.ids.tooltip_image
         image_widget.bind(texture_size=self._update_image_size)
-        self._update_tooltip()
         self._update_image()
+        self._update_tooltip()
 
     def _update_tooltip(self, *largs):
         txt = self.tooltip_txt
@@ -233,12 +236,15 @@ class ToolTipDropDown(DropDown):
 
     def on_mouse_pos(self, *args):
         if not self.get_root_window():
+            self.close_tooltip()
             return
         
         if not self.tooltip_txt and not self.tooltip_image:
+            self.close_tooltip()
             return
         
         if self.disabled:
+            self.close_tooltip()
             return
         
     
@@ -316,8 +322,9 @@ class ToolTipLabel(Label):
 
         image_widget = self._tooltip.ids.tooltip_image
         image_widget.bind(texture_size=self._update_image_size)
-        self._update_tooltip()
+        
         self._update_image()
+        self._update_tooltip()
 
     def _update_tooltip(self, *largs):
         txt = self.tooltip_txt
@@ -364,12 +371,15 @@ class ToolTipLabel(Label):
 
     def on_mouse_pos(self, *args):
         if not self.get_root_window():
+            self.close_tooltip()
             return
         
         if not self.tooltip_txt and not self.tooltip_image:
+            self.close_tooltip()
             return
         
         if self.disabled:
+            self.close_tooltip()
             return
         
     


### PR DESCRIPTION
Tooltips will now disappear correctly when the original tooltip creator has lost focus such as when opening the settings menu. (sometimes you have to shift the mouse to make the tooltip disappear) Tooltip background boxes now no longer cut off certain long strings of text