### PR TITLE
Auto-Vacuum on CA1 via "Ext. Control"

### DIFF
--- a/carveracontroller/config_ca1.json
+++ b/carveracontroller/config_ca1.json
@@ -445,7 +445,20 @@
         "section": "Advanced",
         "key": "temperature_control.spindle.max_temp"
     },
-    
+
+    {
+        "type": "title",
+        "title": "External Control",
+        "section": "Advanced"
+    },
+    {
+        "type": "bool",
+        "title": "Enable External Control as Vacuum (Experimental)",
+        "desc": "Treats the 'External Control' output as a vacuum and enables the auto-vacuum feature.",
+        "section": "Advanced",
+        "key": "ca1_ext_control_as_vacuum",
+        "default": "false"
+    },
 
     {
         "type": "string",

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -2249,6 +2249,10 @@ class Makera(RelativeLayout):
         # model metadata check timer
         Clock.schedule_interval(self.check_model_metadata, 10)
 
+        # Device-specific settings
+        # CA1
+        self.ca1_ext_control_as_vacuum = False
+
         self.has_onscreen_keyboard = False
         if sys.platform == "ios":
             self.has_onscreen_keyboard = True
@@ -2274,6 +2278,18 @@ class Makera(RelativeLayout):
         Config.set('graphics', 'width', int(Window.size[0]/Metrics.dp))
         Config.set('graphics', 'height', int(Window.size[1]/Metrics.dp))
         Config.write()
+
+    def reload_device_specific_ui(self):
+        """ Reloads the device-specific UI elements."""
+        # Initialize device-specific settings
+        app = App.get_running_app()
+        if app.model == 'CA1':
+            self.ca1_ext_control_as_vacuum = self.config.getboolean(
+                'Advanced', 'ca1_ext_control_as_vacuum', fallback=False)
+
+        self.spindle_drop_down = SpindleDropDown()
+        self.coord_popup = CoordPopup(self.coord_config)
+
 
     def load_controller_config(self):
         config_def_file = os.path.join(os.path.dirname(__file__), 'controller_config.json')
@@ -3900,7 +3916,11 @@ class Makera(RelativeLayout):
             elapsed = now - self.control_list['vacuum_mode'][0]
             if elapsed < 2:
                 if elapsed > 0.5:
-                    self.controller.setVacuumMode(self.control_list['vacuum_mode'][1])
+                    logging.info("Setting vacuum mode to: {}".format(self.control_list['vacuum_mode'][1]))
+                    if self.ca1_ext_control_as_vacuum:
+                        self.controller.setExternalControl(100 if self.control_list['vacuum_mode'][1] else 0)
+                    else:
+                        self.controller.setVacuumMode(self.control_list['vacuum_mode'][1])
                     self.control_list['vacuum_mode'][0] = now - 2
             elif elapsed > 3:
                 if self.spindle_drop_down.vacuum_switch.active != CNC.vars["vacuummode"]:
@@ -4396,6 +4416,10 @@ class Makera(RelativeLayout):
             self.config_popup.settings_panel.add_json_panel('Machine - Basic', self.config, data=json.dumps(basic_config))
             self.config_popup.settings_panel.add_json_panel('Machine - Advanced', self.config, data=json.dumps(advanced_config))
             self.config_popup.settings_panel.add_json_panel('Machine - Restore', self.config, data=json.dumps(restore_config))
+        
+        # Reload device-specific UI elements
+        self.reload_device_specific_ui()
+
         return True
 
     # -----------------------------------------------------------------------

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -671,7 +671,7 @@
         padding: '0.5dp'
         size_hint_y: None
         height: '40dp'
-        disabled: app.model == 'CA1'
+        disabled: app.model == 'CA1' and not app.root.ca1_ext_control_as_vacuum
         Switch:
             id: vacuum_switch
             canvas.before:
@@ -2704,7 +2704,7 @@
                     padding: '0.5dp'
                     size_hint_y: None
                     height: '30dp'
-                    disabled: app.model == 'CA1'
+                    disabled: app.model == 'CA1' and not app.root.ca1_ext_control_as_vacuum
                     Label:
                         text: tr._("Auto Vacuum")
                         halign: "left"
@@ -2924,7 +2924,7 @@
 #                BoxLayout:
 #                    size_hint_y: None
 #                    height: '25dp'
-#                    disabled: app.model == 'CA1'
+#                    disabled: app.model == 'CA1' and not app.root.ca1_ext_control_as_vacuum
 #                    canvas.before:
 #                        Color:
 #                            rgba: 65/255, 65/255, 65/255, 1


### PR DESCRIPTION
This PR adds a new configuration setting to enable the "Ext. Control" switch to function as vacuum control for the CA1 model. enabling auto-vacuum functionality. As discussed in #286