### PR TITLE
Handle Spindle temp reporting when running Analog type spindle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes
+- Fixed: Spindle temp reporting when running Analog type spindle without rpm reporting
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -1302,6 +1302,8 @@ class Controller:
            CNC.vars["curfeed"] = float(d['F'][0])
            CNC.vars["tarfeed"] = float(d['F'][1])
            CNC.vars["OvFeed"]  = int(d['F'][2])
+           if len(d['F']) > 3:  # Analog type spindle reports temp via F status for some reason in FW <= 2.1.0
+               CNC.vars["spindletemp"] = float(d['F'][3])
         if 'S' in d:
             CNC.vars["curspindle"]  = float(d['S'][0])
             CNC.vars["tarspindle"]  = float(d['S'][1])


### PR DESCRIPTION
We probably should standardise this in the firmware, but until then this will handle the reporting of temp in the string returned when spindle.type analog