### PR TITLE
Add basic G-Code syntax highlighting to the viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Enhancement: Display alarm message in halt popup
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware
 - Enhancement: Improvements to saving changes in settings menu
+- Enhancement: Add syntax highlighting to the file viewer
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -7,6 +7,61 @@ PARENPAT = re.compile(r"(\(.*?\))")
 SEMIPAT  = re.compile(r"(;.*)")
 CMDPAT   = re.compile(r"([A-Za-z]+)")
 
+GCODE_TOKEN_RE = re.compile(
+    r'(?P<comment>\(.*?\)|;.*)'                              # paren or semicolon comment
+    r'|(?P<g_command>[Gg]\d+\.?\d*)'                         # G command
+    r'|(?P<m_command>[Mm]\d+\.?\d*)'                         # M command
+    r'|(?P<coordinate>[XYZAxyza][-+]?\d*\.?\d*)'             # coordinate axis
+    r'|(?P<feedrate>[Ff][-+]?\d*\.?\d*)'                     # feed rate
+    r'|(?P<spindle>[Ss][-+]?\d*\.?\d*)'                      # spindle speed
+    r'|(?P<tool>[Tt]\d+)'                                    # tool number
+    r'|(?P<line_number>[Nn]\d+)'                             # line number
+    r'|(?P<parameter>[IJKPRHLDQEijkprhldqe][-+]?\d*\.?\d*)' # other parameters
+)
+
+GCODE_DEFAULT_COLORS = {
+    'comment':     '#6A9955',
+    'g_command':   '#569CD6',
+    'm_command':   '#C586C0',
+    'coordinate':  '#CE9178',
+    'feedrate':    '#4EC9B0',
+    'spindle':     '#D16969',
+    'tool':        '#B5CEA8',
+    'line_number': '#858585',
+    'parameter':   '#9CDCFE',
+}
+
+def escape_gcode_markup(text):
+    """Escape characters that Kivy label markup interprets."""
+    return text.replace('&', '&amp;').replace('[', '&bl;').replace(']', '&br;')
+
+def highlight_gcode_line(line, colors=None):
+    """Return *line* wrapped in Kivy ``[color]`` markup tags.
+
+    *colors* is an optional dict mapping category names (see
+    ``GCODE_DEFAULT_COLORS``) to ``#RRGGBB`` hex strings.  Missing keys
+    fall back to the built-in defaults; pass ``None`` to use defaults for
+    everything.
+    """
+    if colors is None:
+        effective = GCODE_DEFAULT_COLORS
+    else:
+        effective = {**GCODE_DEFAULT_COLORS, **colors}
+
+    result = []
+    pos = 0
+    for m in GCODE_TOKEN_RE.finditer(line):
+        if m.start() > pos:
+            result.append(escape_gcode_markup(line[pos:m.start()]))
+
+        hex_color = effective.get(m.lastgroup, '#C8C8C8')
+        result.append(f'[color={hex_color}]{escape_gcode_markup(m.group())}[/color]')
+        pos = m.end()
+
+    if pos < len(line):
+        result.append(escape_gcode_markup(line[pos:]))
+    return ''.join(result)
+
 XY   = 0
 XZ   = 1
 YZ   = 2

--- a/carveracontroller/gcode_viewer_config.json
+++ b/carveracontroller/gcode_viewer_config.json
@@ -1,0 +1,82 @@
+[
+    {
+        "type": "bool",
+        "title": "Enable Syntax Highlighting",
+        "desc": "Colorize G-code tokens in the file viewer. Disable on low-end machines for better scroll performance.",
+        "section": "carvera",
+        "key": "gcode_highlight_enabled",
+        "default": "true"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Comments",
+        "desc": "Color for parenthetical (...) and semicolon comments.",
+        "section": "carvera",
+        "key": "gcode_color_comment",
+        "default": "106,153,85,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "G Commands",
+        "desc": "Color for G commands (G0, G1, G28, etc.).",
+        "section": "carvera",
+        "key": "gcode_color_g_command",
+        "default": "86,156,214,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "M Commands",
+        "desc": "Color for M commands (M3, M5, M6, etc.).",
+        "section": "carvera",
+        "key": "gcode_color_m_command",
+        "default": "197,134,192,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Coordinates (X/Y/Z/A)",
+        "desc": "Color for axis coordinate parameters.",
+        "section": "carvera",
+        "key": "gcode_color_coordinate",
+        "default": "206,145,120,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Feed Rate (F)",
+        "desc": "Color for the feed rate parameter.",
+        "section": "carvera",
+        "key": "gcode_color_feedrate",
+        "default": "78,201,176,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Spindle Speed (S)",
+        "desc": "Color for the spindle speed parameter.",
+        "section": "carvera",
+        "key": "gcode_color_spindle",
+        "default": "209,105,105,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Tool (T)",
+        "desc": "Color for tool number.",
+        "section": "carvera",
+        "key": "gcode_color_tool",
+        "default": "181,206,168,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Line Number (N)",
+        "desc": "Color for line number codes (N100, etc.).",
+        "section": "carvera",
+        "key": "gcode_color_line_number",
+        "default": "133,133,133,255"
+    },
+    {
+        "type": "colorpicker",
+        "title": "Other Parameters",
+        "desc": "Color for other parameters (I, J, K, P, R, etc.).",
+        "section": "carvera",
+        "key": "gcode_color_parameter",
+        "default": "156,220,254,255"
+    }
+]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -190,7 +190,7 @@ import subprocess
 from . import Utils
 from . import ui
 from kivy.config import ConfigParser
