### PR TITLE
Fix: Disable trackpad being treated as touchscreen on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed: Spindle temp reporting when running Analog type spindle without rpm reporting
 - Fixed: Fit the gcode viewer to the path's bounding box instead of its max X/Y/Z
 - Fixed: Last character of the current file was sometimes missing in the file viewer
+- Fixed: Disable trackpad being treated as touchscreen on Linux
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6620,6 +6620,17 @@ def set_config_defaults(default_lang):
     if not kivy_platform in ['android', 'ios']:
         Config.set('input', 'mouse', "mouse,multitouch_on_demand") # disable multitouch simulation on non-mobile platforms
 
+    if kivy_platform == 'linux':
+        # Remove the default probesysfs entry that treats trackpads as touchscreens.
+        # Kivy's default adds '%(name)s = probesysfs,provider=hidinput' which picks up
+        # all HID devices including laptop trackpads.
+        if Config.has_option('input', '%(name)s'):
+            Config.remove_option('input', '%(name)s')
+        # Re-add probesysfs using mtdev, filtered to devices whose name contains
+        # "touchscreen" (case-insensitive). This preserves real touchscreen support
+        # while excluding trackpads, which never have "touchscreen" in their device name.
+        Config.set('input', 'touchscreen_%(name)s', 'probesysfs,provider=mtdev,match=(?i)touchscreen')
+
     # Only update config if running new version
     if not Config.has_option('carvera', 'version') or Config.get('carvera', 'version') != __version__:
         Config.set('carvera', 'version', __version__)


### PR DESCRIPTION
Fixes #571 

Problem
-------
On Linux, Kivy's default configuration adds a catch-all input provider entry:

    %(name)s = probesysfs,provider=hidinput

This causes Kivy to register ALL HID input devices — including laptop trackpads — as touch/multitouch screens. The result is that moving the trackpad generates spurious touch events, making the UI behave as if it's a touchscreen and causing erratic, broken interaction on normal laptops.

Fix
---
In set_config_defaults() in main.py, when running on Linux:

1. Remove the default '%(name)s' probesysfs/hidinput entry before it registers the trackpad as a touch device.

2. Re-add probesysfs using the mtdev backend (the Linux multitouch library, designed for real touchscreen hardware) with a case-insensitive name filter:

       touchscreen_%(name)s = probesysfs,provider=mtdev,match=(?i)touchscreen

   This only registers devices whose kernel name contains "touchscreen" (e.g. "ELAN Touchscreen", "Wacom Touchscreen"). Trackpad device names never contain this string, so they are excluded.

This fix is applied programmatically at startup — no manual editing of ~/.kivy/config.ini is required.

Behaviour after fix
-------------------
- Laptop trackpad: works as a normal mouse cursor (no touch events)
- Real touchscreen hardware: continues to work via mtdev
- Android / iOS: unaffected (the fix is Linux-only)
- macOS / Windows: unaffected (probesysfs is a Linux-only provider)

Tested on
-------------------
Debian 13 Stable with these laptops:
- Framework 13 (trackpad-only)
- Chuwi Minibook X (with trackpad and touch screen)
- GPD Win Max 2 (with trackpad and touch screen)
- Dell XPS 13 (trackpad-only)
Verified the problem existed before this diff, and checked that this change fixes everything with no new regressions. Check that existing trackpads operate as a mouse as expected, and a real touch screen continues to operate as a touch screen.
