### PR TITLE
Add initial support for WHB04 pendant

### DIFF
--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -296,9 +296,12 @@ class Controller:
     def clearAutoLeveling(self):
         self.executeCommand("M370\n")
 
-    def setSpindleSwitch(self, switch, rpm):
+    def setSpindleSwitch(self, switch, rpm=None):
         if switch:
-            self.executeCommand("M3 S%d\n" % (rpm))
+            if rpm is None:
+                self.executeCommand("M3\n")
+            else:
+                self.executeCommand("M3 S%d\n" % (rpm))
         else:
             self.executeCommand("M5\n")
 

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -200,11 +200,11 @@ class Controller:
                 cmd = "buffer " + cmd
             self.executeCommand(cmd) #run margin command. Has to be two seperate commands to offset the start of the autolevel process
         cmd = "M495 X%gY%g" % (CNC.vars['xmin'] + auto_level_offsets[0], CNC.vars['ymin'] + auto_level_offsets[2]) #reinitialize command with any autolevel offsets
-        if zprobe: 
-            if zprobe_abs: 
+        if zprobe:
+            if zprobe_abs:
                 cmd = "M495 X%gY%g" % (CNC.vars['xmin'], CNC.vars['ymin']) #reset command for 4th axis
                 cmd = cmd + "O0"
-            else: 
+            else:
                 cmd = cmd + "O%gF%g" % (z_probe_offset_x, z_probe_offset_y)
         if leveling:
             cmd = cmd + "A%gB%gI%dJ%dH%d" % (CNC.vars['xmax'] - (CNC.vars['xmin']+auto_level_offsets[1]+ auto_level_offsets[0]) , CNC.vars['ymax'] - (CNC.vars['ymin']+auto_level_offsets[3] + auto_level_offsets[2]), i, j, h)
@@ -384,7 +384,7 @@ class Controller:
 
     def clampToolCommand(self):
         self.executeCommand("M490.1\n")
-    
+
     def unclampToolCommand(self):
         self.executeCommand("M490.2\n")
 
@@ -829,8 +829,8 @@ class Controller:
 
     # ----------------------------------------------------------------------
     def jog(self, _dir):
-        self.executeCommand("G91G0{}".format(_dir))
-    
+        self.executeCommand("G91G0{}F5000".format(_dir))
+
     def jog_with_speed(self, _dir, speed):
         if speed > 0:
             self.executeCommand(f"G91G0{_dir} F{speed}")
@@ -845,6 +845,17 @@ class Controller:
         if y is not None: cmd += "Y%g" % (y)
         if z is not None: cmd += "Z%g" % (z)
         self.sendGCode("%s" % (cmd))
+
+    def gotoSafeZ(self):
+        self.sendGCode("G53 G0 Z0")
+
+    def gotoMachineHome(self):
+        self.gotoSafeZ()
+        self.sendGCode("G53 G0 X0 Y0")
+
+    def gotoWCSHome(self):
+        self.gotoSafeZ()
+        self.sendGCode("G53 G0 X%g Y%g" % (CNC.vars['wcox'], CNC.vars['wcoy']))
 
     def wcsSetA(self, a = None):
         cmd = "G92.4"
@@ -886,7 +897,7 @@ class Controller:
         cmd += pos
 
         self.sendGCode(cmd)
-    
+
     def wcsClearRotation(self):
         cmd = "G10L2R0P0"
         self.sendGCode(cmd)

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -297,13 +297,13 @@ class Controller:
         self.executeCommand("M370\n")
 
     def setSpindleSwitch(self, switch, rpm=None):
-        if switch:
-            if rpm is None:
-                self.executeCommand("M3\n")
-            else:
-                self.executeCommand("M3 S%d\n" % (rpm))
+        if switch and rpm is not None:
+            cmd = f"M3 S{int(rpm)}\n"
+        elif switch and rpm is None:
+            cmd = "M3\n"
         else:
-            self.executeCommand("M5\n")
+           cmd = "M5\n"
+        self.executeCommand(cmd)
 
     def setVacuumPower(self, power=0):
         if power > 0:

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -829,7 +829,7 @@ class Controller:
 
     # ----------------------------------------------------------------------
     def jog(self, _dir):
-        self.executeCommand("G91G0{}F5000".format(_dir))
+        self.executeCommand("G91G0{}".format(_dir))
 
     def jog_with_speed(self, _dir, speed):
         if speed > 0:

--- a/carveracontroller/__main__.py
+++ b/carveracontroller/__main__.py
@@ -1,9 +1,5 @@
-from carveracontroller.main import main, init_lang, Lang
-
-# tr is used throughout the kivvy .kv definition files
-# thus kivy expects it be availiable from the caller
-default_lang = init_lang()
-tr = Lang(default_lang)
+from carveracontroller.main import main
+from carveracontroller.translation import tr
 
 if __name__ == "__main__":
     main()

--- a/carveracontroller/addons/pendant/__init__.py
+++ b/carveracontroller/addons/pendant/__init__.py
@@ -1,1 +1,2 @@
-from .pendant import SettingPendantSelector, SUPPORTED_PENDANTS
+from .pendant import SettingPendantSelector, SUPPORTED_PENDANTS, \
+    OverrideController

