### PR TITLE
Allow to configure the active color

### DIFF
--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -32,6 +32,14 @@
         "default": "1.5"
     },
     {
+        "type": "colorpicker",
+        "title": "Active Element Highlight Color",
+        "desc": "The color used to highlight active UI elements like buttons and indicators.",
+        "section": "carvera",
+        "key": "active_color",
+        "default": "0,255,255,255"
+    },
+    {
         "type": "bool",
         "title": "Allow Screensaver",
         "desc": "Should the screensaver be allowed to run?",

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1488,6 +1488,7 @@ class MakeraConfigPanel(SettingsWithSidebar):
         super().__init__(*args, **kwargs)
         self.register_type('pendant', SettingPendantSelector)
         self.register_type('gcodesnippet', ui.SettingGCodeSnippet)
+        self.register_type('colorpicker', ui.SettingColorPicker)
 
     def on_config_change(self, config, section, key, value):
         app = App.get_running_app()
@@ -2475,6 +2476,9 @@ class Makera(RelativeLayout):
         if Config.has_option('carvera', 'invert_y_axis_jogging'):
             App.get_running_app().invert_y_axis_jogging = Config.get('carvera', 'invert_y_axis_jogging') == '1'
 
+        if Config.has_option('carvera', 'active_color'):
+            App.get_running_app().active_color = self._parse_active_color(Config.get('carvera', 'active_color'))
+
         # blink timer
         Clock.schedule_interval(self.blink_state, 0.5)
         # status switch timer
@@ -2491,6 +2495,19 @@ class Makera(RelativeLayout):
 
         # try to connect over wifi if we've used it before
         Clock.schedule_once(self.reconnect_wifi_conn_quietly)
+
+    def _parse_active_color(self, value):
+        """Parse a color string like '0,255,255,255' into an RGBA list (0-1 range)."""
+        try:
+            if not value:
+                return [0, 1, 1, 1]  # Default cyan
+            parts = [float(x.strip()) for x in value.split(',')]
+            if len(parts) == 3:
+                parts.append(255.0)  # Add alpha if missing
+            # Assume 0-255 range, convert to 0-1
+            return [parts[0]/255, parts[1]/255, parts[2]/255, parts[3]/255 if parts[3] > 1 else parts[3]]
+        except Exception:
+            return [0, 1, 1, 1]  # Default cyan
 
     def on_request_close(self, *args):
         # Cleanup the temporary directory when the app is closed
@@ -5156,6 +5173,9 @@ class Makera(RelativeLayout):
             delay_value = float(self.controller_setting_change_list.get('tooltip_delay'))
             App.get_running_app().tooltip_delay = delay_value if delay_value>0 else 0.5
 
+        if self.controller_setting_change_list.get('active_color'):
+            App.get_running_app().active_color = self._parse_active_color(self.controller_setting_change_list.get('active_color'))
+
         if "pendant_type" in self.controller_setting_change_list:
             self.pendant.close()
             self.setup_pendant()
@@ -5531,6 +5551,7 @@ class MakeraApp(App):
     tooltip_delay = NumericProperty(0.5)
     mdi_data = ListProperty([])
     invert_y_axis_jogging = BooleanProperty(False)
+    active_color = ListProperty([0, 1, 1, 1])  # Default cyan (0, 255, 255) in 0-1 range
 
     def on_stop(self):
         # Cancel any ongoing reconnection attempts to prevent hanging
@@ -5605,6 +5626,7 @@ def set_config_defaults(default_lang):
     if not Config.has_option('carvera', 'show_update'): Config.set('carvera', 'show_update', '1')
     if not Config.has_option('carvera', 'show_tooltips'): Config.set('carvera', 'show_tooltips' , '1')
     if not Config.has_option('carvera', 'tooltip_delay'): Config.set('carvera', 'tooltip_delay','1.5')
+    if not Config.has_option('carvera', 'active_color'): Config.set('carvera', 'active_color', '0,255,255,255')
     if not Config.has_option('carvera', 'language'): Config.set('carvera', 'language', default_lang)
     if not Config.has_option('carvera', 'local_folder_1'): Config.set('carvera', 'local_folder_1', '')
     if not Config.has_option('carvera', 'local_folder_2'): Config.set('carvera', 'local_folder_2', '')

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -84,10 +84,10 @@
     background_color: 0, 0, 0, 0
     Label:
         text: root.text if root.text else ''
-        color: (0/255, 255/255, 255/255, 1) if (root.active and not root.disabled) else ((110/255, 110/255, 110/255, 1) if root.disabled else (250/255, 250/255, 250/255, 1))
+        color: tuple(app.active_color) if (root.active and not root.disabled) else ((110/255, 110/255, 110/255, 1) if root.disabled else (250/255, 250/255, 250/255, 1))
         canvas.before:
             Color:
-                rgba: (0/255, 255/255, 255/255, 1) if (root.active and not root.disabled) else ((110/255, 110/255, 110/255, 1) if root.disabled else (250/255, 250/255, 250/255, 1))
+                rgba: tuple(app.active_color) if (root.active and not root.disabled) else ((110/255, 110/255, 110/255, 1) if root.disabled else (250/255, 250/255, 250/255, 1))
             Rectangle:
                 source: root.icon
                 pos: self.center_x - dp(root.icon_size / 2), self.center_y - dp(root.icon_size / 2)
@@ -1185,7 +1185,7 @@
     Label:
         canvas.before:
             Color:
-                rgba: (0/255, 255/255, 255/255, 1) if (root.active and not root.disabled) else root.color
+                rgba: tuple(app.active_color) if (root.active and not root.disabled) else root.color
             Rectangle:
                 source: root.data_icon
                 pos: self.center_x - dp(10), self.center_y - dp(14)
@@ -1193,12 +1193,12 @@
         text: root.data_text if root.data_text else ''
         size_hint_x: 0.22
         font_size: '23sp'
-        color: (0/255, 255/255, 255/255, 1) if root.active else root.color
+        color: tuple(app.active_color) if root.active else root.color
     BoxLayout:
         orientation: 'vertical'
         Label:
             text: root.main_text
-            color: (0/255, 255/255, 255/255, 1) if root.scale != 100 else (225/255, 225/255, 225/255, 1)
+            color: tuple(app.active_color) if root.scale != 100 else (225/255, 225/255, 225/255, 1)
             font_size: '18sp'
             text_size: self.size
             halign: "right"

--- a/carveracontroller/ui.py
+++ b/carveracontroller/ui.py
@@ -5,10 +5,167 @@ from kivy.uix.popup import Popup
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.anchorlayout import AnchorLayout
 from kivy.uix.textinput import TextInput
+from kivy.uix.colorpicker import ColorPicker
+from kivy.uix.widget import Widget
+from kivy.graphics import Color, Rectangle
 from kivy.metrics import dp
 import json
 
 from carveracontroller.translation import tr
+
+
+class ColorPreview(Widget):
+    """A simple widget that displays a color preview."""
+    def __init__(self, color=(0, 1, 1, 1), **kwargs):
+        super().__init__(**kwargs)
+        self._color = color
+        with self.canvas:
+            self._bg_color = Color(*self._color)
+            self._rect = Rectangle(pos=self.pos, size=self.size)
+        self.bind(pos=self._update_rect, size=self._update_rect)
+
+    def _update_rect(self, *args):
+        self._rect.pos = self.pos
+        self._rect.size = self.size
+
+    def set_color(self, color):
+        self._color = color
+        self._bg_color.rgba = color
+
+
+class SettingColorPicker(SettingItem):
+    """A custom settings item that provides a color picker."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.size_hint_y = None
+        self.height = dp(60)
+
+        # Parse initial color value
+        self._current_color = self._parse_color(self.value)
+
+        # Wrapper for vertical centering
+        wrapper = AnchorLayout(anchor_y='center', anchor_x='left')
+
+        inner = BoxLayout(
+            orientation='horizontal',
+            spacing=dp(10),
+            size_hint=(1, None),
+            height=dp(40),
+            padding=[dp(10), 0]
+        )
+
+        # Color preview widget
+        self.color_preview = ColorPreview(
+            color=self._current_color,
+            size_hint=(None, 1),
+            width=dp(60)
+        )
+
+        # Color value label
+        self.color_label = Label(
+            text=self._format_color(self._current_color),
+            halign='left',
+            valign='middle',
+            size_hint=(1, 1),
+        )
+
+        # Button to open color picker
+        btn = Button(text=tr._("Pick Color..."), size_hint=(None, 1), width=dp(130))
+        btn.bind(on_release=self.open_popup)
+
+        inner.add_widget(self.color_preview)
+        inner.add_widget(self.color_label)
+        inner.add_widget(btn)
+        wrapper.add_widget(inner)
+        self.add_widget(wrapper)
+
+    def _parse_color(self, value):
+        """Parse a color string like '0,255,255,255' or '0,1,1,1' into an RGBA tuple (0-1 range)."""
+        try:
+            if not value:
+                return (0, 1, 1, 1)  # Default cyan
+            parts = [float(x.strip()) for x in value.split(',')]
+            if len(parts) == 3:
+                parts.append(1.0)  # Add alpha if missing
+            # If values are > 1, assume 0-255 range
+            if any(p > 1 for p in parts[:3]):
+                return (parts[0]/255, parts[1]/255, parts[2]/255, parts[3] if parts[3] <= 1 else parts[3]/255)
+            return tuple(parts)
+        except Exception:
+            return (0, 1, 1, 1)  # Default cyan
+
+    def _format_color(self, color):
+        """Format color tuple as a readable string."""
+        r, g, b, a = color
+        return f"R:{int(r*255)} G:{int(g*255)} B:{int(b*255)}"
+
+    def _color_to_string(self, color):
+        """Convert color tuple to storage string (0-255 range)."""
+        r, g, b, a = color
+        return f"{int(r*255)},{int(g*255)},{int(b*255)},{int(a*255)}"
+
+    def open_popup(self, *args):
+        """Open the color picker popup."""
+        content = BoxLayout(orientation='vertical', spacing=dp(10), padding=dp(10))
+
+        # Color picker widget
+        self.picker = ColorPicker(color=self._current_color)
+        content.add_widget(self.picker)
+
+        # Buttons
+        btns = BoxLayout(size_hint_y=None, height=dp(40), spacing=dp(10))
+
+        popup = Popup(
+            title=self.title or tr._("Select Color"),
+            content=content,
+            size_hint=(0.8, 0.9),
+            auto_dismiss=False
+        )
+
+        save_btn = Button(text=tr._("Save"))
+        save_btn.bind(on_release=lambda *a: self._save_and_close(popup))
+
+        cancel_btn = Button(text=tr._("Cancel"))
+        cancel_btn.bind(on_release=lambda *a: popup.dismiss())
+
+        # Reset to default button
+        reset_btn = Button(text=tr._("Reset to Default"))
+        reset_btn.bind(on_release=lambda *a: self._reset_to_default())
+
+        btns.add_widget(cancel_btn)
+        btns.add_widget(reset_btn)
+        btns.add_widget(save_btn)
+        content.add_widget(btns)
+
+        popup.open()
+        self._popup = popup
+
+    def _reset_to_default(self):
+        """Reset color to default cyan."""
+        default_color = (0, 1, 1, 1)
+        self.picker.color = default_color
+
+    def _save_and_close(self, popup):
+        """Save the selected color and close the popup."""
+        self._current_color = self.picker.color
+        new_value = self._color_to_string(self._current_color)
+
+        self.color_preview.set_color(self._current_color)
+        self.color_label.text = self._format_color(self._current_color)
+
+        self.panel.set_value(self.section, self.key, new_value)
+        self.value = new_value
+
+        popup.dismiss()
+
+    def on_value(self, instance, value):
+        """Called when the value changes."""
+        if hasattr(self, 'color_preview'):
+            self._current_color = self._parse_color(value)
+            self.color_preview.set_color(self._current_color)
+            self.color_label.text = self._format_color(self._current_color)
 
 class SettingGCodeSnippet(SettingItem):
     def __init__(self, **kwargs):


### PR DESCRIPTION
Maybe it's just me and my color blindness, but I've always had trouble distinguishing the 'active' cyan color from the white default color. It often leads to wasted time troubleshooting because I don't realize settings like grid compensation are on.

This PR allows to configure that color through the settings screen using the (not so pretty - but functional) color picker from Kivy:

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/2ebd97ca-e12d-4f84-8542-734fec9ea0fd" />

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/928aa018-89df-4ea7-ad13-16905982dd38" />

<img width="1920" height="1056" alt="image" src="https://github.com/user-attachments/assets/2895a2f3-37d1-4cac-865d-bfbd1c63e3a8" />
