### PR TITLE
Add drop down to 3D probing to select WCS zeroing of X/Y or X/Y/Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 [unreleased]
 - Enhancement: Initial support for rotated WCS in visualizations
 - Change: Minimum Python version increased to 3.9
-- Change: Controller no longer warnings about missing config key values in MDI because it's assumed that firmware defaults are used instead
+- Change: Controller no longer warns about missing config key values in MDI because it's assumed that firmware defaults are used instead
 - Enhancement: Controller support for updating setting definition if machine model is CA1 (via config_ca1_diff.json)
 - Enhancement: Support for controller Carvera Air beeper through controller settings
 - Change: Better wording on the xyz probe screen about block thickness
@@ -10,6 +10,7 @@
 - Fix: Compressed gcode now stored in temp directory if source directory isn't writable
 - Fix: Fix MDI window showing the keyboard for onscreen keyboard devices on iOS
 - Enhancement: Controller config option to select what kind of keyboard to use, physical/virtual/both with options for different size virtual.
+- Fix: Invisible jog control panel buttons clickable when panel disabled.
 
 [0.8.2]
 - Fix: Linux ARM64 appimage builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix: Fix MDI window showing the keyboard for onscreen keyboard devices on iOS
 - Enhancement: Controller config option to select what kind of keyboard to use, physical/virtual/both with options for different size virtual.
 - Fix: Invisible jog control panel buttons clickable when panel disabled.
+- Change: Add UI to select X/Y or X/Y/Z WCS zeroing during 3D probing of corners and boss
 
 [0.8.2]
 - Fix: Linux ARM64 appimage builds

--- a/carveracontroller/addons/probing/ProbingControls.py
+++ b/carveracontroller/addons/probing/ProbingControls.py
@@ -1,6 +1,6 @@
 from kivy.uix.gridlayout import GridLayout
 from kivy.properties import StringProperty
-from ...addons.tooltips.Tooltips import ToolTipButton
+from ...addons.tooltips.Tooltips import ToolTipButton, ToolTipDropDown
 
 
 class ProbeButton(ToolTipButton):
@@ -12,3 +12,6 @@ class ProbeButton(ToolTipButton):
     def on_size(self, *args):
         pass
         #at some point add code to respect halign and valign in img
+
+class ProbeZeroXYZDropDown(ToolTipDropDown):
+    pass

--- a/carveracontroller/addons/probing/ProbingControls.py
+++ b/carveracontroller/addons/probing/ProbingControls.py
@@ -1,6 +1,6 @@
 from kivy.uix.gridlayout import GridLayout
 from kivy.properties import StringProperty
-from ...addons.tooltips.Tooltips import ToolTipButton, ToolTipDropDown
+from ...addons.tooltips.Tooltips import ToolTipButton
 
 
 class ProbeButton(ToolTipButton):
@@ -12,6 +12,3 @@ class ProbeButton(ToolTipButton):
     def on_size(self, *args):
         pass
         #at some point add code to respect halign and valign in img
-
-class ProbeZeroXYZDropDown(ToolTipDropDown):
-    pass

--- a/carveracontroller/addons/probing/operations/Boss/BossSettings.kv
+++ b/carveracontroller/addons/probing/operations/Boss/BossSettings.kv
@@ -163,7 +163,8 @@
 
                 ToolTipButton:
                     id: ZeroXYPosition
-                    text:  ["Disabled", "X/Y", "X/Y/Z"][int(root.get_setting('ZeroXYPosition'))]  # get_setting() returns an int, so doing an inline mapping to the display text here
+                    # In the below get_setting() returns an int, so doing an inline mapping to the display text here
+                    text: ["Disabled", "X/Y", "X/Y/Z"][int(root.get_setting('ZeroXYPosition') or '0')]
                     tooltip_txt: tr._('This switch will set your current WCS to the center of the bore/pocket you are probing')
                     canvas.before:
                         Color:

--- a/carveracontroller/addons/probing/operations/Boss/BossSettings.kv
+++ b/carveracontroller/addons/probing/operations/Boss/BossSettings.kv
@@ -10,6 +10,7 @@
             spacing:dp(3)
             padding:dp(1)
             halign:'right'
