### PR TITLE
Disable probing button in burger menu when we're not idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 [unreleased]
 - Fixed: Closing the Controller after auto-reconnection canceled causes the app to freeze
+- Fixed: Probing popup shouldn't be accessible when playback is suspended
 
 [2.0.0-RC2]
 - Enhancement: Controller option "Allow Jogging When Machine is Running". This allows advanced users to jog the spindle manually while it is spinning enabling manual milling operations.

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1060,7 +1060,7 @@
         icon_size: 35
         small_icon: True
         size_hint_y: None
-        # disabled: app.state == 'N/A'
+        disabled: app.state != 'Idle'
         height: '50dp'
         on_release:
             root.select('')


### PR DESCRIPTION
This uses the enable/disable expression from the main control popover [here](https://github.com/Carvera-Community/Carvera_Controller/blob/1c14b96c55b81781867513147daff5683756de19/carveracontroller/makera.kv#L3639).

Repro steps for testing:
1. Run a small program. I ran one with auto Z probe enabled so that it didn't start using the spindle immediately
2. As soon as you can, hit pause in the controller UI
3. Click the hamburger menu and verify that the probing button is disabled

Fixes #395 