### PR TITLE
Reduce tooltip delay from 2s to 0.5s

### DIFF
--- a/carveracontroller/addons/tooltips/Tooltips.py
+++ b/carveracontroller/addons/tooltips/Tooltips.py
@@ -27,7 +27,7 @@ class ToolTipButton(Button):
     tooltip_txt = StringProperty('')
     tooltip_cls = ObjectProperty(Tooltip)
     tooltip_image = StringProperty('')
-    tooltip_delay = 2
+    tooltip_delay = 0.5
     tooltip_image_size = ObjectProperty(None)
 
     def __init__(self, **kwargs):
@@ -160,7 +160,7 @@ class ToolTipDropDown(DropDown):
     tooltip_txt = StringProperty('')
     tooltip_cls = ObjectProperty(Tooltip)
     tooltip_image = StringProperty('')
-    tooltip_delay = 2
+    tooltip_delay = 0.5
     tooltip_image_size = ObjectProperty(None)
 
     def __init__(self, **kwargs):
@@ -294,7 +294,7 @@ class ToolTipLabel(Label):
     tooltip_txt = StringProperty('')
     tooltip_cls = ObjectProperty(Tooltip)
     tooltip_image = StringProperty('')
-    tooltip_delay = 2
+    tooltip_delay = 0.5
     tooltip_image_size = ObjectProperty(None)
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Not sure if there is any opposition to this, but I'm finding the current 2 second delay before showing the tooltips to be rather slow, especially if you're trying to hunt for a specific option or browse what is available. This reduces it to 0.5s, although an even shorter (or possibly no) delay might be better? Thoughts?

## Before
https://github.com/user-attachments/assets/ae321169-138c-467a-b81e-2c35c67e3e4c

## After
https://github.com/user-attachments/assets/13623b9f-7c1a-4ff6-9e20-578923a62826