### PR TITLE
Fix initial machine config load and remove remaining "Can not load config, Key:" messages from the MDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed: Fit the gcode viewer to the path's bounding box instead of its max X/Y/Z
 - Fixed: Last character of the current file was sometimes missing in the file viewer
 - Fixed: Disable trackpad being treated as touchscreen on Linux
+- Change: Remove remaining "Can not load config, Key:" messages from the MDI
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5634,17 +5634,12 @@ class Makera(RelativeLayout):
     def load_machine_config(self):
         panels = self.config_popup.settings_panel.interface.content.panels
 
-        # Need to subtract the controller config panels from count to see if machine config panels already loaded
-        controller_config_panels = 0
-        for panel in panels.values():
-            if panel.title == 'Controller':
-                controller_config_panels += 1
-            if panel.title == 'Pendant':
-                controller_config_panels += 1
+        # Filter panels that are bound to the machine config
+        machine_panels = [panel for panel in panels.values() if panel.config is self.config]
 
-        if len(panels.values()) - controller_config_panels > 0:
+        if machine_panels:
             # already have panels, update data
-            for panel in panels.values():
+            for panel in machine_panels:
                 children = panel.children
                 for child in children:
                     if isinstance(child, SettingItem):
@@ -5662,8 +5657,12 @@ class Makera(RelativeLayout):
                             self.setting_change_list[child.key] = new_value
                             if new_value != child.value:
                                 child.value = new_value
-                            self.controller.log.put(
-                                (Controller.MSG_NORMAL, 'Can not load config, Key: {}'.format(child.key)))
+                            # This warning message doesn't make sense since settings values not in config.txt will just use the firmware default value.
+                            #
+                            # Until functionality is added to the firmware to output the complete settings values we should not display such messages
+                            #
+                            # self.controller.log.put(
+                            #     (Controller.MSG_NORMAL, 'Can not load config, Key: {}'.format(child.key)))
 
                         # restore/default are used for default config management
                         # carvera/graphics options are managed via Controller settings (not here)


### PR DESCRIPTION
While fixing #570 (I just commented out a second `log.put(...)`) I noticed that the machine config panels were not displayed in the settings anymore.


This was caused by #575: I hadn't noticed that the check deciding whether we are doing the first config load or a subsequent update was based on the titles of the existing config panels.

Because that PR added a new "G-Code viewer" panel `len(panels.values()) - controller_config_panels` always returned `1` forcing the "update" path.


Instead of just adding that new panel to the exclusion list I decided to filter the existing panels by their `config` property:
- the "machine" panels are bound to `self.config`
- the other panels are bound to the Kivy `Config` object

This should (hopefully) avoid similar mistakes in the future.


I only mentioned #570 in the changelog since #575 hasn't been released yet.