### PR TITLE
Fix base android window size so that UI fits again on 5:3 screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed: UI state for manual MDI text box and the Send button can be incorrect and make MDI seem broken
 - Fixed: Hard-coded search paths in Xcode project for iOS app
 - Fixed: The H parameter in A axis Y calibration and graphic was wrong, the probe depth is set via E
+- Fixed: Scaling of the UI in Android no longer cuts off menu button on displays with 5:3 aspect ratio
 - Change: Intel MacOS minimum version increased to MacOS-14 (Sonoma). Previous versions might work, but will be unsupported
 
 [2.0.0-RC2]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -19,7 +19,7 @@ if is_android():
         activity = PythonActivity.mActivity
         metrics = DisplayMetrics()
         activity.getWindowManager().getDefaultDisplay().getMetrics(metrics)
-        screen_width_density  = int(metrics.widthPixels  * 10 / 960) / 10
+        screen_width_density  = int(metrics.widthPixels  * 10 / 1000) / 10
         screen_height_density = int(metrics.heightPixels * 10 / 550) / 10
 
         os.environ["KIVY_METRICS_DENSITY"] = str(min(screen_width_density, screen_height_density))


### PR DESCRIPTION
Addresses #394 by revising the base window size.

<img width="2152" height="1381" alt="image" src="https://github.com/user-attachments/assets/ad972f60-3e1f-49bc-9cf3-c0c1ade82168" />
