### PR TITLE
Always on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Enhancement: Select a file when it's double clicked in the remote file browser
 - Enhancement: Automatically connect to the machine on startup if its wifi address is configured
 - Enhancement: CI workflow for building iOS app
+- Enhancement: Added allows on top Controller config option to keep the application window always ontop of other windows
 - Bugfix: Improved reliability of the app cleanup/exit handler by swithing to the Kivy on_request_close() hook.
 - Fixed: MDI scrolling behavior was sometimes quirky when new text was added
 - Fixed: Prevent keyboard jog when MDI text box has focus

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -40,6 +40,14 @@
         "default": "false"
     },
     {
+        "type": "bool",
+        "title": "Allows on top",
+        "desc": "Should the application window be always ontop?",
+        "section": "graphics",
+        "key": "always_on_top",
+        "default": "false"
+    },
+    {
         "type": "numeric",
         "title": "Max FPS",
         "desc": "What maximum FPS to use for rendering? Reduce this if you are experiencing performance issues.",


### PR DESCRIPTION
Added allows on top Controller config option to keep the application window always ontop of other windows

Implements #450