### PR TITLE
Fixed squished center buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enhancement: Set and change to custom tool number
 - Bugfix: Fixed Speed/Feed scaling when using +/- buttons. Now can reach 10% and 300% scaling.
 - Bugfix: Fixed firmware download button. Now opens the github releases page for the Community firmware
+- Bugfix: Fixed squished center buttons
 
 [0.7.1]
 - Fix: Set a default for the A axis microsteps per degree config option

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -242,7 +242,6 @@
 
 <SmallRoundButton@Button>:
     background_color: 0,0,0,0  # the last zero is the critical on, make invisible
-    size_hint_y: None
     height: '35dp'
     canvas.before:
         Color:
@@ -305,7 +304,7 @@
 <JogSpeedDropDown>:
     on_select: app.root.ids.jog_speed_btn.text = tr._('Jog Speed:') + args[1]
     Button:
-        text: tr._('Same as Feed')
+        text: tr._('Match Feed')
         size_hint_y: None
         height: '40dp'
         on_release:
@@ -3391,15 +3390,17 @@
                                         on_release: root.controller.jog_with_speed("Y{}".format(root.step_xy.text), root.jog_speed)
                                 GridBoxLayout:
                         BoxLayout:
+                            disabled: app.state != 'Idle'
                             orientation: 'vertical'
-                            
-                            BoxLayout:
+                            padding: '10dp'
+                            Widget:
+                                size_hint_y: 0.5
                             BoxLayout:
                                 disabled: app.state != 'Idle'
                                 orientation: 'vertical'
-                                padding: '10dp'
+                                padding: '3dp'
                                 BoxLayout:
-                                    padding: '10dp'
+                                    padding: '3dp'
                                     canvas.before:
                                         Color:
                                             rgba: 50/255, 50/255, 50/255, 1
@@ -3408,6 +3409,7 @@
                                             size: self.size
                                             radius: [dp(12),]
                                     GridLayout:
+                                        padding: '10dp'
                                         cols: 3
                                         rows: 3
                                         GridBoxLayout:
@@ -3458,7 +3460,6 @@
                                         GridBoxLayout:
                                             Spinner:
                                                 center: 0.5, 0.5
-                                                size_hint_y: None
                                                 height: '35dp'
                                                 text: tr._('Goto...')
                                                 values: 'Clearance', 'Work Origin', 'Path Origin', 'Anchor1', 'Anchor2'
@@ -3471,8 +3472,7 @@
                                                 on_release: root.coord_popup.origin_popup.open()
                                         GridBoxLayout:
                                             ToggleButton:
-                                                text: tr._('Adv Jog Controls')
-                                                size_hint_y: None
+                                                text: tr._('Jog Controls')
                                                 height: '35dp'
                                                 on_release: app.root.toggle_jog_control_ui()
                             BoxLayout:
@@ -3495,9 +3495,8 @@
                                                     radius: [dp(12),]
                                             GridBoxLayout:
                                                 Button:
-                                                    text: tr._('Jog Speed: Same as Feed')
+                                                    text: tr._('Jog Speed: Match Feed')
                                                     id: jog_speed_btn
-                                                    size_hint_y: None
                                                     center: 0.5, 0.5
                                                     height: '35dp'
                                                     on_release: root.jog_speed_drop_down.open(self)
@@ -3507,7 +3506,6 @@
                                                     id: kb_jog_btn
                                                     text: tr._('Keyboard Jog Mode')
                                                     height: '35dp'
-                                                    size_hint_y: None
                                                     on_release: app.root.toggle_keyboard_jog_control()
 
                         BoxLayout:


### PR DESCRIPTION
My attempt to fix #140 .

1x DPI looks correct now, but 2x looks a bit smaller than it should on my machine.

Still better than the "overinflated" look previously