### PR TITLE
Throw error if WHB04 is enabled but permissions are not configured correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enhancement: Improve Gcode viewer toolbar buttons layout
 - Enhancement: Show current config probe tip diameter in probing panels
 - Enhancement: Add grid visualization and color schemes selector to the G-Code viewer
+- Enhancement: Detect WHB04 pendant permission errors instead of silently ignoring pendant
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -140,6 +140,7 @@ if WHB04_SUPPORTED:
             self._daemon.on_jog = self._handle_jogging
             self._daemon.on_button_press = self._handle_button_press
             self._daemon.on_stop_jog = self._handle_stop_jog
+            self._daemon.on_permission_error = self._handle_permission_error
 
             self._daemon.start()
 
@@ -319,6 +320,38 @@ if WHB04_SUPPORTED:
                 self._controller.stopContinuousJog()
                 if self._update_ui_on_jog_stop:
                     self._update_ui_on_jog_stop()
+
+        def _handle_permission_error(self, daemon: whb04.Daemon) -> None:
+            message = (
+                "The WHB04 pendant was found but cannot be opened due to\n"
+                "insufficient permissions on the USB HID device.\n\n"
+                "See the documentation on how to fix these permissions on Linux:\n"
+                "https://carvera-community.gitbook.io/docs/controller/features/pendant-support#linux"
+            )
+            print(f"\nERROR: {message}\n", flush=True)
+
+            scroll = ScrollView(size_hint=(1, 1))
+            lbl = Label(text=message, halign='left', valign='top', size_hint_y=None)
+            lbl.bind(
+                width=lambda w, v: setattr(w, 'text_size', (v, None)),
+                texture_size=lambda w, v: setattr(w, 'height', v[1]),
+            )
+            scroll.add_widget(lbl)
+
+            btn = Button(text="Exit", size_hint_y=None, height=dp(44))
+
+            content = BoxLayout(orientation='vertical', spacing=dp(10), padding=dp(10))
+            content.add_widget(scroll)
+            content.add_widget(btn)
+
+            popup = Popup(
+                title="Pendant Permission Error",
+                content=content,
+                size_hint=(0.85, 0.65),
+                auto_dismiss=False,
+            )
+            btn.bind(on_release=lambda *_: App.get_running_app().stop())
+            popup.open()
 
 
 class GamepadPendant(Pendant):

--- a/carveracontroller/addons/pendant/whb04.py
+++ b/carveracontroller/addons/pendant/whb04.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from enum import Enum
+import logging
+import os
 import struct
 import threading
 import time
@@ -8,6 +10,12 @@ from typing import Callable, List, Optional
 import platform
 
 import hid
+
+logger = logging.getLogger(__name__)
+
+
+class _PendantPermissionError(Exception):
+    """Raised when the pendant device is found but cannot be opened due to permissions."""
 
 # On Windows, the pendant is represented by two devices, meanwhile on Linux
 # the pendant is a single device. Let's abstract this away into the PendantHid class:
@@ -153,6 +161,7 @@ class Daemon:
         self.on_step_size_change: Optional[Callable[[Daemon, StepSize], None]] = None
         self.on_update: Optional[Callable[[Daemon], None]] = None
         self.on_stop_jog: Optional[Callable[[Daemon], None]] = None
+        self.on_permission_error: Optional[Callable[[Daemon], None]] = None
 
     def start(self) -> None:
         self._daemon_thread = threading.Thread(target=self._thread_loop, daemon=True)
@@ -329,28 +338,41 @@ class Daemon:
 
     def _thread_loop(self) -> None:
         while self._is_running:
+            connected = False
             try:
                 device = self._connect()
                 if device is None:
                     continue
 
                 with device as guarded_device:
+                    connected = True
                     if self.on_connect is not None:
                         self.callback_executor(lambda: self.on_connect(self))
                     self._device_loop(guarded_device)
-            except Exception:
-                # Exception means the device was disconnected or an error occurred.
-                # Let's just try again
-                pass
+            except _PendantPermissionError as e:
+                logger.error("Pendant found but cannot be opened: permission denied on %s", e)
+                self._is_running = False
+                if self.on_permission_error is not None:
+                    self.callback_executor(lambda: self.on_permission_error(self))
+            except Exception as e:
+                logger.warning("Pendant error (will retry): %s", e)
             finally:
-                if self.on_disconnect is not None:
-                        self.callback_executor(lambda: self.on_disconnect(self))
+                if connected and self.on_disconnect is not None:
+                    self.callback_executor(lambda: self.on_disconnect(self))
 
     def _connect(self, poll_interval: float = 0.1) -> Optional[PendantHid]:
         while self._is_running:
             devices = [d for d in hid.enumerate() if (d["vendor_id"], d["product_id"]) in self.DEVICE_IDS]
-            if len(devices) > 0:
-                return PendantHid(devices)
+            if devices:
+                try:
+                    return PendantHid(devices)
+                except Exception as e:
+                    path = devices[0].get("path", b"")
+                    if isinstance(path, bytes):
+                        path = path.decode("utf-8", errors="replace")
+                    if path and not os.access(path, os.R_OK | os.W_OK):
+                        raise _PendantPermissionError(path) from e
+                    raise
             time.sleep(poll_interval)
 
         return None


### PR DESCRIPTION
Previously would silently just ignore connected pendant without giving the user any feedback on the failure. Now we give a detailed message to the user on how to correct the problem.

Tested with LHB04B-4 pendant on a Debian 13 x86_64 laptop. Debian does not configure permissions for the pendant, they are root:root by default.