### PR TITLE
Fix UI showing 'No Pendant' when pendant is actually working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed: Last character of the current file was sometimes missing in the file viewer
 - Fixed: Disable trackpad being treated as touchscreen on Linux
 - Fixed: Jogging was incorrectly blocked/allowed under certain conditions
+- Fixed: Fix incorrect "No Pendant" in UI when pendant is working
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file
 

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5912,6 +5912,7 @@ class Makera(RelativeLayout):
     def handle_pendant_connected(self):
         self.ids.pendant_jogging_en_btn.disabled = False
         app =App.get_running_app()
+        app.jog_pendant_text = tr._('Pendant Jogging')
         self.update_pendant_jog_text()
         app.jog_pendant_enable = 'down' if self.pendant_jogging_default else 'normal'
         app.root.pendant_jog_control = self.pendant_jogging_default


### PR DESCRIPTION
Previously the UI would show "No Pendant" from startup even when it was working fine. If you went to Settings, disabled, and then re-enabled it, the UI would then be updated correctly.

Explanation from Claude that analyzed the code:
At startup, app.state is "N/A" (NOT_CONNECTED), so the parent BoxLayout containing the pendant jogging button has its disabled binding evaluate to True. Kivy propagates disabled state to children via a _disabled_count counter: the parent increments the button's count, and then handle_pendant_disconnected() increments it again (count=2).

When the pendant connects and handle_pendant_connected() fires via Clock.schedule_once, it sets disabled=False which decrements the count to 1 — but because the parent BoxLayout is still disabled (the machine hasn't finished connecting and app.state isn't Idle yet), the count never reaches 0. The button remains disabled, so update_pendant_jog_text() sees disabled=True and skips setting the text.

Fix: set app.jog_pendant_text directly in handle_pendant_connected() before calling update_pendant_jog_text(). This ensures "Pendant Jogging" is shown regardless of the button's disabled count. The subsequent update_pendant_jog_text() call still runs and will refine the text with step-size info for pendant types that support it.