### PR TITLE
Log the error when we fail to connect over wifi

### DIFF
--- a/carveracontroller/WIFIStream.py
+++ b/carveracontroller/WIFIStream.py
@@ -6,6 +6,7 @@ import select
 
 from .XMODEM import XMODEM
 import logging
+logger = logging.getLogger(__name__)
 
 
 TCP_PORT = 2222
@@ -30,6 +31,7 @@ class MachineDetector:
             with socket.create_connection((addr, "2222"), timeout=1):
                 return False
         except (socket.timeout, socket.error) as e:
+            logger.error(f"Socket error: {e}")
             return True
 
     def query_for_machines(self):


### PR DESCRIPTION
I was debugging a connection failure today ([details](https://discord.com/channels/1341908765212934320/1410913474502066206/1443692691358613646)) and added this logging to explore what the underlying error was. Otherwise, the controller shows the vague "Cannot connect, machine is busy or not available" error but doesn't explain what happened. The logging was useful and seems worth keeping.