--- a/carveracontroller/addons/pendant/__init__.py
+++ b/carveracontroller/addons/pendant/__init__.py
@@ -1,0 +1,1 @@
+from .pendant import SettingPendantSelector, SUPPORTED_PENDANTS

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -1,0 +1,102 @@
+from typing import Callable
+from ...CNC import CNC
+from ...Controller import Controller
+from . import whb04
+
+from kivy.clock import Clock
+from kivy.uix.settings import SettingItem
+from kivy.uix.spinner import Spinner
+from kivy.uix.togglebutton import ToggleButton
+
+
+class Pendant:
+    def __init__(self, controller: Controller, cnc: CNC,
+                 report_connection: Callable[[], None],
+                 report_disconnection: Callable[[], None]) -> None:
+        self._controller = controller
+        self._cnc = cnc
+        self._report_connection = report_connection
+        self._report_disconnection = report_disconnection
+
+        self.is_jogging_enabled = False
+
+    def close(self) -> None:
+        pass
+
+    def executor(self, f: Callable[[], None]) -> None:
+        Clock.schedule_once(lambda _: f(), 0)
+
+class NonePendant(Pendant):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class WHB04(Pendant):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._is_spindle_running = False
+
+        self._daemon = whb04.Daemon(self.executor)
+
+        self._daemon.on_connect = self._handle_connect
+        self._daemon.on_disconnect = self._handle_disconnect
+        self._daemon.on_update = self._handle_display_update
+        self._daemon.on_jog = self._handle_jogging
+        self._daemon.on_button_press = self._handle_button_press
+
+        self._daemon.start()
+
+    def _handle_connect(self, daemon: whb04.Daemon) -> None:
+        daemon.set_display_step_indicator(whb04.StepIndicator.STEP)
+        self._report_connection()
+
+    def _handle_disconnect(self, daemon: whb04.Daemon) -> None:
+        self._report_disconnection()
+
+    def _handle_display_update(self, daemon: whb04.Daemon) -> None:
+        daemon.set_display_position(whb04.Axis.X, self._cnc.vars["wx"])
+        daemon.set_display_position(whb04.Axis.Y, self._cnc.vars["wy"])
+        daemon.set_display_position(whb04.Axis.Z, self._cnc.vars["wz"])
+        daemon.set_display_position(whb04.Axis.A, self._cnc.vars["wa"])
+
+    def _handle_jogging(self, daemon: whb04.Daemon, steps: int) -> None:
+        if not self.is_jogging_enabled:
+            return
+
+        distance = steps * daemon.step_size_value
+        axis = daemon.active_axis_name
+
+        if axis not in "XYZA":
+            return
+
+        self._controller.jog(f"{axis}{distance}")
+
+    def _handle_button_press(self, daemon: whb04.Daemon, button: whb04.Button) -> None:
+        if button == whb04.Button.S_ON_OFF:
+            self._is_spindle_running = not self._is_spindle_running
+            self._controller.setSpindleSwitch(self._is_spindle_running)
+
+        if button == whb04.Button.RESET:
+            self._controller.estopCommand()
+
+
+SUPPORTED_PENDANTS = {
+    "None": NonePendant,
+    "WHB04": WHB04
+}
+
+
+class SettingPendantSelector(SettingItem):
+    def __init__(self, **kwargs):
+        self.spinner = Spinner(text="None", values=list(SUPPORTED_PENDANTS.keys()), size_hint=(1, None), height='36dp')
+        super().__init__(**kwargs)
+        self.spinner.bind(text=self.on_spinner_select)
+        self.add_widget(self.spinner)
+
+    def on_spinner_select(self, spinner, text):
+        self.panel.set_value(self.section, self.key, text)
+
+    def on_value(self, instance, value):
+        if self.spinner.text != value:
+            self.spinner.text = value

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -133,7 +133,10 @@ if WHB04_SUPPORTED:
             if axis not in "XYZA":
                 return
 
-            self._controller.jog(f"{axis}{distance}")
+            # Jog as fast as you can as the machine should follow the pendant as
+            # closely as possible. We choose some reasonably high speed here,
+            # the machine will limit itself to the maximum speed it can handle.
+            self._controller.jog_with_speed(f"{axis}{distance}", 10000)
 
         def _handle_button_press(self, daemon: whb04.Daemon, button: whb04.Button) -> None:
             is_fn_pressed = whb04.Button.FN in daemon.pressed_buttons

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -9,7 +9,7 @@ from ...Controller import Controller
 from kivy.clock import Clock
 from kivy.uix.settings import SettingItem
 from kivy.uix.spinner import Spinner
-from kivy.uix.togglebutton import ToggleButton
+from kivy.uix.anchorlayout import AnchorLayout
 
 
 class Pendant:
@@ -91,7 +91,7 @@ if WHB04_SUPPORTED:
 
             if button == whb04.Button.RESET:
                 self._controller.estopCommand()
