### PR TITLE
Fix custom widget settings to apply changed values  #576

### DIFF
--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1135,8 +1135,18 @@ class DiagnosePopup(ModalView):
 # with no undo. This subclass overrides set_value to skip the Config write
 # while still notifying on_config_change, so changes only persist when the
 # user clicks Apply.
+#
+# ConfigPopup._apply_changes detects pending changes by comparing each
+# SettingItem's `value` ObjectProperty against a snapshot taken on open. That
+# only works if `widget.value` reflects user input. Standard Kivy widgets
+# assign `self.value` directly on input, but custom widgets that call
+# `panel.set_value(...)` without first updating `self.value` (e.g.
+# SettingPendantSelector) would otherwise be invisible to the Apply loop and
+# silently lose data. We sync `widget.value` here so the contract holds for
+# any caller of set_value.
 class DeferredSettingsPanel(SettingsPanel):
     _skip_sections = ('Backup', 'Restore')
+    _setting_widget_value = False
 
     def set_value(self, section, key, value):
         if section in self._skip_sections:
@@ -1151,9 +1161,22 @@ class DeferredSettingsPanel(SettingsPanel):
             if self.settings:
                 self.settings.dispatch('on_config_change', config, section, key, value)
             return
-        current = self.get_value(section, key)
-        if current == value:
+        # Re-entry guard: assigning child.value below fires SettingItem.on_value,
+        # which calls back into panel.set_value. Skip the inner call.
+        if self._setting_widget_value:
             return
+        current = self.get_value(section, key)
+        if str(current) == str(value):
+            return
+        for child in self.walk():
+            if isinstance(child, SettingItem) and child.section == section and child.key == key:
+                if str(child.value) != str(value):
+                    self._setting_widget_value = True
+                    try:
+                        child.value = value
+                    finally:
+                        self._setting_widget_value = False
+                break
         if self.settings:
             self.settings.dispatch('on_config_change', self.config, section, key, value)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,19 @@
+"""Unit-test setup for tests that import Kivy.
+
+Isolates Kivy state to a temp directory so unit tests don't read or mutate
+the user's real ~/.kivy config. Must run before any Kivy import — pytest
+loads conftest.py before collecting test modules in the same directory.
+"""
+
+import os
+import shutil
+import tempfile
+
+_kivy_home = tempfile.mkdtemp(prefix="kivy_unit_test_")
+os.environ.setdefault("KIVY_HOME", _kivy_home)
+os.environ.setdefault("KIVY_NO_FILELOG", "1")
+os.environ.setdefault("KIVY_NO_CONSOLELOG", "1")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    shutil.rmtree(_kivy_home, ignore_errors=True)

