### PR TITLE
Controller logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change: Probing cancel button becomes halt button if machine is moving
 - Change: Machine heartbeat is now 5s to be a bit more responsive on disconnects
 - Change: Light toggle button initial state is set on connect
+- Change: Controller logging options now available in settings. Default log_level is info and log to file is enabled.
 - Fix: Upload-and-Select button is now disabled until a file is selected
 
 [0.10.1]

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -111,5 +111,22 @@
         "section": "carvera",
         "key": "reconnect_attempts",
         "default": "3"
+    },
+    {
+        "type": "options",
+        "title": "Log Level",
+        "desc": "Sets the logging level for the application. Higher levels include all lower levels.",
+        "section": "kivy",
+        "key": "log_level",
+        "default": "info",
+        "options": ["debug", "info", "warning", "error"]
+    },
+    {
+        "type": "bool",
+        "title": "Log to file",
+        "desc": "Store logs to file",
+        "section": "kivy",
+        "key": "log_enable",
+        "default": "true"
     }
 ]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -4822,6 +4822,13 @@ class Makera(RelativeLayout):
 
         self.config_popup.btn_apply.disabled = True
 
+        # Configure logging level from config
+        if "log_level" in self.controller_setting_change_list:
+            log_level = Config.get('kivy', 'log_level').upper()
+            if log_level in ['DEBUG', 'INFO', 'WARNING', 'ERROR']:
+                logging.getLogger().setLevel(getattr(logging, log_level))
+                logger.info(f"Log level set to {log_level}")
+
 
     # -----------------------------------------------------------------------
     def open_setting_restore_confirm_popup(self):
@@ -5201,6 +5208,13 @@ class MakeraApp(App):
 def load_app_configs():
     if Config.has_option('carvera', 'ui_density_override') and Config.get('carvera', 'ui_density_override') == "1":
         Metrics.set_density(float(Config.get('carvera', 'ui_density')))
+
+    # Configure logging level from config
+    if Config.has_option('kivy', 'log_level'):
+        log_level = Config.get('kivy', 'log_level').upper()
+        if log_level in ['DEBUG', 'INFO', 'WARNING', 'ERROR']:
+            logging.getLogger().setLevel(getattr(logging, log_level))
+            logger.info(f"Log level set to {log_level}")
 
 def set_config_defaults(default_lang):
     if not Config.has_section('carvera'):


### PR DESCRIPTION
Controller logging options now available in settings. Default log_level is info and log to file is enabled.

This properly sets the Logger level so child python modules also output logs

<img width="1293" height="173" alt="image" src="https://github.com/user-attachments/assets/ad98d666-ce13-4869-8fb4-c8629866f4cb" />