+            wcs_drop_content: wcs_drop_content.__self__  # hack to prevent gc from removing object per https://kivy.org/doc/stable/guide/lang.html#referencing-widgets
 
             ProbeSettingLabel:
                 label_text: 'X:'
@@ -157,10 +158,12 @@
                     on_text: root.setting_changed('ProbeDepth', self.text)
 
             ProbeSettingLabel:
-                label_text: 'S ZeroXY:'
-                hint_text: 'ZeroXY Position'
-                ToolTipSwitch:
+                label_text: 'S Zero WCS Axis:'
+                hint_text: 'Zero X/Y/Z Position'
+
+                ToolTipButton:
                     id: ZeroXYPosition
+                    text:  ["Disabled", "X/Y", "X/Y/Z"][int(root.get_setting('ZeroXYPosition'))]  # get_setting() returns an int, so doing an inline mapping to the display text here
                     tooltip_txt: tr._('This switch will set your current WCS to the center of the bore/pocket you are probing')
                     canvas.before:
                         Color:
@@ -168,8 +171,39 @@
                         Rectangle:
                             pos: self.pos
                             size: self.size
-                    active: root.get_setting('ZeroXYPosition') == "1"
-                    on_active: root.setting_changed('ZeroXYPosition', "1" if self.active else "0")
+                    on_parent: wcs_drop_content.dismiss()
+                    on_release: wcs_drop_content.open(self)
+                
+                    DropDown:
+                        id: wcs_drop_content
+                        on_select: ZeroXYPosition.text = f'{args[1]}'
+
+                        Button:
+                            id: wcs_btn1
+                            text: tr._('Disabled')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "0")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn2
+                            text: tr._('X/Y')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "1")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn3
+                            text: tr._('X/Y/Z')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "2")
+                                wcs_drop_content.select(self.text)
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'

--- a/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.kv
@@ -10,6 +10,7 @@
             spacing:dp(3)
             padding:dp(1)
             halign:'right'
+            wcs_drop_content: wcs_drop_content.__self__  # hack to prevent gc from removing object per https://kivy.org/doc/stable/guide/lang.html#referencing-widgets
 
             ProbeSettingLabel:
                 label_text: 'X:'
@@ -131,21 +132,53 @@
                     on_text: root.setting_changed('BottomSurfaceRetract', self.text)
 
             ProbeSettingLabel:
-                label_text: 'S ZeroXY:'
-                hint_text: 'ZeroXY Position'
-                Spinner:
+                label_text: 'S Zero WCS Axis:'
+                hint_text: 'Zero X/Y/Z Position'
+
+                ToolTipButton:
                     id: ZeroXYPosition
-                    tooltip_txt: tr._('This switch will set your current WCS to the corner that you are probing')
+                    # In the below get_setting() returns an int, so doing an inline mapping to the display text here
+                    text: ["Disabled", "X/Y", "X/Y/Z"][int(root.get_setting('ZeroXYPosition') or '0')]
+                    tooltip_txt: tr._('This switch will set your current WCS to the corner you are probing')
                     canvas.before:
                         Color:
                             rgba: 50/255, 50/255, 50/255, 1
                         Rectangle:
                             pos: self.pos
                             size: self.size
-                    values: 'Disabled', 'X/Y', 'X/Y/Z'
-                    text: root.get_setting('ZeroXYPosition')
-                    on_text: 
-                        root.setting_changed('ZeroXYPosition', self.text)
+                    on_parent: wcs_drop_content.dismiss()
+                    on_release: wcs_drop_content.open(self)
+                
+                    DropDown:
+                        id: wcs_drop_content
+                        on_select: ZeroXYPosition.text = f'{args[1]}'
+
+                        Button:
+                            id: wcs_btn1
+                            text: tr._('Disabled')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "0")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn2
+                            text: tr._('X/Y')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "1")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn3
+                            text: tr._('X/Y/Z')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "2")
+                                wcs_drop_content.select(self.text)
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'

--- a/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.kv
@@ -133,7 +133,7 @@
             ProbeSettingLabel:
                 label_text: 'S ZeroXY:'
                 hint_text: 'ZeroXY Position'
-                ToolTipSwitch:
+                Spinner:
                     id: ZeroXYPosition
                     tooltip_txt: tr._('This switch will set your current WCS to the corner that you are probing')
                     canvas.before:
@@ -142,8 +142,10 @@
                         Rectangle:
                             pos: self.pos
                             size: self.size
-                    active: root.get_setting('ZeroXYPosition') == "1"
-                    on_active: root.setting_changed('ZeroXYPosition', "1" if self.active else "0")
+                    values: 'Disabled', 'X/Y', 'X/Y/Z'
+                    text: root.get_setting('ZeroXYPosition')
+                    on_text: 
+                        root.setting_changed('ZeroXYPosition', self.text)
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'

--- a/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.py
+++ b/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.py
@@ -14,6 +14,15 @@ class InsideCornerSettings(BoxLayout):
         super(InsideCornerSettings, self).__init__(**kwargs)
 
     def setting_changed(self, key: str, value: float):
+        # Hacky code to translate between key/value of Kivy Spinner
+        if key == 'ZeroXYPosition':
+            if value == 'Disabled':
+                value = "0"
+            elif value == 'X/Y':
+                value = "1"
+            elif value == 'X/Y/Z':
+                value = "2"
+
         param = getattr(InsideCornerParameterDefinitions, key, None)
         if param is None:
             raise KeyError(f"Invalid key '{key}'")
@@ -23,7 +32,17 @@ class InsideCornerSettings(BoxLayout):
 
     def get_setting(self, key: str) -> str:
         param = getattr(InsideCornerParameterDefinitions, key, None)
+
+        # Hacky code to translate between key/value of Kivy Spinner
+        if key == "ZeroXYPosition" and self.config.get("S"):
+            if self.config["S"] == '0':
+                return 'Disabled'
+            elif self.config["S"] == '1':
+                return 'X/Y'
+            elif self.config["S"] == '2':
+                return 'X/Y/Z'
+        
         return str(self.config[param.code] if param.code in self.config else "")
 
     def get_config(self):
-        return self.config;
+        return self.config

--- a/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.py
+++ b/carveracontroller/addons/probing/operations/InsideCorner/InsideCornerSettings.py
@@ -14,15 +14,6 @@ class InsideCornerSettings(BoxLayout):
         super(InsideCornerSettings, self).__init__(**kwargs)
 
     def setting_changed(self, key: str, value: float):
-        # Hacky code to translate between key/value of Kivy Spinner
-        if key == 'ZeroXYPosition':
-            if value == 'Disabled':
-                value = "0"
-            elif value == 'X/Y':
-                value = "1"
-            elif value == 'X/Y/Z':
-                value = "2"
-
         param = getattr(InsideCornerParameterDefinitions, key, None)
         if param is None:
             raise KeyError(f"Invalid key '{key}'")
@@ -33,15 +24,6 @@ class InsideCornerSettings(BoxLayout):
     def get_setting(self, key: str) -> str:
         param = getattr(InsideCornerParameterDefinitions, key, None)
 
-        # Hacky code to translate between key/value of Kivy Spinner
-        if key == "ZeroXYPosition" and self.config.get("S"):
-            if self.config["S"] == '0':
-                return 'Disabled'
-            elif self.config["S"] == '1':
-                return 'X/Y'
-            elif self.config["S"] == '2':
-                return 'X/Y/Z'
-        
         return str(self.config[param.code] if param.code in self.config else "")
 
     def get_config(self):

--- a/carveracontroller/addons/probing/operations/OperationsBase.py
+++ b/carveracontroller/addons/probing/operations/OperationsBase.py
@@ -42,5 +42,3 @@ class ProbeSettingDefinition:
         self.code = g_code_param
         self.description = description
         self.is_required = is_required
-
-

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerParameterDefinitions.py
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerParameterDefinitions.py
@@ -25,7 +25,7 @@ class OutsideCornerParameterDefinitions:
     BottomSurfaceRetract = ProbeSettingDefinition('C', "Btm Retract", False,
                                                   "optional parameter, if H is enabled and the probe happens, this is how far to retract off the bottom surface of the part. Defaults to 2mm")
 
-    ZeroXYPosition = ProbeSettingDefinition('S', "ZeroXY", False, "save corner position as new WCS Zero in X and Y")
+    ZeroXYPosition = ProbeSettingDefinition('S', "ZeroXY", False, "save corner position as new WCS Zero in X and Y if 1, X/Y and Z if 2. Do nothing if 0.")
 
     ProbeTipDiameter = ProbeSettingDefinition('D', "Tip Dia", False, "Probe Tip Diameter, stored in config")
 

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
@@ -10,6 +10,7 @@
             spacing:dp(3)
             padding:dp(1)
             halign:'right'