-from .CNC import CNC
+from .CNC import CNC, highlight_gcode_line, escape_gcode_markup, GCODE_DEFAULT_COLORS
 from .GcodeViewer import GCodeViewer
 from .Controller import Controller, NOT_CONNECTED, STATECOLOR, STATECOLORDEF,\
     LOAD_DIR, LOAD_MV, LOAD_RM, LOAD_MKDIR, LOAD_WIFI, LOAD_CONN_WIFI, CONN_USB, CONN_WIFI, SEND_FILE
@@ -2128,6 +2128,7 @@ class GCodeRow(RecycleDataViewBehavior, BoxLayout):
     selectable = BooleanProperty(True)
     line_no = NumericProperty(0)
     text = StringProperty('')
+    highlighted_text = StringProperty('')
     color = ListProperty([1, 1, 1, 1])
     is_resume_line = BooleanProperty(False)
     touch_start_time = 0
@@ -2915,6 +2916,7 @@ class Makera(RelativeLayout):
         self.setting_default_list = {}
         self.controller_setting_change_list = {}
         self.load_controller_config()
+        self.load_gcode_viewer_config()
         self.load_pendant_config()
 
         self.usb_event = lambda instance, x: self.openUSB(x)
@@ -2960,6 +2962,8 @@ class Makera(RelativeLayout):
         if Config.has_option('carvera', 'active_color'):
             App.get_running_app().active_color = self._parse_active_color(Config.get('carvera', 'active_color'))
 
+        self._load_gcode_highlight_settings()
+
         # blink timer
         Clock.schedule_interval(self.blink_state, 0.5)
         # status switch timer
@@ -2989,6 +2993,33 @@ class Makera(RelativeLayout):
             return [parts[0]/255, parts[1]/255, parts[2]/255, parts[3]/255 if parts[3] > 1 else parts[3]]
         except Exception:
             return [0, 1, 1, 1]  # Default cyan
+
+    def _load_gcode_highlight_settings(self):
+        """Read gcode highlighting config into cached attributes."""
+        raw_enabled = Config.get('carvera', 'gcode_highlight_enabled') if Config.has_option('carvera', 'gcode_highlight_enabled') else '1'
+        self.gcode_highlight_enabled = raw_enabled not in ('0', 'false', 'False')
+        self.gcode_highlight_colors = {}
+        for cat in GCODE_DEFAULT_COLORS:
+            config_key = f'gcode_color_{cat}'
+            raw = Config.get('carvera', config_key) if Config.has_option('carvera', config_key) else None
+            if raw:
+                self.gcode_highlight_colors[cat] = self._config_color_to_hex(raw)
+
+    @staticmethod
+    def _config_color_to_hex(value):
+        """Convert a 'R,G,B,A' config string (0-255) to a Kivy markup hex color.
+
+        Returns '#RRGGBBAA' when alpha < 255, otherwise '#RRGGBB'.
+        """
+        try:
+            parts = [int(float(x.strip())) for x in value.split(',')]
+            r, g, b = parts[0], parts[1], parts[2]
+            a = parts[3] if len(parts) >= 4 else 255
+            if a < 255:
+                return '#{:02X}{:02X}{:02X}{:02X}'.format(r, g, b, a)
+            return '#{:02X}{:02X}{:02X}'.format(r, g, b)
+        except Exception:
+            return '#C8C8C8'
 
     def on_request_close(self, *args):
         # Cleanup the temporary directory when the app is closed
@@ -3026,6 +3057,24 @@ class Makera(RelativeLayout):
         self.config_popup.settings_panel.add_json_panel(tr._('Controller'), Config, data=json.dumps(controller_config))
 
         self._update_macro_button_text()
+
+    def load_gcode_viewer_config(self):
+        config_def_file = os.path.join(os.path.dirname(__file__), 'gcode_viewer_config.json')
+        try:
+            with open(config_def_file) as file:
+                gcode_viewer_config_definition = json.load(file)
+        except Exception as e:
+            logger.error(f"Failed to load gcode_viewer_config.json: {e}")
+            return
+        gcode_viewer_config = []
+
+        for setting in gcode_viewer_config_definition:
+            if 'default' in setting:
+                Config.setdefault(setting['section'], setting['key'], setting['default'])
+                setting.pop('default', None)
+            gcode_viewer_config.append(setting)
+
+        self.config_popup.settings_panel.add_json_panel(tr._('G-Code Viewer'), Config, data=json.dumps(gcode_viewer_config))
 
     def load_pendant_config(self):
         config_def_file = os.path.join(os.path.dirname(__file__), 'pendant_config.json')
