### PR TITLE
Fixed: Improved Overheat/Too Cold/temp undefined warning text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Enhancement: Add keyboard shortcuts for launching settings (ctrl+,) and navigating to MDI (ctrl+m)
 - Enhancement: Restore the previously-loaded background image in Config and Run
 - Enhancement: Support increasing USB connection speed if the firmware is >= 2.1.0c. Enable feature and set baud rate in Controller settings
+- Fixed: Improved Overheat/Too Cold/temp undefined warning text
 - Fixed: Improved reliability of the app cleanup/exit handler by switching to the Kivy on_request_close() hook.
 - Fixed: MDI scrolling behavior was sometimes quirky when new text was added
 - Fixed: Prevent keyboard jog when MDI text box has focus

--- a/carveracontroller/locales/en/LC_MESSAGES/en.po
+++ b/carveracontroller/locales/en/LC_MESSAGES/en.po
@@ -45,7 +45,7 @@ msgid "ATC Position Occupied"
 msgstr ""
 
 #: main.py:180
-msgid "Spindle Overheated"
+msgid "Spindle Temp Error"
 msgstr ""
 
 #: main.py:181

--- a/carveracontroller/locales/zh-CN/LC_MESSAGES/zh-CN.po
+++ b/carveracontroller/locales/zh-CN/LC_MESSAGES/zh-CN.po
@@ -45,7 +45,7 @@ msgid "ATC Position Occupied"
 msgstr "自动换刀位置被占用"
 
 #: main.py:180
-msgid "Spindle Overheated"
+msgid "Spindle Temp Error"
 msgstr "主轴过热"
 
 #: main.py:181

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -212,11 +212,12 @@ def load_halt_translations(tr: translation.Lang):
         6:  tr._("ATC Invalid Tool Number"),
         7:  tr._("ATC Drop Tool Fail"),
         8:  tr._("ATC Position Occupied"),
-        9:  tr._("Spindle Overheated"),
+        9:  tr._("Spindle Temp Error"),
         10: tr._("Soft Limit Triggered"),
         11: tr._("Cover opened when playing"),
         12: tr._("Wireless probe dead or not set"),
         13: tr._("Emergency stop button pressed"),
+        14: tr._("Electronics Temp Error"),
         16: tr._("3D probe crash detected"),
         # Need to reset the machine
         21: tr._("Hard Limit Triggered, reset needed"),


### PR DESCRIPTION
Issue #471 

The previous error would say "Spindle Overheat" when the spindle is too cold, or the temperature is undefined (demonstrating a wiring issue)

This PR changes the text in the error window to be Spindle Temp Error and adds an error condition for electronics cabinet temp errors. 

It is to be used in conjunction with 
https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/231

which adds more information to the string sent along with the command to the controller