-                
+
 
 SUPPORTED_PENDANTS = {
     "None": NonePendant
@@ -103,10 +103,14 @@ if WHB04_SUPPORTED:
 
 class SettingPendantSelector(SettingItem):
     def __init__(self, **kwargs):
+        # Wrapper to ensure the content is centered vertically
+        wrapper = AnchorLayout(anchor_y='center', anchor_x='left')
+
         self.spinner = Spinner(text="None", values=list(SUPPORTED_PENDANTS.keys()), size_hint=(1, None), height='36dp')
         super().__init__(**kwargs)
         self.spinner.bind(text=self.on_spinner_select)
-        self.add_widget(self.spinner)
+        wrapper.add_widget(self.spinner)
+        self.add_widget(wrapper)
 
     def on_spinner_select(self, spinner, text):
         self.panel.set_value(self.section, self.key, text)

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -4,8 +4,8 @@ from typing import Callable
 import logging
 logger = logging.getLogger(__name__)
 
-from ...CNC import CNC
-from ...Controller import Controller
+from carveracontroller.CNC import CNC
+from carveracontroller.Controller import Controller
 
 from kivy.clock import Clock
 from kivy.uix.settings import SettingItem

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -11,14 +11,15 @@ from kivy.uix.togglebutton import ToggleButton
 
 class Pendant:
     def __init__(self, controller: Controller, cnc: CNC,
+                 is_jogging_enabled: Callable[[], None],
                  report_connection: Callable[[], None],
                  report_disconnection: Callable[[], None]) -> None:
         self._controller = controller
         self._cnc = cnc
+
+        self._is_jogging_enabled = is_jogging_enabled
         self._report_connection = report_connection
         self._report_disconnection = report_disconnection
-
-        self.is_jogging_enabled = False
 
     def close(self) -> None:
         pass
@@ -61,7 +62,7 @@ class WHB04(Pendant):
         daemon.set_display_position(whb04.Axis.A, self._cnc.vars["wa"])
 
     def _handle_jogging(self, daemon: whb04.Daemon, steps: int) -> None:
-        if not self.is_jogging_enabled:
+        if not self._is_jogging_enabled():
             return
 
         distance = steps * daemon.step_size_value

--- a/carveracontroller/addons/pendant/whb04.py
+++ b/carveracontroller/addons/pendant/whb04.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from enum import Enum
+import struct
+import threading
+import time
+from typing import Callable, Optional
+import hid
+
+class Button(Enum):
+    RESET = 0x01
+    STOP = 0x02
+    START_PAUSE = 0x03
+    FEED_PLUS = 0x04
+    FEED_MINUS = 0x05
+    SPINDLE_PLUS = 0x06
+    SPINDLE_MINUS = 0x07
+    M_HOME = 0x08
+    SAFE_Z = 0x09
+    W_HOME = 0x0a
+    S_ON_OFF = 0x0b
+    FN = 0x0c
+    PROBE_Z = 0x0d
+    MACRO_10 = 0x10
+    MODE_CONTINUOUS = 0x0e
+    MODE_STEP = 0x0f
+
+class Axis(Enum):
+    OFF = 0x06
+    X = 0x11
+    Y = 0x12
+    Z = 0x13
+    A = 0x14
+    B = 0x15
+    C = 0x16
+
+class StepSize(Enum):
+    STEP_0_001 = 0x0d
+    STEP_0_01 = 0x0e
+    STEP_0_1 = 0x0f
+    STEP_1 = 0x10
+    PERCENT_60 = 0x1a
+    PERCENT_100 = 0x1b
+    LEAD = 0x1c
+
+class StepIndicator(Enum):
+    CONTINUOUS = 0x00
+    STEP = 0x01
+    MPG = 0x02
+    PERCENT = 0x03
+
+class Daemon:
+    """
+    A class that establishes a connection to the WHB04 pedant, receives messages
+    and invokes callbacks.
+    """
+
+    DEVICE_IDS = [
+        (0x10ce, 0xeb93)
+    ]
+
+    def __init__(self, callback_executor: Callable[[Callable[[], None]], None] = lambda f: f()) -> None:
+        """
+        Params:
+
+        - callback_executor: a function that receives an invokable and it is
+          supposed to invoke it. E.g., in a way safe for GUI.
+        """
+        self._is_running = False
+        self._pressed_buttons = set()
+        self._active_axis = Axis.OFF
+        self._step_size = StepSize.LEAD
+
+        self._display_position = {
+            Axis.X: 0.0,
+            Axis.Y: 0.0,
+            Axis.Z: 0.0,
+            Axis.A: 0.0,
+            Axis.B: 0.0,
+            Axis.C: 0.0
+        }
+        self._display_feedrate = 0
+        self._display_spindle_speed = 0
+        self._display_step_indicator = StepIndicator.CONTINUOUS
+        self._display_reset = False
+        self._display_workpiece_coords = False
+
+        self.callback_executor = callback_executor
+
+        self.on_connect: Optional[Callable[[Daemon], None]] = None
+        self.on_disconnect: Optional[Callable[[Daemon], None]] = None
+        self.on_button_press: Optional[Callable[[Daemon, Button], None]] = None
+        self.on_button_release: Optional[Callable[[Daemon, Button], None]] = None
+        self.on_jog: Optional[Callable[[Daemon, int], None]] = None
+        self.on_axis_change: Optional[Callable[[Daemon, Axis], None]] = None
+        self.on_step_size_change: Optional[Callable[[Daemon, StepSize], None]] = None
+        self.on_update: Optional[Callable[[Daemon], None]] = None
+
+    def start(self) -> None:
+        self._daemon_thread = threading.Thread(target=self._thread_loop, daemon=True)
+        self._is_running = True
+        self._daemon_thread.start()
+
+    def stop(self) -> None:
+        if not self._is_running:
+            return
+        self._is_running = False
+        self._daemon_thread.join()
+
+    @property
+    def pressed_buttons(self) -> set[Button]:
+        """
+        Returns a set of currently pressed buttons.
+        """
+        return self._pressed_buttons
+
+    @property
+    def active_axis(self) -> Axis:
+        """
+        Returns the currently active axis.
+        """
+        return self._active_axis
+
+    @property
+    def active_axis_name(self) -> str:
+        """
+        Returns the name of the currently active axis.
+        This is a convenience method to get the axis name.
+        """
+        return {
+            Axis.OFF: "OFF",
+            Axis.X: "X",
+            Axis.Y: "Y",
+            Axis.Z: "Z",
+            Axis.A: "A",
+            Axis.B: "B",
+            Axis.C: "C"
+        }[self.active_axis]
+
+    @property
+    def step_size(self) -> StepSize:
+        """
+        Returns the currently active step size.
+        """
+        return self._step_size
+
+    @property
+    def step_size_value(self) -> float:
+        """
+        Returns the step size value as a float.
+        This is a convenience method to get the step size value.
+        """
+        if self._step_size == StepSize.STEP_0_001:
+            return 0.001
+        elif self._step_size == StepSize.STEP_0_01:
+            return 0.01
+        elif self._step_size == StepSize.STEP_0_1:
+            return 0.1
+        elif self._step_size == StepSize.STEP_1:
+            return 1.0
+        return 0
+
+    def set_display_position(self, axis: Axis, value: float) -> None:
+        """
+        Sets the display position for the given axis.
+        """
+        if axis not in self._display_position:
+            raise ValueError(f"Invalid axis: {axis}")
+        self._display_position[axis] = value
+
+    def set_display_feedrate(self, feedrate: int) -> None:
+        """
+        Sets the display feedrate.
+        """
+        if feedrate < 0 or feedrate > 65535:
+            raise ValueError("Feedrate outside range")
+        self._display_feedrate = feedrate
+
+    def set_display_spindle_speed(self, speed: int) -> None:
+        """
+        Sets the display spindle speed.
+        """
+        if speed < 0 or speed > 65535:
+            raise ValueError("Spindle speed outside range")
+        self._display_spindle_speed = speed
+
+    def set_display_step_indicator(self, indicator: StepIndicator) -> None:
+        """
+        Sets the display step indicator.
+        """
+        if not isinstance(indicator, StepIndicator):
+            raise ValueError("Invalid step indicator")
+        self._display_step_indicator = indicator
+
+    def set_display_reset(self, reset: bool) -> None:
+        """
+        Sets the display reset state.
+        """
+        if not isinstance(reset, bool):
+            raise ValueError("Reset must be a boolean value")
+        self._display_reset = reset
+
+    def set_display_machine_coords(self) -> None:
+        """
+        Sets the display to show machine coordinates.
+        """
+        self._display_workpiece_coords = False
+
+    def set_display_workpiece_coords(self) -> None:
+        """
+        Sets the display to show workpiece coordinates.
+        """
+        self._display_workpiece_coords = True
+
+    def _thread_loop(self) -> None:
+        while self._is_running:
+            try:
+                device = self._connect()
+                if device is None:
+                    continue
+
+                with device as guarded_device:
+                    if self.on_connect is not None:
+                        self.callback_executor(lambda: self.on_connect(self))
+                    self._device_loop(guarded_device)
+            except Exception:
+                # Exception means the device was disconnected or an error occurred.
+                # Let's just try again
+                pass
+            finally:
+                if self.on_disconnect is not None:
+                        self.callback_executor(lambda: self.on_disconnect(self))
+
+    def _connect(self, poll_interval: float = 0.1) -> Optional[hid.Device]:
+        while self._is_running:
+            for dev_info in hid.enumerate():
+                if (dev_info["vendor_id"], dev_info["product_id"]) in self.DEVICE_IDS:
+                    return hid.Device(path=dev_info["path"])
+            time.sleep(poll_interval)
+        return None
+
+    def _device_loop(self, device: hid.Device) -> None:
+        while self._is_running:
+            data = device.read(8, timeout=100)
+            if len(data) > 0:
+                self._process_input_packet(data)
+            if self.on_update is not None:
+                self.callback_executor(lambda: self.on_update(self))
+            self._refresh_display(device)
+
+    def _process_input_packet(self, data: bytes) -> None:
+        """
+        Processes the input packet received from the device.
+        This method should be overridden to handle specific data processing.
+        """
+        if len(data) != 8:
+            return
+
+        header, random_byte, button1, button2, step_rotary, \
+             axis_rotary, jog_delta, crc = struct.unpack('BBBBBBbB', data)
+
+        # As the checksum has not been reverse engineered yet, we will ignore it
+        # for now and just check the header.
+        if header != 0x04:
+            return
+
+        pressed_buttons = set()
+        if button1 != 0:
+            pressed_buttons.add(Button(button1))
+        if button2 != 0:
+            pressed_buttons.add(Button(button2))
+        newly_pressed = pressed_buttons - self._pressed_buttons
+        newly_released = self._pressed_buttons - pressed_buttons
+        self._pressed_buttons = pressed_buttons
+
+        has_axis_change = False
+        try:
+            active_axis = Axis(axis_rotary)
+            has_axis_change = active_axis != self._active_axis
+            self._active_axis = active_axis
+        except ValueError:
+            # We ignore error as quick rotary changes may lead to
+            # invalid axis values.
+            pass
+
+        has_step_size_change = False
+        try:
+            step_rotary = StepSize(step_rotary)
+            has_step_size_change = step_rotary != self._step_size
+            self._step_size = step_rotary
+        except ValueError:
+            # We ignore error as quick rotary changes may lead to
+            # invalid step size values.
+            pass
+
+        # We make sure that any callback is executed after fully updating the
+        # internal state of the daemon so the callback can use the methods.
+        for button in newly_pressed:
+            if self.on_button_press is not None:
+                self.callback_executor(lambda b=button: self.on_button_press(self, b))
+        for button in newly_released:
+            if self.on_button_release is not None:
+                self.callback_executor(lambda b=button: self.on_button_release(self, b))
+
+        if has_axis_change and self.on_axis_change is not None:
+            self.callback_executor(lambda a=self._active_axis: self.on_axis_change(self, a))
+
+        if has_step_size_change and self.on_step_size_change is not None:
+            self.callback_executor(lambda s=self._step_size: self.on_step_size_change(self, s))
+
+        if jog_delta != 0:
+            if self.on_jog is not None:
+                self.callback_executor(lambda d=jog_delta: self.on_jog(self, d))
+
+    def _refresh_display(self, device: hid.Device) -> None:
+        """
+        Refreshes the display of the pedant.
+        This method should be overridden to implement specific display logic.
+        """
+        display_flags = 0
+        display_flags |= self._display_step_indicator.value
+        if self._display_reset:
+            display_flags |= 0x40
+        if self._display_workpiece_coords:
+            display_flags |= 0x80
+
+        data = struct.pack('<HBB', 0xfdfe, 0xfe, display_flags)
+
+        LIN_AXES = [Axis.X, Axis.Y, Axis.Z]
+        ROT_AXES = [Axis.A, Axis.B, Axis.C]
+        visible_axes = LIN_AXES if self._active_axis in LIN_AXES else ROT_AXES
+        for coord in [self._display_position[a] for a in visible_axes]:
+            coord_abs = abs(coord)
+            coord_sign = 1 if coord < 0 else 0
+            scaled_coord = int(round(coord_abs * 10000))
+            integer_part = scaled_coord // 10000
+            fraction_part = scaled_coord % 10000
+
+            data += struct.pack('<HH',
+                              integer_part & 0xFFFF,
+                              (fraction_part & 0x7FFF) | (coord_sign << 15))
+
+        data += struct.pack('<HH',
+                            self._display_feedrate & 0xFFFF,
+                            self._display_spindle_speed & 0xFFFF)
+
+        # Add padding
+        while len(data) < 21:
+            data += b"\x00"
+
+        # Split into packets of 7 bytes each
+        for i in range(3):
+            start_idx = i * 7
+            end_idx = min(start_idx + 7, len(data))
+            packet_data = data[start_idx:end_idx]
+
+            # Pad to 7 bytes if needed
+            while len(packet_data) < 7:
+                packet_data += b'\x00'
+
+            # Add report ID (0x06) at the beginning
+            packet = b'\x06' + packet_data
+            device.send_feature_report(packet)
+
+
+
+if __name__ == "__main__":
+    daemon = Daemon()
+
+    daemon.set_display_step_indicator(StepIndicator.STEP)
+    daemon.set_display_machine_coords()
+
+    positions = {
+        Axis.X: 0,
+        Axis.Y: 0,
+        Axis.Z: 0,
+        Axis.A: 0
+    }
+
+    def update_jog(daemon: Daemon, jog_steps: int):
+        distance = jog_steps * daemon.step_size_value
+        positions[daemon.active_axis] += distance
+        daemon.set_display_position(daemon.active_axis, positions[daemon.active_axis])
+
+
+    daemon.on_connect = lambda _: print("Device connected")
+    daemon.on_disconnect = lambda _: print("Device disconnected")
+    daemon.on_button_press = lambda _, button: print(f"Button {button.name} pressed")
+    daemon.on_button_release = lambda _, button: print(f"Button {button.name} released")
+    daemon.on_jog = update_jog
+    daemon.on_axis_change = lambda _, axis: print(f"Active axis changed to {axis.name}")
+    daemon.on_step_size_change = lambda d, step_size: print(f"Step size changed to {step_size.name}/ {d.step_size_value}")
+
+
+    daemon.start()
+    while True:
+        time.sleep(1)

--- a/carveracontroller/addons/pendant/whb04.py
+++ b/carveracontroller/addons/pendant/whb04.py
@@ -90,7 +90,7 @@ class StepSize(Enum):
     STEP_1 = 0x10
     PERCENT_60 = 0x1a
     PERCENT_100 = 0x1b
-    LEAD = 0x1c
+    LEAD = 0x9b
 
 class StepIndicator(Enum):
     CONTINUOUS = 0x00
@@ -223,7 +223,7 @@ class Daemon:
         """
         if feedrate < 0 or feedrate > 65535:
             raise ValueError("Feedrate outside range")
-        self._display_feedrate = feedrate
+        self._display_feedrate = int(feedrate)
 
     def set_display_spindle_speed(self, speed: int) -> None:
         """
@@ -231,7 +231,7 @@ class Daemon:
         """
         if speed < 0 or speed > 65535:
             raise ValueError("Spindle speed outside range")
-        self._display_spindle_speed = speed
+        self._display_spindle_speed = int(speed)
 
     def set_display_step_indicator(self, indicator: StepIndicator) -> None:
         """

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -62,6 +62,22 @@
         "section": "kivy",
         "key": "keyboard_mode",
         "default": "",
-        "options": ["", "system", "dock", "multi", "systemanddock", "systemandmulti"] 
+        "options": ["", "system", "dock", "multi", "systemanddock", "systemandmulti"]
+    },
+    {
+        "type": "pendant",
+        "title": "Use Hardware Pendant",
+        "desc": "Select a hardware pendant to use with Carvera.",
+        "section": "carvera",
+        "key": "pendant_type",
+        "default": "None"
+    },
+    {
+        "type": "bool",
+        "title": "Jogging Via Pendant Is Default",
+        "desc": "This defines if the pendant jogging is automatically active on the jog screen",
+        "section": "carvera",
+        "key": "pendant_jogging_default",
+        "default": "true"
     }
 ]

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -63,21 +63,5 @@
         "key": "keyboard_mode",
         "default": "",
         "options": ["", "system", "dock", "multi", "systemanddock", "systemandmulti"]
