### PR TITLE
Respond to double clicks in local/remote file browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 [unreleased]
 - Fixed: Closing the Controller after auto-reconnection canceled causes the app to freeze
 - Enhancement: Support connecting to hidden wifi networks
+- Enhancement: Upload and select a file when it's double clicked in the local file browser
 
 [2.0.0-RC2]
 - Enhancement: Controller option "Allow Jogging When Machine is Running". This allows advanced users to jog the spindle manually while it is spinning enabling manual milling operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 [unreleased]
 - Fixed: Closing the Controller after auto-reconnection canceled causes the app to freeze
+- Enhancement: Support connecting to hidden wifi networks
 
 [2.0.0-RC2]
 - Enhancement: Controller option "Allow Jogging When Machine is Running". This allows advanced users to jog the spindle manually while it is spinning enabling manual milling operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed: Closing the Controller after auto-reconnection canceled causes the app to freeze
 - Enhancement: Support connecting to hidden wifi networks
 - Enhancement: Upload and select a file when it's double clicked in the local file browser
+- Enhancement: Select a file when it's double clicked in the remote file browser
 
 [2.0.0-RC2]
 - Enhancement: Controller option "Allow Jogging When Machine is Running". This allows advanced users to jog the spindle manually while it is spinning enabling manual milling operations.

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1870,6 +1870,7 @@ class RemoteRV(DataRV):
     def __init__(self, **kwargs):
         super(RemoteRV, self).__init__(**kwargs)
         self.register_event_type('on_select')
+        self.register_event_type('on_double_tap')
 
         self.base_dir = '/sd/gcodes'
         self.base_dir_win = '\\sd\\gcodes'
@@ -1901,6 +1902,10 @@ class RemoteRV(DataRV):
         app.root.loadRemoteDir(new_dir)
         self.curr_dir = str(new_dir)
         # self.curr_dir_name = os.path.normpath(self.curr_dir)
+    
+    def on_double_tap(self):
+        app = App.get_running_app()
+        app.root.check_and_download()
 
 # -----------------------------------------------------------------------
 # Local Recycle View

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1735,6 +1735,8 @@ class SelectableBoxLayout(RecycleDataViewBehavior, BoxLayout):
                 rv = self.parent.recycleview
                 if rv.data[self.index]['is_dir']:
                     rv.child_dir(rv.data[self.index]['filename'])
+                else:
+                    rv.dispatch('on_double_tap')
                 return True
             return self.parent.select_with_touch(self.index, touch)
 
@@ -1776,9 +1778,13 @@ class DataRV(RecycleView):
     def __init__(self, **kwargs):
         super(DataRV, self).__init__(**kwargs)
         self.register_event_type('on_select')
+        self.register_event_type('on_double_tap')
 
     # -----------------------------------------------------------------------
     def on_select(self):
+        pass
+        
+    def on_double_tap(self):
         pass
 
     # -----------------------------------------------------------------------
@@ -1904,6 +1910,7 @@ class LocalRV(DataRV):
     def __init__(self, **kwargs):
         super(LocalRV, self).__init__(**kwargs)
         self.register_event_type('on_select')
+        self.register_event_type('on_double_tap')
         if kivy_platform == 'android':
             self.curr_dir = os.path.abspath('.carveracontroller/gcodes')
             if not os.path.exists(self.curr_dir):
@@ -1984,6 +1991,10 @@ class LocalRV(DataRV):
 
         if self.curr_path_list[0] == self.base_dir:
             self.curr_path_list[0] = 'root'
+    
+    def on_double_tap(self):
+        app = App.get_running_app()
+        app.root.check_upload_and_select()
 
 # -----------------------------------------------------------------------
 # GCode Recycle View


### PR DESCRIPTION
A common pattern in UI file chooser dialogs is that a double click runs the default action on the selected file. The Controller's dialogs could do the same, e.g. by loading the file in the remote dialog and uploading (+ selecting) in the local dialog. This PR wires up both.

Tested on macOS. I'll test on linux tonight or tomorrow, too.