### PR TITLE
File viewer: Fix character sometimes missing in the last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes
 - Fixed: Spindle temp reporting when running Analog type spindle without rpm reporting
+- Fixed: Last character of the current file was sometimes missing in the file viewer
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6253,7 +6253,7 @@ class Makera(RelativeLayout):
         hl_colors = getattr(self, 'gcode_highlight_colors', None)
         line_no = (page_no - 1) * MAX_LOAD_LINES + 1
         for line in self.lines[(page_no - 1) * MAX_LOAD_LINES : MAX_LOAD_LINES * page_no]:
-            line_txt = line[:-1].replace("\x0d", "")
+            line_txt = line.rstrip("\r\n")
             plain = line_txt.strip()
             if hl_enabled:
                 hl = highlight_gcode_line(plain, hl_colors)


### PR DESCRIPTION
I'm not sure why it was done this way but the current code stripped one character at the end of each line (for `\n`) before removing `\x0d` (= `\r`).

This doesn't work if there is no empty line at the end of the file since it will instead remove the last character of the last line.
Instead we can just strip both `\r` and `\n`.

For instance using [this file](https://github.com/user-attachments/files/27552535/facing_wizard_top_right.txt):

**Before**
<img width="576" height="173" alt="image" src="https://github.com/user-attachments/assets/fb7c8b98-ba9c-4f10-9c35-ed1713a660ba" />


**After**
<img width="578" height="174" alt="image" src="https://github.com/user-attachments/assets/17c399e5-0208-4c20-b619-8d504652ccaa" />
