### PR TITLE
Cache iOS build output, take 2

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -530,6 +530,7 @@ def main():
         except subprocess.CalledProcessError as e:
             logger.error(f"Stdout from build_ios.sh: {e.stdout}")
             logger.error(f"Error from build_ios.sh: {e.stderr}")
+            sys.exit(1)
         else:
             logger.info(f"Stdout from build_ios.sh: {result.stdout}")
 


### PR DESCRIPTION
Fixes a bug/typo in #428. Another way to handle it would be to pass `check=False` and get both stdout and stderr from `result`, but this seemed clearer to me.

[Example success](https://github.com/acj/Carvera_Controller/actions/runs/19859452366/attempts/1) (and [cached rerun](https://github.com/acj/Carvera_Controller/actions/runs/19859452366))
[Example failure](https://github.com/acj/Carvera_Controller/actions/runs/19859149723/job/56904494378#step:6:19)