### PR TITLE
Add permissions for pypi publish id-token in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,6 +163,8 @@ jobs:
   build-pypi-artifacts:
     name: build-python
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
should resolve failed publishes like: https://github.com/Carvera-Community/Carvera_Controller/actions/runs/16581969354/job/46899827293