### PR TITLE
Support connecting to hidden wifi networks

### DIFF
--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -401,6 +401,13 @@ class InputPopup(ModalView):
     def __init__(self, **kwargs):
         super(InputPopup, self).__init__(**kwargs)
 
+class ManualWifiPopup(ModalView):
+    cache_var1 = StringProperty('')
+    cache_var2 = StringProperty('')
+    cache_var3 = StringProperty('')
+    def __init__(self, **kwargs):
+        super(ManualWifiPopup, self).__init__(**kwargs)
+
 class ProgressPopup(ModalView):
     progress_text = StringProperty('')
     progress_value = NumericProperty('0')
@@ -2104,6 +2111,7 @@ class Makera(RelativeLayout):
     reconnection_popup = ObjectProperty()
     progress_popup = ObjectProperty()
     input_popup = ObjectProperty()
+    manual_wifi_popup = ObjectProperty()
     show_advanced_jog_controls = BooleanProperty(False)
     keyboard_jog_control = BooleanProperty(False)
 
@@ -2278,6 +2286,7 @@ class Makera(RelativeLayout):
         self.reconnection_popup = ReconnectionPopup()
         self.progress_popup = ProgressPopup()
         self.input_popup = InputPopup()
+        self.manual_wifi_popup = ManualWifiPopup()
 
         self.probing_popup = ProbingPopup(self.controller)
         self.wcs_settings_popup = WCSSettingsPopup(self.controller, self.wcs_names)
@@ -2955,6 +2964,26 @@ class Makera(RelativeLayout):
         Config.write()
         self.past_machine_addr = address
 
+    def manually_input_ssid(self):
+        self.manual_wifi_popup.lb_title1.text = tr._('Input Wi-Fi network name (SSID):')
+        self.manual_wifi_popup.lb_title2.text = tr._('Input Wi-Fi password (leave blank if open network):')
+        self.manual_wifi_popup.txt_content1.password = False
+        self.manual_wifi_popup.txt_content2.password = True
+        self.manual_wifi_popup.confirm = self.manually_open_ssid
+        self.manual_wifi_popup.open(self)
+        self.wifi_ap_drop_down.dismiss()
+        self.status_drop_down.dismiss()
+
+    def manually_open_ssid(self):
+        ssid = self.manual_wifi_popup.txt_content1.text.strip()
+        password = self.manual_wifi_popup.txt_content2.text.strip()
+        self.manual_wifi_popup.dismiss()
+        if not ssid:
+            return False
+        self.input_popup.cache_var1 = ssid
+        self.input_popup.txt_content.text = password
+        self.connectToWiFi()
+
     # -----------------------------------------------------------------------
     def update_coord_config(self):
         self.wpb_margin.width = 50 if self.coord_config['margin']['active'] else 0
@@ -3546,6 +3575,9 @@ class Makera(RelativeLayout):
             btn = WiFiButton(connected = ap['connected'], ssid = ap['ssid'], encrypted = ap['encrypted'], strength = ap['strength'])
             btn.bind(on_release=lambda btn: self.wifi_ap_drop_down.select(btn.ssid))
             self.wifi_ap_drop_down.add_widget(btn)
+        btn = WiFiButton(ssid = tr._('Other...'))
+        btn.bind(on_release=lambda btn: self.manually_input_ssid())
+        self.wifi_ap_drop_down.add_widget(btn)
 
     # -----------------------------------------------------------------------
     def loadWiFiError(self, error_msg, *args):

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1314,6 +1314,57 @@
                     if root.confirm():\
                     root.dismiss()
 
+<ManualWifiPopup>:
+    lb_title1: lb_title1
+    lb_title2: lb_title2
+    txt_content1: txt_content1
+    txt_content2: txt_content2
+    size_hint: 0.5, 0.4
+    pos_hint: {"right": 0.75, "top": 0.7}
+    auto_dismiss: False
+    BoxLayout:
+        padding: '15dp'
+        orientation: 'vertical'
+        Label:
+            size_hint_y: 0.4
+            id: lb_title1
+            text: tr._('Input Box')
+            bold: True
+        BoxLayout:
+            orientation: 'vertical'
+            Label:
+            TextInput:
+                id: txt_content1
+                size_hint_y: None
+                height: '35dp'
+                multiline: False
+                text: ''
+            Label:
+        Label:
+            size_hint_y: 0.4
+            id: lb_title2
+            text: tr._('Input Box')
+            bold: True
+        BoxLayout:
+            orientation: 'vertical'
+            Label:
+            TextInput:
+                id: txt_content2
+                size_hint_y: None
+                height: '35dp'
+                multiline: False
+                text: ''
+            Label:
+        BoxLayout:
+            size_hint_y: 0.4
+            Button:
+                text: tr._('Cancel')
+                on_release: root.dismiss()
+            Button:
+                text: tr._('Ok')
+                on_release:
+                    if root.confirm():\
+                    root.dismiss()
 
 <ConfirmPopup>:
     lb_title: lb_title


### PR DESCRIPTION
Fixes #189. I've tested this on firmware 1.0.11c but can't currently test it on 2.0.0-RC1 because of the crash described in https://github.com/Carvera-Community/Carvera_Community_Firmware/issues/146. I'll troubleshoot that separately.

This is my first time working with kivy, so I'll be grateful for any feedback you have. `DualInputPopup` is a copy of `InputPopup` with modifications for the second label and input box. The code changes are modeled after the existing wifi callback code as much as possible. Storing the most recent manually-entered SSID in the config has been useful for testing but might be overkill for normal usage.