+            wcs_drop_content: wcs_drop_content.__self__  # hack to prevent gc from removing object per https://kivy.org/doc/stable/guide/lang.html#referencing-widgets
 
             ProbeSettingLabel:
                 label_text: 'X:'
@@ -146,13 +147,51 @@
             ProbeSettingLabel:
                 label_text: 'S Zero WCS Axis:'
                 hint_text: 'Zero X/Y/Z Position'
-                Button:
-                    text: tr._('Disabled')
+
+                ToolTipButton:
                     id: ZeroXYPosition
-                    center: 0.5, 0.5
-                    height: '35dp'
-                    on_release: root.probe_xyz_drop_down.open(self)
-                    
+                    # In the below get_setting() returns an int, so doing an inline mapping to the display text here
+                    text: ["Disabled", "X/Y", "X/Y/Z"][int(root.get_setting('ZeroXYPosition') or '0')]
+                    tooltip_txt: tr._('This switch will set your current WCS to the corner you are probing')
+                    canvas.before:
+                        Color:
+                            rgba: 50/255, 50/255, 50/255, 1
+                        Rectangle:
+                            pos: self.pos
+                            size: self.size
+                    on_parent: wcs_drop_content.dismiss()
+                    on_release: wcs_drop_content.open(self)
+                
+                    DropDown:
+                        id: wcs_drop_content
+                        on_select: ZeroXYPosition.text = f'{args[1]}'
+
+                        Button:
+                            id: wcs_btn1
+                            text: tr._('Disabled')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "0")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn2
+                            text: tr._('X/Y')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "1")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn3
+                            text: tr._('X/Y/Z')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "2")
+                                wcs_drop_content.select(self.text)     
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'
@@ -168,29 +207,3 @@
                             size: self.size
                     active: root.get_setting('UseProbeNormallyClosed') == "1"
                     on_active: root.setting_changed('UseProbeNormallyClosed', "1" if self.active else "0")
-
-<ProbeZeroXYZDropDown>:
-    on_select: app.root.probing_popup.outside_corner_settings.ids["ZeroXYPosition"].text = args[1]
-    Button:
-        text: tr._('Disabled')
-        size_hint_y: None
-        height: '40dp'
-        on_release:
-            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "0")
-            root.select(self.text)
-
-    Button:
-        text: tr._('X/Y')
-        size_hint_y: None
-        height: '40dp'
-        on_release:
-            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "1")
-            root.select(self.text)
-
-    Button:
-        text: tr._('X/Y/Z')
-        size_hint_y: None
-        height: '40dp'
-        on_release:
-            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "2")
-            root.select(self.text)

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
@@ -148,9 +148,11 @@
                 hint_text: 'Zero X/Y/Z Position'
                 Button:
                     text: tr._('Disabled')
+                    id: ZeroXYPosition
                     center: 0.5, 0.5
                     height: '35dp'
-                    on_release: app.root.probe_xyz_drop_down.open(self)
+                    on_release: root.probe_xyz_drop_down.open(self)
+                    
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'
@@ -168,12 +170,27 @@
                     on_active: root.setting_changed('UseProbeNormallyClosed', "1" if self.active else "0")
 
 <ProbeZeroXYZDropDown>:
+    on_select: app.root.probing_popup.outside_corner_settings.ids["ZeroXYPosition"].text = args[1]
+    Button:
+        text: tr._('Disabled')
+        size_hint_y: None
+        height: '40dp'
+        on_release:
+            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "0")
+            root.select(self.text)
+
     Button:
         text: tr._('X/Y')
         size_hint_y: None
         height: '40dp'
+        on_release:
+            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "1")
+            root.select(self.text)
 
     Button:
         text: tr._('X/Y/Z')
         size_hint_y: None
         height: '40dp'
+        on_release:
+            app.root.probing_popup.outside_corner_settings.setting_changed('ZeroXYPosition', "2")
+            root.select(self.text)

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
@@ -144,19 +144,13 @@
                     on_text: root.setting_changed('ProbeDepth', self.text)
 
             ProbeSettingLabel:
