### PR TITLE
Fix is_jogging_enabled logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed: Fit the gcode viewer to the path's bounding box instead of its max X/Y/Z
 - Fixed: Last character of the current file was sometimes missing in the file viewer
 - Fixed: Disable trackpad being treated as touchscreen on Linux
+- Fixed: Jogging was incorrectly blocked/allowed under certain conditions
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 
 [2.1.0]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5797,14 +5797,15 @@ class Makera(RelativeLayout):
 
     def is_jogging_enabled(self):
         app = App.get_running_app()
-        
-        # Allow jogging when machine is running if the setting is enabled
-        if app.state == 'Run' and self.allow_jogging_while_machine_running == '1':
-            return not self._is_popup_open()
-        return \
-            not app.playing and \
-            (app.state in ['Idle', 'Run', 'Pause'] or (app.playing and app.state == 'Pause')) and \
-            not (self._is_popup_open() and not self.probing_popup._is_open)
+
+        return (
+            (not app.playing or app.state == 'Pause')
+            and (
+                app.state in ['Idle', 'Pause']
+                or (app.state == 'Run' and self.allow_jogging_while_machine_running == '1')
+            )
+            and not (self._is_popup_open() and not self.probing_popup._is_open)
+        )
 
     def is_pendant_jogging_enabled(self):
         # If the user disabled pendant, respect it.


### PR DESCRIPTION
Copy/paste from my comment [here](https://github.com/Carvera-Community/Carvera_Controller/pull/592#issuecomment-4505132821):

I noticed a couple potential issues with the `is_jogging_enabled()` method on `develop`:

https://github.com/Carvera-Community/Carvera_Controller/blob/aae363179ddf6b3c23b3f649a5fbf3cbb8bd1d17/carveracontroller/main.py#L5798-L5807

1) The first check allows jogging if the machine is playing a file (and not paused) which I don't think should be the case
2) The first condition in the final `return` is `not app.playing` which means that `(app.playing and app.state == 'Pause')` on the next line will never be used (since `app.playing` cannot be `true` anymore at that point).
3) If `allow_jogging_while_machine_running` is not enabled it goes into the final `return` which allows jogging if the current state is `Run`