-    },
-    {
-        "type": "pendant",
-        "title": "Use Hardware Pendant",
-        "desc": "Select a hardware pendant to use with Carvera.",
-        "section": "carvera",
-        "key": "pendant_type",
-        "default": "None"
-    },
-    {
-        "type": "bool",
-        "title": "Jogging Via Pendant Is Default",
-        "desc": "This defines if the pendant jogging is automatically active on the jog screen",
-        "section": "carvera",
-        "key": "pendant_jogging_default",
-        "default": "true"
     }
 ]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3776,8 +3776,10 @@ class Makera(RelativeLayout):
     def setup_pendant(self):
         self.handle_pendant_disconnected()
 
-        type = Config.get('carvera', 'pendant_type')
-        self.pendant = SUPPORTED_PENDANTS[type](self.controller, self.cnc,
+        type_name = Config.get('carvera', 'pendant_type')
+        pendant_type = SUPPORTED_PENDANTS.get(type_name, SUPPORTED_PENDANTS["None"])
+
+        self.pendant = pendant_type(self.controller, self.cnc,
                                 self.is_jogging_enabled,
                                 self.handle_pendant_connected,
                                 self.handle_pendant_disconnected)

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -152,6 +152,7 @@ import string
 import subprocess
 
 from . import Utils
+from . import ui
 from kivy.config import ConfigParser
 from .CNC import CNC
 from .GcodeViewer import GCodeViewer
@@ -704,6 +705,7 @@ class MakeraConfigPanel(SettingsWithSidebar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.register_type('pendant', SettingPendantSelector)
+        self.register_type('gcodesnippet', ui.SettingGCodeSnippet)
 
     def on_config_change(self, config, section, key, value):
         app = App.get_running_app()

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3577,7 +3577,9 @@ class Makera(RelativeLayout):
         controller_config_panels = 0
         for panel in panels.values():
             if panel.title == 'Controller':
-                controller_config_panels = 1
+                controller_config_panels += 1
+            if panel.title == 'Pendant':
+                controller_config_panels += 1
 
         if len(panels.values()) - controller_config_panels > 0:
             # already have panels, update data

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3774,12 +3774,12 @@ class Makera(RelativeLayout):
                                 self.handle_pendant_disconnected)
 
     def handle_pendant_connected(self):
-        self.ids.pendant_jogging_en_btn.text = tr._('Enable Pendant Jogging')
+        self.ids.pendant_jogging_en_btn.text = tr._('Enable Pendant')
         self.ids.pendant_jogging_en_btn.disabled = False
         self.ids.pendant_jogging_en_btn.state = 'down' if self.pendant_jogging_default else 'normal'
 
     def handle_pendant_disconnected(self):
-        self.ids.pendant_jogging_en_btn.text = tr._('No Pendant Connected')
+        self.ids.pendant_jogging_en_btn.text = tr._('No Pendant')
         self.ids.pendant_jogging_en_btn.disabled = True
 
     def handle_pendat_run_pause_resume(self):

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3757,6 +3757,13 @@ class Makera(RelativeLayout):
             app.root.ids.kb_jog_btn.state = 'normal'
             Window.unbind(on_key_down=self._keyboard_jog_keydown)
 
+    def is_jogging_enabled(self):
+        app = App.get_running_app()
+        return (app.state in ['Idle', 'Run', 'Pause'] or (app.playing and app.state == 'Pause')) and not self._is_popup_open()
+
+    def is_pendant_jogging_enabled(self):
+        return self.pendant_jogging_en_bt.state == 'down' and self.is_jogging_enabled()
+
     def toggle_keyboard_jog_control(self):
         app = App.get_running_app()
         app.root.keyboard_jog_control = not app.root.keyboard_jog_control  # toggle the boolean
@@ -3771,6 +3778,7 @@ class Makera(RelativeLayout):
 
         type = Config.get('carvera', 'pendant_type')
         self.pendant = SUPPORTED_PENDANTS[type](self.controller, self.cnc,
+                                self.is_jogging_enabled,
                                 self.handle_pendant_connected,
                                 self.handle_pendant_disconnected)
 
@@ -3798,7 +3806,7 @@ class Makera(RelativeLayout):
         app = App.get_running_app()
 
         # Only allow keyboard jogging when machine in a suitable state and has no popups open
-        if (app.state in ['Idle', 'Run', 'Pause'] or (app.playing and app.state == 'Pause')) and not self._is_popup_open():
+        if self.is_jogging_enabled():
             key = args[1]  # keycode
             if key == 274:  # down button
                 app.root.controller.jog_with_speed("Y{}".format(app.root.step_xy.text), app.root.jog_speed)

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3713,7 +3713,10 @@ class Makera(RelativeLayout):
 
     def is_jogging_enabled(self):
         app = App.get_running_app()
-        return (app.state in ['Idle', 'Run', 'Pause'] or (app.playing and app.state == 'Pause')) and not self._is_popup_open()
+        return \
+            not app.playing and \
+            (app.state in ['Idle', 'Run', 'Pause'] or (app.playing and app.state == 'Pause')) and \
+            not self._is_popup_open()
 
     def is_pendant_jogging_enabled(self):
         # If the user disabled pendant, respect it.
@@ -3778,8 +3781,11 @@ class Makera(RelativeLayout):
         self.ids.pendant_jogging_en_btn.disabled = True
 
     def handle_pendat_run_pause_resume(self):
-        # TBA
-        pass
+        app = App.get_running_app()
+        if app.state == 'Pause':
+            self.controller.resumeCommand()
+        else:
+            self.controller.suspendCommand()
 
     def handle_pendant_open_probing_popup(self):
         self.probing_popup.open()

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1845,13 +1845,13 @@
             Label:
                 size_hint_x: 0.2
             Label:
-                
+
             Label:
-                
+
             Label:
-                
+
             Label:
-                
+
 
             # row5 new section
             Label:
@@ -3425,7 +3425,7 @@
                                     GridLayout:
                                         padding: '10dp'
                                         cols: 3
-                                        rows: 4
+                                        rows: 5
                                         spacing: dp(3)
                                         GridBoxLayout:
                                             SmallRoundButton:
@@ -3510,7 +3510,11 @@
                                                 on_release: app.root.controller.setExternalControl(100 if self.state=="down" else 0)
 
                                         GridBoxLayout:
-                                            # Empty for now
+                                            ToggleButton:
+                                                id: pendant_jogging_en_btn
+                                                text: tr._('No Pendant Connected')
+                                                height: '35dp'
+                                                on_state: app.root.pendant.is_jogging_enabled = (self.state == 'down')
 
                             BoxLayout:
                                 BoxLayout:
@@ -3537,7 +3541,7 @@
                                                     center: 0.5, 0.5
                                                     height: '35dp'
                                                     on_release: root.jog_speed_drop_down.open(self)
-                                                
+
                                             GridBoxLayout:
                                                 ToggleButton:
                                                     id: kb_jog_btn

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3514,7 +3514,6 @@
                                                 id: pendant_jogging_en_btn
                                                 text: tr._('No Pendant Connected')
                                                 height: '35dp'
-                                                on_state: app.root.pendant.is_jogging_enabled = (self.state == 'down')
 
                             BoxLayout:
                                 BoxLayout:

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3512,7 +3512,7 @@
                                         GridBoxLayout:
                                             ToggleButton:
                                                 id: pendant_jogging_en_btn
-                                                text: tr._('No Pendant Connected')
+                                                text: tr._('No Pendant')
                                                 height: '35dp'
 
                             BoxLayout:

--- a/carveracontroller/pendant_config.json
+++ b/carveracontroller/pendant_config.json
@@ -1,0 +1,108 @@
+[
+    {
+        "type": "pendant",
+        "title": "Use Hardware Pendant",
+        "desc": "Select a hardware pendant to use with Carvera.",
+        "section": "carvera",
+        "key": "pendant_type",
+        "default": "None"
+    },
+    {
+        "type": "bool",
+        "title": "Jogging Via Pendant Is Default",
+        "desc": "This defines if the pendant jogging is automatically active on the jog screen",
+        "section": "carvera",
+        "key": "pendant_jogging_default",
+        "default": "true"
+    },
+    {
+        "type": "options",
+        "title": "Primary button action is",
+        "desc": "Buttons on pendant have a secondary action when combined with Fn key. You can either set the primary button action to be a user macro or a key-specific action",
+        "section": "carvera",
+        "key": "pendant_primary_button_action",
+        "default": "Macro",
+        "options": [
+            "Macro",
+            "Key-specific Action"]
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 1",
+        "desc": "GCode to trigger when pressing the Macro 1 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_1",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 2",
+        "desc": "GCode to trigger when pressing the Macro 2 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_2",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 3",
+        "desc": "GCode to trigger when pressing the Macro 3 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_3",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 4",
+        "desc": "GCode to trigger when pressing the Macro 4 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_4",
+        "default": {}
+    },
+    {"type": "gcodesnippet",
+        "title": "Macro 5",
+        "desc": "GCode to trigger when pressing the Macro 5 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_5",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 6",
+        "desc": "GCode to trigger when pressing the Macro 6 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_6",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 7",
+        "desc": "GCode to trigger when pressing the Macro 7 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_7",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 8",
+        "desc": "GCode to trigger when pressing the Macro 8 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_8",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 9",
+        "desc": "GCode to trigger when pressing the Macro 9 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_9",
+        "default": {}
+    },
+    {
+        "type": "gcodesnippet",
+        "title": "Macro 10",
+        "desc": "GCode to trigger when pressing the Macro 10 button on the pendant.",
+        "section": "carvera",
+        "key": "pendant_macro_10",
+        "default": {}
+    }
+]

--- a/carveracontroller/translation.py
+++ b/carveracontroller/translation.py
@@ -1,0 +1,88 @@
+# This module provides translation functionality for the Carvera Controller
+# application that can be shared across all modules in the application.
+
+import locale
+import os
+import gettext
+from typing import Optional
+from kivy.lang import Observable
+
+
+LANGS = {
+    'en':  'English',
+    'zh-CN': '中文简体(Simplified Chinese)',
+}
+
+class Lang(Observable):
+    observers = []
+    lang = None
+
+    def __init__(self, defaultlang):
+        super(Lang, self).__init__()
+        self.ugettext = None
+        self.lang = defaultlang
+        self.switch_lang(self.lang)
+
+    def _(self, text):
+        return self.ugettext(text)
+
+    def fbind(self, name, func, args, **kwargs):
+        if name == "_":
+            self.observers.append((func, args, kwargs))
+        else:
+            return super(Lang, self).fbind(name, func, *args, **kwargs)
+
+    def funbind(self, name, func, args, **kwargs):
+        if name == "_":
+            key = (func, args, kwargs)
+            if key in self.observers:
+                self.observers.remove(key)
+        else:
+            return super(Lang, self).funbind(name, func, *args, **kwargs)
+
+    def switch_lang(self, lang):
+        # get the right locales directory, and instanciate a gettext
+        locale_dir = os.path.join(os.path.dirname(__file__), 'locales')
+        locales = None
+        try:
+            locales = gettext.translation(lang, locale_dir, languages=[lang])
+        except:
+            pass
+        if locales == None:
+            locales = gettext.NullTranslations()
+        self.ugettext = locales.gettext
+        self.lang = lang
+
+        # update all the kv rules attached to this text
+        for func, largs, kwargs in self.observers:
+            func(largs, None, None)
+
+# Proxy class is needed to allow for from carveracontroller.translation import tr.
+# Without proxy, the initialization of the translation module would fail
+# because the tr object is copied from the module to the caller's namespace
+# before the translation is initialized.
+class TrProxy:
+    def __getattr__(self, name):
+        if _translator is None:
+            raise RuntimeError("Translation not initialized")
+        return getattr(_translator, name)
+
+_translator: Optional[Lang] = None
+tr = TrProxy()
+
+def init(langname: Optional[str] = None):
+    if langname is None or langname not in LANGS:
+        try:
+            default_locale = locale.getdefaultlocale()
+            if default_locale != None:
+                for lang_key in LANGS.keys():
+                    if default_locale[0][0:2] in lang_key:
+                        langname = lang_key
+                        break
+        except:
+            pass
+    if langname is None:
+        langname = 'en'
+
+    global _translator
+    _translator = Lang(langname)

--- a/carveracontroller/ui.py
+++ b/carveracontroller/ui.py
@@ -1,0 +1,128 @@
+from kivy.uix.settings import SettingItem
+from kivy.uix.button import Button
+from kivy.uix.label import Label
+from kivy.uix.popup import Popup
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.anchorlayout import AnchorLayout
+from kivy.uix.textinput import TextInput
+from kivy.metrics import dp
+import json
+
+from carveracontroller.translation import tr
+
+class SettingGCodeSnippet(SettingItem):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.size_hint_y = None
+        self.height = dp(80)
+
+        # Wrapper: ensure the content is centered vertically
+        wrapper = AnchorLayout(anchor_y='center', anchor_x='left')
+
+        # And split it horizontally into two parts:
+        # 1. Block with preview of the G-code snippet name
+        # 2. Button to open the editor popup
+        inner = BoxLayout(
+            orientation='horizontal',
+            spacing=dp(10),
+            size_hint=(1, None),
+            height=dp(40),
+            padding=[dp(10), 0]
+        )
+
+        self.preview = Label(
+            text=self._get_name(self.value),
+            halign='left',
+            valign='middle',
+            size_hint=(1, 1),
+            text_size=(None, None),
+        )
+
+        btn = Button(text=tr._("Open editor…"), size_hint=(None, 1), width=dp(130))
+        btn.bind(on_release=self.open_popup)
+
+        inner.add_widget(self.preview)
+        inner.add_widget(btn)
+        wrapper.add_widget(inner)
+        self.add_widget(wrapper)
+
+    def _get_name(self, value):
+        try:
+            obj = json.loads(value)
+            return obj.get("name", tr._("<unnamed>"))
+        except Exception:
+            return tr._("<invalid>")
+
+    def _update_text_size(self, instance, width):
+        instance.text_size = (width - dp(20), None)
+
+    def _update_height(self, instance, size):
+        instance.height = size[1]
+
+    def open_popup(self, *args):
+        try:
+            obj = json.loads(self.value or '{}')
+        except Exception:
+            obj = {}
+
+        name = obj.get("name", "")
+        gcode = obj.get("gcode", "")
+
+        content = BoxLayout(orientation='vertical', spacing=dp(10), padding=dp(10))
+
+        self.name_input = TextInput(
+            text=name,
+            multiline=False,
+            size_hint_y=None,
+            height=dp(40)
+        )
+        content.add_widget(Label(text=tr._("Name:"), size_hint_y=None, height=dp(20)))
+        content.add_widget(self.name_input)
+
+        self.gcode_input = TextInput(
+            text=gcode,
+            size_hint=(1, 1)
+        )
+        content.add_widget(Label(text=tr._("G-code:"), size_hint_y=None, height=dp(20)))
+        content.add_widget(self.gcode_input)
+
+        btns = BoxLayout(size_hint_y=None, height=dp(40), spacing=dp(10))
+        popup = Popup(
+            title=self.title or tr._("Edit command"),
+            content=content,
+            size_hint=(0.8, 0.8),
+            auto_dismiss=False
+        )
+
+        save_btn = Button(text=tr._("Save"))
+        save_btn.bind(on_release=lambda *a: self._save_and_close(popup))
+
+        cancel_btn = Button(text=tr._("Cancel"))
+        cancel_btn.bind(on_release=lambda *a: popup.dismiss())
+
+        btns.add_widget(cancel_btn)
+        btns.add_widget(save_btn)
+        content.add_widget(btns)
+
+        popup.open()
+        self._popup = popup
+
+    def _save_and_close(self, popup):
+        obj = {
+            "name": self.name_input.text.strip(),
+            "gcode": self.gcode_input.text.strip()
+        }
+
+        new_value = json.dumps(obj)
+
+        self.panel.set_value(self.section, self.key, new_value)
+
+        self.value = new_value
+        self.on_value(self, new_value)
+
+        popup.dismiss()
+
+    def on_value(self, instance, value):
+        if hasattr(self, 'preview'):
+            self.preview.text = self._get_name(value)

--- a/poetry.lock
+++ b/poetry.lock
@@ -559,6 +559,23 @@ url = "https://pypi.org/simple"
 reference = "pypi-public"
 
 [[package]]
+name = "hid"
+version = "1.0.7"
+description = "ctypes bindings for hidapi"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "hid-1.0.7-py3-none-any.whl", hash = "sha256:8a4f1b081202599018564c4fbc4805d9b97b9c2495f2be177a1ed9600940436d"},
+    {file = "hid-1.0.7.tar.gz", hash = "sha256:3f809e292ab52c4435ad1442c8ef205be4c9ca4eeb80fb47c7d98e0c75527b2a"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-public"
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -2109,4 +2126,4 @@ reference = "pypi-public"
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.14,>=3.9"
-content-hash = "a4e4a2205efc7c91cee111368c6962a97082fdc5dca1355e936600a4e1b9b5ef"
+content-hash = "62ade5a098603345750be56a8416476528fcc856ea130c5c6417fceea79a0938"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python = "<3.14,>=3.9"
 Kivy = "^2.3.1"
 pyserial = "^3.5"
 pyquicklz = "^1.4.1"
+hid = "^1.0.7"
 
 [tool.poetry.group.dev.dependencies]
 pyinstaller = "^6.11.0"


### PR DESCRIPTION
Hi,

I am really used to MPGs for CNCs. I implemented initial support for the cheap Chinese WHB04 wireless MPG into the Controller. At the moment, I consider this a proof of concept rather than a polished solution. But I would like to gather feedback on the usage sooner rather than later.

## What works:

- basic driver of the pendant:
	- we can read all user inputs and
	- we can control the LCD to some extent.
- jogging of each axis with displaying of the workpiece coordinates on the LCD
- you can turn on/off the spindle.
- you can trigger e-stop via the RESET button.

## What doesn't work:

- I didn't manage to properly RE the display protocol of the pendant. So I struggle to properly set display flags,  e.g., the step size.
- Jogging shouldn't work when the machine is running or the jogging UI is not shown.
- Feed and spindle overrides are not implemented yet. 
- Job control is not implemented yet.
- It is undecided what buttons to support and what they should do.
- It works on Linux, I haven't tested Windows yet. It will probably crash on Android and iOS.

## How to test it:
- just plug


At the moment, I am trying to dive into the code and understand how the code is structured and how to properly hook into it. Any feedback in this regard is welcome! I also appreciate any suggestions on what the control elements should do.

![Screenshot from 2025-06-11 21-49-04](https://github.com/user-attachments/assets/9e1c556a-1d86-41f1-aa8f-072a25785d39)
![Screenshot from 2025-06-11 21-48-51](https://github.com/user-attachments/assets/0156dcbf-abc0-400b-a382-f5c2248b94a2)


https://github.com/user-attachments/assets/64410206-d979-47f9-8b8c-653cc2d9736f