-                label_text: 'S ZeroXY:'
-                hint_text: 'ZeroXY Position'
-                ToolTipSwitch:
-                    id: ZeroXYPosition
-                    tooltip_txt: tr._('This switch will set your current WCS to the corner that you are probing')
-                    canvas.before:
-                        Color:
-                            rgba: 50/255, 50/255, 50/255, 1
-                        Rectangle:
-                            pos: self.pos
-                            size: self.size
-                    active: root.get_setting('ZeroXYPosition') == "1"
-                    on_active: root.setting_changed('ZeroXYPosition', "1" if self.active else "0")
+                label_text: 'S Zero WCS Axis:'
+                hint_text: 'Zero X/Y/Z Position'
+                Button:
+                    text: tr._('Disabled')
+                    center: 0.5, 0.5
+                    height: '35dp'
+                    on_release: app.root.probe_xyz_drop_down.open(self)
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'
@@ -172,3 +166,14 @@
                             size: self.size
                     active: root.get_setting('UseProbeNormallyClosed') == "1"
                     on_active: root.setting_changed('UseProbeNormallyClosed', "1" if self.active else "0")
+
+<ProbeZeroXYZDropDown>:
+    Button:
+        text: tr._('X/Y')
+        size_hint_y: None
+        height: '40dp'
+
+    Button:
+        text: tr._('X/Y/Z')
+        size_hint_y: None
+        height: '40dp'

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.py
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.py
@@ -5,7 +5,6 @@ from kivy.uix.textinput import TextInput
 from carveracontroller.addons.probing.operations.ConfigUtils import ConfigUtils
 from carveracontroller.addons.probing.operations.OperationsBase import ProbeSettingDefinition
 from carveracontroller.addons.probing.operations.OutsideCorner.OutsideCornerParameterDefinitions import OutsideCornerParameterDefinitions
-from carveracontroller.addons.probing.ProbingControls import ProbeZeroXYZDropDown
 
 class OutsideCornerSettings(BoxLayout):
     config_filename = "outside-corner-settings.json"
@@ -14,7 +13,6 @@ class OutsideCornerSettings(BoxLayout):
     def __init__(self, **kwargs):
         super(OutsideCornerSettings, self).__init__(**kwargs)
         self.config = ConfigUtils.load_config(self.config_filename)
-        self.probe_xyz_drop_down = ProbeZeroXYZDropDown()
 
     def setting_changed(self, key: str, value: float):
         param = getattr(OutsideCornerParameterDefinitions, key, None)

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.py
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.py
@@ -5,6 +5,7 @@ from kivy.uix.textinput import TextInput
 from carveracontroller.addons.probing.operations.ConfigUtils import ConfigUtils
 from carveracontroller.addons.probing.operations.OperationsBase import ProbeSettingDefinition
 from carveracontroller.addons.probing.operations.OutsideCorner.OutsideCornerParameterDefinitions import OutsideCornerParameterDefinitions
+from carveracontroller.addons.probing.ProbingControls import ProbeZeroXYZDropDown
 
 class OutsideCornerSettings(BoxLayout):
     config_filename = "outside-corner-settings.json"
@@ -13,6 +14,7 @@ class OutsideCornerSettings(BoxLayout):
     def __init__(self, **kwargs):
         super(OutsideCornerSettings, self).__init__(**kwargs)
         self.config = ConfigUtils.load_config(self.config_filename)
+        self.probe_xyz_drop_down = ProbeZeroXYZDropDown()
 
     def setting_changed(self, key: str, value: float):
         param = getattr(OutsideCornerParameterDefinitions, key, None)
@@ -42,4 +44,4 @@ class OutsideCornerSettings(BoxLayout):
             else:
                 print("no control with name: " + name)
 
-        return self.config;
+        return self.config

--- a/carveracontroller/addons/probing/operations/SingleAxis/SingleAxisProbeSettings.kv
+++ b/carveracontroller/addons/probing/operations/SingleAxis/SingleAxisProbeSettings.kv
@@ -10,6 +10,8 @@
             spacing:dp(3)
             padding:dp(1)
             halign:'right'
+            wcs_drop_content: wcs_drop_content.__self__  # hack to prevent gc from removing object per https://kivy.org/doc/stable/guide/lang.html#referencing-widgets
+
 
             ProbeSettingLabel:
                 label_text: 'X:'
