### PR TITLE
Fixes MDI input box no longer accepting text, only numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enhancement: Added 3 axis probe screen
 - Enhancement: update_translations.py now searches for all .py and .kv files in the project instead of manually adding each one
 - Enhancement: Added enclosure light switch to centre control panel
+- Bugfix: Fixed inability to type in MDI command text input
 
 
 [0.7.1]

--- a/carveracontroller/addons/probing/ProbingControls.kv
+++ b/carveracontroller/addons/probing/ProbingControls.kv
@@ -37,7 +37,7 @@
         text_size: self.size
         multiline: False
 
-<TextInput>
+<ProbeTextInput@TextInput>:
     multiline: False
     halign:'right'
     input_type: 'number'


### PR DESCRIPTION
I believe this definition was somehow affecting the global definition, although nothing in this Kivy stuff makes any sense to me ;)