### PR TITLE
Show current config probe tip diameter as a placeholder in probing panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enhancement: Only re-render the G-Code viewer scene if something has changed
 - Enhancement: Support gamepads as pendants
 - Enhancement: Added iPhone support
+- Enhancement: Show current config probe tip diameter in probing panels
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/addons/probing/ProbingPopup.py
+++ b/carveracontroller/addons/probing/ProbingPopup.py
@@ -30,6 +30,8 @@ from .operations.ProbeTip.ProbeTipSettings import ProbeTipSettings
 
 from .operations.FourthAxis.FourthAxisOperationType import FourthAxisOperationType
 from .operations.FourthAxis.FourthAxisSettings import FourthAxisSettings
+from .operations.ConfigUtils import get_machine_config_hint
+from carveracontroller.translation import tr
 
 import logging
 logger = logging.getLogger(__name__)
@@ -52,6 +54,7 @@ class ProbingPopup(ModalView):
         self.probeTipSettings = None
         self.calibration_settings = None
         self.fourth_axis_settings = None
+        self._settings_panels = ()
         self.controller = controller
 
         self.preview_popup = ProbingPreviewPopup(controller)
@@ -77,12 +80,30 @@ class ProbingPopup(ModalView):
         self.angle_settings = self.ids.angle_settings
         self.probeTipSettings = self.ids.probeTipSettings
         self.fourth_axis_settings = self.ids.fourth_axis_settings
+        self._settings_panels = (
+            self.angle_settings,
+            self.bore_settings,
+            self.boss_settings,
+            self.inside_corner_settings,
+            self.outside_corner_settings,
+            self.single_axis_settings,
+            self.calibration_settings,
+        )
+
+    def open(self, *args, **kwargs):
+        self.refresh_probe_tip_diameter_hints()
+        super().open(*args, **kwargs)
 
     def delayed_bind_complete(self, dt):
         #self.angle_settings = self.ids.angle_settings
         #self.probeTipSettings = self.ids.probeTipSettings
         return
 
+    def refresh_probe_tip_diameter_hints(self):
+        hint = get_machine_config_hint('zprobe.probe_tip_diameter') or tr._("config")
+        for settings in self._settings_panels:
+            if settings and 'ProbeTipDiameter' in settings.ids:
+                settings.ids.ProbeTipDiameter.hint_text = hint
 
     def on_single_axis_probing_pressed(self, operation_key: str):
         cfg = self.single_axis_settings.get_config()

--- a/carveracontroller/addons/probing/operations/ConfigUtils.py
+++ b/carveracontroller/addons/probing/operations/ConfigUtils.py
@@ -1,6 +1,8 @@
 import json
 import os
 import logging
+from typing import Optional
+
 logger = logging.getLogger(__name__)
 
 class ConfigUtils:
@@ -27,3 +29,28 @@ class ConfigUtils:
             except Exception as e:
                 logger.error(f"Error loading configuration: {e}")
         return {}  # Return an empty dictionary if loading fails or file doesn't exist
+
+
+def _format_hint_value(val) -> str:
+    try:
+        f = float(val)
+        if f == int(f):
+            return str(int(f))
+        return ('%g' % f)
+    except (ValueError, TypeError):
+        return str(val).strip()
+
+
+def _get_setting_list() -> dict:
+    from kivy.app import App
+    return App.get_running_app().root.setting_list
+
+
+def get_machine_config_hint(config_key: str) -> Optional[str]:
+    try:
+        val = _get_setting_list().get(config_key)
+        if val is not None and str(val).strip():
+            return _format_hint_value(val)
+    except Exception:
+        pass
+    return None

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
@@ -25,6 +25,7 @@
                     size_hint_x: 0.4
                     font_size: '14dp'
                     hint_text: tr._("required")
+                    hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('X distance to probe')
                     tooltip_image: ''
                     multiline: False
@@ -44,6 +45,7 @@
                     tooltip_image: ''
                     multiline: False
                     hint_text: tr._("required")
+                    hint_text_color: (0.2,0.5,0.5,0.5)
                     halign:'right'
                     input_type: 'number'
                     input_filter: 'float'
@@ -55,7 +57,9 @@
                 ToolTipTextInput:
                     id: ProbeTipDiameter
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: tr._("config")
+                    hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Effective Diameter of Probe Tip. Measure with M460')
                     tooltip_image: 'addons/probing/data/icons_1024x768/general_parameters/probe_parameter_d.png'
                     tooltip_image_size: 200,200
@@ -71,6 +75,7 @@
                 ToolTipTextInput:
                     id: PocketProbeDepth
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "0"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Distance to probe straight down before performing remainder of probing operations')
@@ -87,6 +92,7 @@
                 ToolTipTextInput:
                     id: FastFeedRate
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "300"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Optional probing feed rate override')
@@ -103,6 +109,7 @@
                 ToolTipTextInput:
                     id: RapidFeedRate
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "800"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Optional rapid feed rate override')
@@ -117,8 +124,9 @@
                 ProbeSettingLabel:
                     label_text: 'Repeat (L):'
                 ToolTipTextInput:
-                    size_hint_x: 0.4
                     id: RepeatOperationCount
+                    size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "1"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Number of times to repeat the probing operation')
@@ -135,6 +143,7 @@
                 ToolTipTextInput:
                     id: EdgeRetractDistance
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "1.5"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Distance away from surface to retract before double tapping the probe')
@@ -151,6 +160,7 @@
                 ToolTipTextInput:
                     id: BottomSurfaceRetract
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "2"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('If Pocket Depth is enabled, how far above the surface to raise before continuing the operation')
@@ -167,6 +177,7 @@
                 ToolTipTextInput:
                     id: QAngle
                     size_hint_x: 0.4
+                    font_size: '14dp'
                     hint_text: "0"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Degrees to rotate the XY coordinate plane when probing.')
@@ -183,6 +194,7 @@
                     label_text: 'Probe Depth (E)'
                 ToolTipTextInput:
                     id: ProbeDepth
+                    font_size: '14dp'
                     hint_text: "0"
                     hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('How far below the start height to move down for probing the sides of the part')


### PR DESCRIPTION
Fixes #543 by displaying the current value of `zprobe.probe_tip_diameter` as a placeholder for the ProbeTipDiameter fields of the various probing panels.

I also added some missing `font_size`/`hint_text_color`/`size_hint_x` values that were missing from the fields of the "Outside Corners" panel so they render the same way as the other panels.

<img width="1511" height="486" alt="image" src="https://github.com/user-attachments/assets/9dfb42e6-2244-4c95-91b0-2892d251e198" />