@@ -118,10 +120,13 @@
                     on_text: root.setting_changed('EdgeRetractDistance', self.text)
 
             ProbeSettingLabel:
-                label_text: 'S ZeroXY:'
-                hint_text: 'ZeroXY Position'
-                ToolTipSwitch:
-                    id: zero_xy
+                label_text: 'S Zero WCS Axis:'
+                hint_text: 'Zero X/Y/Z Position'
+
+                ToolTipButton:
+                    id: ZeroXYPosition
+                    # In the below get_setting() returns an int, so doing an inline mapping to the display text here
+                    text: ["Disabled", "X or Y", "Z"][int(root.get_setting('ZeroXYPosition') or '0')]
                     tooltip_txt: tr._('This switch will set your current WCS to the surface you are probing. It will only set the currently selected axis/axes')
                     canvas.before:
                         Color:
@@ -129,8 +134,39 @@
                         Rectangle:
                             pos: self.pos
                             size: self.size
-                    active: root.get_setting('ZeroXYPosition') == "1"
-                    on_active: root.setting_changed('ZeroXYPosition', "1" if self.active else "0")
+                    on_parent: wcs_drop_content.dismiss()
+                    on_release: wcs_drop_content.open(self)
+                
+                    DropDown:
+                        id: wcs_drop_content
+                        on_select: ZeroXYPosition.text = f'{args[1]}'
+
+                        Button:
+                            id: wcs_btn1
+                            text: tr._('Disabled')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "0")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn2
+                            text: tr._('X or Y')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "1")
+                                wcs_drop_content.select(self.text)
+                        
+                        Button:
+                            id: wcs_btn3
+                            text: tr._('Z')
+                            size_hint_y: None
+                            height: '40dp'
+                            on_release:
+                                root.setting_changed('ZeroXYPosition', "2")
+                                wcs_drop_content.select(self.text)
 
             ProbeSettingLabel:
                 label_text: 'I Normally Closed:'

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -747,9 +747,6 @@ class MakeraConfigPanel(SettingsWithSidebar):
 class JogSpeedDropDown(ToolTipDropDown):
     pass
 
-class ProbeZeroXYZDropDown(ToolTipDropDown):
-    pass
-
 class XDropDown(ToolTipDropDown):
     pass
 
@@ -1579,7 +1576,6 @@ class Makera(RelativeLayout):
         self.status_drop_down = StatusDropDown()
         self.operation_drop_down = OperationDropDown()
         self.jog_speed_drop_down = JogSpeedDropDown()
-        self.probe_xyz_drop_down = ProbeZeroXYZDropDown()
 
         self.confirm_popup = ConfirmPopup()
         self.message_popup = MessagePopup()

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -747,6 +747,9 @@ class MakeraConfigPanel(SettingsWithSidebar):
 class JogSpeedDropDown(ToolTipDropDown):
     pass
 
+class ProbeZeroXYZDropDown(ToolTipDropDown):
+    pass
+
 class XDropDown(ToolTipDropDown):
     pass
 
@@ -1576,6 +1579,7 @@ class Makera(RelativeLayout):
         self.status_drop_down = StatusDropDown()
         self.operation_drop_down = OperationDropDown()
         self.jog_speed_drop_down = JogSpeedDropDown()
+        self.probe_xyz_drop_down = ProbeZeroXYZDropDown()
 
         self.confirm_popup = ConfirmPopup()
         self.message_popup = MessagePopup()

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3509,7 +3509,7 @@
 
                             BoxLayout:
                                 BoxLayout:
-                                    disabled: app.state != 'Idle'
+                                    disabled: not root.show_advanced_jog_controls or app.state != 'Idle'
                                     orientation: 'horizontal'
                                     size_hint_y: 0.4
                                     opacity: 1 if root.show_advanced_jog_controls else 0


### PR DESCRIPTION
Add drop down to 3D probing to select WCS zeroing of X/Y or X/Y/Z not just X/Y to Inside/Outside Corner and Boss probing screens.

Also:
Fix: Invisible jog control panel buttons being clickable when panel disabled.

![image](https://github.com/user-attachments/assets/d16d62d3-74a9-4026-be77-adbb68903e72)