--- a/tests/unit/test_settings_persistence.py
+++ b/tests/unit/test_settings_persistence.py
@@ -1,0 +1,128 @@
+"""Persistence-contract tests for DeferredSettingsPanel.
+
+DeferredSettingsPanel defers Config writes until the user clicks Apply.
+ConfigPopup._apply_changes detects what to persist by comparing each
+SettingItem's `value` ObjectProperty against a snapshot taken on popup
+open. That diff-detection only works if `widget.value` reflects user input.
+
+A custom SettingItem subclass that calls `panel.set_value(...)` without
+first updating `self.value` (the original SettingPendantSelector bug, see
+issue #576) would otherwise be invisible to the Apply loop and silently
+lose data on application restart.
+
+These tests pin the panel's contract so future custom SettingItem types
+can't reintroduce the same class of bug. When adding a new custom widget
+type, register it in CASES.
+"""
+
+import json
+
+import pytest
+from kivy.config import ConfigParser
+from kivy.uix.settings import SettingItem, Settings
+
+from carveracontroller.addons.pendant.pendant import SettingPendantSelector
+from carveracontroller.custom_widgets import SettingColorPicker, SettingGCodeSnippet
+from carveracontroller.main import DeferredSettingsPanel
+
+
+# (test_id, registered_type, type_class_or_None, initial, new_value, panel_def_extras)
+# type_class_or_None is None for built-in Kivy types that Settings registers
+# automatically (bool, numeric, string, options, etc.).
+CASES = [
+    ("bool", "bool", None, "0", "1", {}),
+    ("numeric", "numeric", None, "0", "42", {}),
+    ("string", "string", None, "old", "new", {}),
+    ("options", "options", None, "a", "b", {"options": ["a", "b"]}),
+    ("pendant", "pendant", SettingPendantSelector, "None", "WHB04", {}),
+    ("colorpicker", "colorpicker", SettingColorPicker, "0,255,255,255", "255,0,0,255", {}),
+    (
+        "gcodesnippet",
+        "gcodesnippet",
+        SettingGCodeSnippet,
+        "{}",
+        '{"name":"x","gcode":"y"}',
+        {},
+    ),
+]
+
+
+def _make_panel(reg_type, cls, initial, extras):
+    """Build a DeferredSettingsPanel containing one SettingItem of the
+    requested type. Mirrors how MakeraConfigPanel.create_json_panel
+    constructs panels in production (subclass swizzle on the result of
+    Settings.create_json_panel)."""
+    config = ConfigParser()
+    config.add_section("test")
+    config.set("test", "key", initial)
+
+    settings = Settings()
+    if cls is not None:
+        settings.register_type(reg_type, cls)
+
+    panel_def = {"type": reg_type, "title": "T", "section": "test", "key": "key"}
+    panel_def.update(extras)
+
+    panel = settings.create_json_panel("T", config, data=json.dumps([panel_def]))
+    panel.__class__ = DeferredSettingsPanel
+    item = next(w for w in panel.walk() if isinstance(w, SettingItem))
+    return panel, item, config
+
+
+@pytest.mark.parametrize(
+    "reg_type,cls,initial,new_value,extras",
+    [c[1:] for c in CASES],
+    ids=[c[0] for c in CASES],
+)
+def test_panel_set_value_syncs_widget_value(reg_type, cls, initial, new_value, extras):
+    """After panel.set_value(...), the matching SettingItem's `value` must
+    reflect the new value. _apply_changes relies on this to detect what
+    needs persisting; a widget that fails this check silently loses data
+    on app restart."""
+    panel, item, _config = _make_panel(reg_type, cls, initial, extras)
+    assert str(item.value) == initial, "fixture sanity check"
+
+    panel.set_value("test", "key", new_value)
+
+    assert str(item.value) == new_value, (
+        f"{reg_type}: widget.value did not sync after panel.set_value. "
+        f"This widget would be invisible to ConfigPopup._apply_changes "
+        f"and silently lose data on app restart."
+    )
+
+
+@pytest.mark.parametrize(
+    "reg_type,cls,initial,new_value,extras",
+    [c[1:] for c in CASES],
+    ids=[c[0] for c in CASES],
+)
+def test_panel_set_value_defers_config_write(reg_type, cls, initial, new_value, extras):
+    """The deferred panel must not touch Config until Apply.
+
+    If Config gets written eagerly, Discard cannot revert and other parts
+    of the app would observe pending changes before the user confirms."""
+    panel, _item, config = _make_panel(reg_type, cls, initial, extras)
+
+    panel.set_value("test", "key", new_value)
+
+    assert config.get("test", "key") == initial, (
+        f"{reg_type}: Config was written before Apply. "
+        f"Deferred semantics broken — Discard would not revert."
+    )
+
+
+def test_pendant_spinner_change_propagates():
+    """Changing the spinner text on SettingPendantSelector must end up in
+    widget.value so the Apply loop can persist it. Catches regressions in
+    either the panel sync logic or the pendant's on_spinner_select handler."""
+    panel, item, config = _make_panel("pendant", SettingPendantSelector, "None", {})
+
+    # Mimic the user picking an entry from the spinner dropdown. Spinner
+    # text changes fire the bound on_spinner_select callback.
+    item.spinner.text = "WHB04"
+
+    assert str(item.value) == "WHB04", (
+        "Pendant change did not reach widget.value — would silently drop "
+        "user selections on restart."
+    )
+    assert config.get("test", "key") == "None", "Config write must remain deferred"


### PR DESCRIPTION
More fixes for #576 
Pendant options are different from standard Kivy widgets, so they need to have their values set explicitly. This is a more generic approach that should make it so future widgets not have to add in code to make saving work.

I've also added some sanity tests to help check that this fixes the issue. Run the tests without the changes to main.py and you'll get several failures. (Until we add more unit tests, I don't want to worry about folder or naming structure for unit tests.)