### PR TITLE
Use correct check-and-upload function when double clicking firmware file

### DIFF
--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1999,7 +1999,10 @@ class LocalRV(DataRV):
     
     def on_double_tap(self):
         app = App.get_running_app()
-        app.root.check_upload_and_select()
+        if app.root.file_popup.firmware_mode:
+            app.root.check_and_upload()
+        else:
+            app.root.check_upload_and_select()
 
 # -----------------------------------------------------------------------
 # GCode Recycle View


### PR DESCRIPTION
This fixes a bug that I accidentally introduced in #403. Double clicking a firmware file would upload the file and then treat it as gcode instead of firmware.