### PR TITLE
Added the instant spindle speed and feed rate overrides to the relevant +/- buttons and gated them behind a controller setting and firmware version 2.1.0c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Change: Values in the top bar buttons now shrink in font_size if just a bit too big (by up to 20%), and if still overflowing perform a marquee scroll
 - Change: Workspace Descriptions are now shown (if set) instead of G54 etc
 - Change: Laser and Spindle Top Bar buttons are now combined, and laser mode enable button added to Tool drop down to switch between them
+- Change - Added the instant spindle speed and feed rate overrides to the relavent +/- buttons and gated them behind a controller setting and firmware version 2.1.0c
 
 [2.0.0]
 - Fixed: Closing the Controller after auto-reconnection canceled causes the app to freeze

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -356,12 +356,20 @@ class Controller:
             self.executeCommand("M490.2\n")
 
     def setFeedScale(self, scale):
+        app = App.get_running_app()
+        if (app.is_community_firmware and app.fw_version_digitized >= Utils.digitize_v("2.1.0")) and app.root.instantFSoverride:
+            self.executeCommand("$F S%d\n" % (scale))
+            return
         self.executeCommand("M220 S%d\n" % (scale))
 
     def setLaserScale(self, scale):
         self.executeCommand("M325 S%d\n" % (scale))
 
     def setSpindleScale(self, scale):
+        app = App.get_running_app()
+        if (app.is_community_firmware and app.fw_version_digitized >= Utils.digitize_v("2.1.0")) and app.root.instantFSoverride:
+            self.executeCommand("$O S%d\n" % (scale))
+            return
         self.executeCommand("M223 S%d\n" % (scale))
 
     def clearAutoLeveling(self):

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -72,6 +72,14 @@
         "default": "true"
     },
     {
+        "type": "bool",
+        "title": "Use Instant Feed And Spindle Overrides",
+        "desc": "Off uses stock commands that wait for the current block to execute",
+        "section": "carvera",
+        "key": "instantFSoverride",
+        "default": "true"
+    },
+    {
         "type": "path",
         "title": "Play Background Images Custom Folder",
         "desc": "The user directory to pull custom background images for the play file screen from",

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -2638,6 +2638,7 @@ class Makera(RelativeLayout):
     _progress_smooth_clock = None
 
     show_update = True
+    instantFSoverride = True
     fw_upd_text = ''
     fw_version_new = ''
     fw_version = ''
@@ -2818,6 +2819,8 @@ class Makera(RelativeLayout):
         self.file_just_loaded = False
 
         self.fill_remote_dir_callback = None
+
+        self.instantFSoverride = (Config.get('carvera', 'instantFSoverride') == '1')
 
         self.show_update = (Config.get('carvera', 'show_update') == '1')
         self.upgrade_popup.cbx_check_at_startup.active = self.show_update
@@ -6294,6 +6297,7 @@ def set_config_defaults(default_lang):
     if not Config.has_option('graphics', 'allow_screensaver'): Config.set('graphics', 'allow_screensaver', '0')
     if not Config.has_option('graphics', 'height'): Config.set('graphics', 'height', '1440')
     if not Config.has_option('graphics', 'width'): Config.set('graphics', 'width',  '900')
+    if not Config.has_option('carvera', 'instantFSoverride'): Config.set('carvera','instantFSoverride','1')
 
     Config.write()
 


### PR DESCRIPTION
Added

$F S100 to instantly update the feed rate override percentage, similar to M220
$O S100 to instantly update the spindle speed override percentage, similar to M223

These only work if the firmware is version 2.1.0c or above and the use instant feed and spindle overrides controller setting is on. 
Note: this defaults to true, there is some discussion to be had about if it should default to false. 

<img width="1532" height="814" alt="image" src="https://github.com/user-attachments/assets/7e77d7f3-d152-4b9f-9647-d069d7b255fa" />

requires this firmware branch to work
https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/249/
