### PR TITLE
Update p4a, override p4a recipe's Cython to use 3.1.8

### DIFF
--- a/assets/packaging/android/recipes/cython/__init__.py
+++ b/assets/packaging/android/recipes/cython/__init__.py
@@ -1,0 +1,20 @@
+from pythonforandroid.recipe import CompiledComponentsPythonRecipe
+
+
+class CythonRecipe(CompiledComponentsPythonRecipe):
+    # Upstream p4a pins Cython 0.29.36, whose generated C calls
+    # _PyLong_AsByteArray() with the pre-3.13 signature and fails to compile
+    # against Python 3.14 (which p4a's develop branch now bundles):
+    #   Cython/Plex/Scanners.c: error: too few arguments to function call,
+    #   expected 6, have 5
+    # Bump to a Cython that supports 3.14 (3.1.x; the same series the
+    # PyProjectRecipes already pip-install to produce cp314 wheels).
+    version = '3.1.8'
+    url = 'https://github.com/cython/cython/archive/{version}.tar.gz'
+    site_packages_name = 'cython'
+    depends = ['setuptools']
+    call_hostpython_via_targetpython = False
+    install_in_hostpython = True
+
+
+recipe = CythonRecipe()

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -327,11 +327,10 @@ android.allow_backup = True
 #p4a.fork = kivy
 
 # (str) python-for-android branch to use, defaults to master
-p4a.branch = develop
+p4a.branch = v2026.05.09
 
 # (str) python-for-android specific commit to use, defaults to HEAD, must be within p4a.branch
-# Commits after 6b66944a2f51e0c848c7ac51e04a771324067ecc break the build
-p4a.commit = c02cf781a0d3d232eb4ffbeaf580cc82cf2bd65f
+#p4a.commit =
 
 # (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
 #p4a.source_dir =


### PR DESCRIPTION
Fixes #438

P4A doesn't update its target version of Cython due to upstream dependencies, and so pretty much all of Kivy's projects individually target Cython 3. We have one legacy unmaintained dependency (PyQuicklZ) that's causing the fail. It's just a wrapper, so changing to Cython 3's format shouldn't impact it. 