@@ -5987,6 +6036,20 @@ class Makera(RelativeLayout):
         if "high_precision_reamining_time_estimate" in self.controller_setting_change_list:
             self.gcode_viewer.high_precision_time_estimate = self.controller_setting_change_list.get("high_precision_reamining_time_estimate")
 
+        gcode_hl_changed = False
+        if 'gcode_highlight_enabled' in self.controller_setting_change_list:
+            self.gcode_highlight_enabled = self.controller_setting_change_list['gcode_highlight_enabled'] not in ('0', 'false', 'False')
+            gcode_hl_changed = True
+        for cat in GCODE_DEFAULT_COLORS:
+            config_key = f'gcode_color_{cat}'
+            if config_key in self.controller_setting_change_list:
+                self.gcode_highlight_colors[cat] = self._config_color_to_hex(self.controller_setting_change_list[config_key])
+                gcode_hl_changed = True
+        if gcode_hl_changed:
+            app = App.get_running_app()
+            if hasattr(self, 'gcode_rv') and self.gcode_rv.data:
+                self.load_page(app.curr_page)
+
         self.controller_setting_change_list.clear()
 
     # -----------------------------------------------------------------------
@@ -6180,12 +6243,19 @@ class Makera(RelativeLayout):
         if page_no > app.total_pages:
             page_no = app.total_pages
         self.gcode_rv.data = []
+        hl_enabled = getattr(self, 'gcode_highlight_enabled', False)
+        hl_colors = getattr(self, 'gcode_highlight_colors', None)
         line_no = (page_no - 1) * MAX_LOAD_LINES + 1
         for line in self.lines[(page_no - 1) * MAX_LOAD_LINES : MAX_LOAD_LINES * page_no]:
             line_txt = line[:-1].replace("\x0d", "")
+            plain = line_txt.strip()
+            if hl_enabled:
+                hl = highlight_gcode_line(plain, hl_colors)
+            else:
+                hl = escape_gcode_markup(plain)
             try:
                 self.gcode_rv.data.append(
-                    {'line_no': line_no, 'text': line_txt.strip(), 'color': (200 / 255, 200 / 255, 200 / 255, 1)})
+                    {'line_no': line_no, 'text': plain, 'highlighted_text': hl, 'color': (200 / 255, 200 / 255, 200 / 255, 1)})
             except IndexError:
                 logger.error("Tried to write to recycle view data at same time as reading, ignore (indexError)")
             line_no = line_no + 1
@@ -6556,6 +6626,18 @@ def set_config_defaults(default_lang):
     if not Config.has_option('graphics', 'height'): Config.set('graphics', 'height', '1440')
     if not Config.has_option('graphics', 'width'): Config.set('graphics', 'width',  '900')
     if not Config.has_option('carvera', 'instantFSoverride'): Config.set('carvera','instantFSoverride','1')
+
+    # G-code viewer syntax highlighting defaults
+    if not Config.has_option('carvera', 'gcode_highlight_enabled'): Config.set('carvera', 'gcode_highlight_enabled', '1')
+    if not Config.has_option('carvera', 'gcode_color_comment'): Config.set('carvera', 'gcode_color_comment', '106,153,85,255')
+    if not Config.has_option('carvera', 'gcode_color_g_command'): Config.set('carvera', 'gcode_color_g_command', '86,156,214,255')
+    if not Config.has_option('carvera', 'gcode_color_m_command'): Config.set('carvera', 'gcode_color_m_command', '197,134,192,255')
+    if not Config.has_option('carvera', 'gcode_color_coordinate'): Config.set('carvera', 'gcode_color_coordinate', '206,145,120,255')
+    if not Config.has_option('carvera', 'gcode_color_feedrate'): Config.set('carvera', 'gcode_color_feedrate', '78,201,176,255')
+    if not Config.has_option('carvera', 'gcode_color_spindle'): Config.set('carvera', 'gcode_color_spindle', '209,105,105,255')
+    if not Config.has_option('carvera', 'gcode_color_tool'): Config.set('carvera', 'gcode_color_tool', '181,206,168,255')
+    if not Config.has_option('carvera', 'gcode_color_line_number'): Config.set('carvera', 'gcode_color_line_number', '133,133,133,255')
+    if not Config.has_option('carvera', 'gcode_color_parameter'): Config.set('carvera', 'gcode_color_parameter', '156,220,254,255')
 
     Config.write()
 

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -202,7 +202,8 @@
         opacity: 1 if root.is_resume_line else 0
         source: 'data/open_iconic_UI/flag-8x.png'
     Label:
-        text: root.text
+        text: root.highlighted_text or root.text
+        markup: True
         color: root.color
         halign: 'left'
         valign: 'middle'


### PR DESCRIPTION
Had some Cursor credits that were about to expire and thought it would be a nice thing to have.
The implemented tokenizer is a bit naive but probably enough for this use case.


<img width="1920" height="1054" alt="image" src="https://github.com/user-attachments/assets/916e44bd-610e-4c71-af74-aa42faae6e84" />

<img width="1920" height="1056" alt="image" src="https://github.com/user-attachments/assets/6874d79f-d6a6-4f98-9c97-c757c7d2c74b" />
