### PR TITLE
Probe scan: Allow to configure probe tip diameter

### DIFF
--- a/carveracontroller/addons/probe_scan/core/gcode.py
+++ b/carveracontroller/addons/probe_scan/core/gcode.py
@@ -240,6 +240,7 @@ def _build_probe_cmd(
     *,
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
+    d_tip: str = "",
     l_repeat: str = "",
     r_retract: str = "",
     result_vars: list[str] | None = None,
@@ -248,6 +249,9 @@ def _build_probe_cmd(
     parts.extend(w for w in axis_words if w)
     parts.append(f"F{_fmt(f_probe)}")
     parts.append(f"K{_fmt(k_rapid)}")
+    dw = _word("D", d_tip)
+    if dw:
+        parts.append(dw)
     lw = _word("L", l_repeat)
     if lw:
         parts.append(lw)
@@ -265,6 +269,7 @@ def build_m466(
     e: str = "",
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -280,7 +285,7 @@ def build_m466(
         "M466",
         [xw, yw, _word("E", e), _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
         result_vars=result_vars or list(VAR_SETS["M466"]),
     )
 
@@ -292,6 +297,7 @@ def build_m461(
     e: str = "",
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -307,7 +313,7 @@ def build_m461(
         "M461",
         [xw, yw, _word("E", e), _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
         result_vars=result_vars or list(VAR_SETS["M461"]),
     )
 
@@ -320,6 +326,7 @@ def build_m462(
     j_clearance: str = "",
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -336,7 +343,7 @@ def build_m462(
         [xw, yw, _word("J", j_clearance),
          _word("E", e_depth), _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
         result_vars=result_vars or list(VAR_SETS["M462"]),
     )
 
@@ -348,6 +355,7 @@ def build_m463(
     e: str = "",
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -358,7 +366,7 @@ def build_m463(
         [f"X{_fmt(x)}", f"Y{_fmt(y)}",
          _word("E", e), _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
     )
 
 
@@ -369,6 +377,7 @@ def build_m464(
     e: str = "",
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -379,7 +388,7 @@ def build_m464(
         [f"X{_fmt(x)}", f"Y{_fmt(y)}",
          _word("E", e), _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
     )
 
 
@@ -390,6 +399,7 @@ def build_m465(
     *,
     h: str = "",
     c: str = "",
+    d_tip: str = "",
     f_probe: float = 300.0,
     k_rapid: float = 800.0,
     l_repeat: str = "",
@@ -400,7 +410,7 @@ def build_m465(
         [_word("X", x), _word("Y", y), _word("E", e),
          _word("H", h), _word("C", c)],
         f_probe=f_probe, k_rapid=k_rapid,
-        l_repeat=l_repeat, r_retract=r_retract,
+        d_tip=d_tip, l_repeat=l_repeat, r_retract=r_retract,
     )
 
 

--- a/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.kv
+++ b/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.kv
@@ -249,6 +249,11 @@
                                         id: t466_k
                                         text: '800'
                                     ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t466_d
+                                        hint_text: tr._('config')
+                                    ProbeScanFieldLabel:
                                         text: tr._('Depth E')
                                     ProbeScanFieldInput:
                                         id: t466_e
@@ -364,6 +369,11 @@
                                     ProbeScanFieldInput:
                                         id: t461_k
                                         text: '800'
+                                    ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t461_d
+                                        hint_text: tr._('config')
                                     ProbeScanFieldLabel:
                                         text: tr._('Depth E')
                                     ProbeScanFieldInput:
@@ -501,6 +511,11 @@
                                         id: t462_k
                                         text: '800'
                                     ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t462_d
+                                        hint_text: tr._('config')
+                                    ProbeScanFieldLabel:
                                         text: tr._('Repeat L')
                                     ProbeScanFieldInput:
                                         id: t462_l
@@ -611,6 +626,11 @@
                                     ProbeScanFieldInput:
                                         id: t463_k
                                         text: '800'
+                                    ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t463_d
+                                        hint_text: tr._('config')
                                     ProbeScanFieldLabel:
                                         text: tr._('Repeat L')
                                     ProbeScanFieldInput:
@@ -723,6 +743,11 @@
                                         id: t464_k
                                         text: '800'
                                     ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t464_d
+                                        hint_text: tr._('config')
+                                    ProbeScanFieldLabel:
                                         text: tr._('Repeat L')
                                     ProbeScanFieldInput:
                                         id: t464_l
@@ -828,6 +853,11 @@
                                     ProbeScanFieldInput:
                                         id: t465_k
                                         text: '800'
+                                    ProbeScanFieldLabel:
+                                        text: tr._('Tip Dia D')
+                                    ProbeScanFieldInput:
+                                        id: t465_d
+                                        hint_text: tr._('config')
                                     ProbeScanFieldLabel:
                                         text: tr._('Repeat L')
                                     ProbeScanFieldInput:

--- a/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.py
+++ b/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.py
@@ -24,6 +24,7 @@ from kivy.factory import Factory
 from carveracontroller.CNC import CNC
 from carveracontroller.Controller import Controller
 from carveracontroller.main import is_ios
+from carveracontroller.addons.probing.operations.ConfigUtils import get_machine_config_hint
 from carveracontroller.serial_listeners import (
     register_serial_listener,
     unregister_serial_listener,
@@ -405,6 +406,7 @@ class ProbeScanPopup(ModalView):
         Clock.schedule_once(lambda _dt: self._tick_wcs_live(), 0.05)
         Clock.schedule_once(lambda _dt: self._sync_manual_wcs_fields_from_machine(), 0.08)
         Clock.schedule_once(lambda _dt: self._refresh_feature_ui(), 0)
+        Clock.schedule_once(lambda _dt: self._refresh_probe_tip_diameter_hints(), 0)
 
     def dismiss(self, *args, **kwargs):
         if self.is_probing:
@@ -1184,6 +1186,14 @@ class ProbeScanPopup(ModalView):
     def on_angle_axis_hint(self, which: str):
         self._angle_variant = which
 
+    def _refresh_probe_tip_diameter_hints(self) -> None:
+        hint = get_machine_config_hint("zprobe.probe_tip_diameter") or tr._("config")
+        for prefix in ("466", "461", "462", "463", "464", "465"):
+            try:
+                self.ids[f"t{prefix}_d"].hint_text = hint
+            except Exception:
+                logger.debug("Could not update tip diameter hint for t%s_d", prefix)
+
     def _read_common_probe_opts(self, prefix: str) -> dict:
         return dict(
             h=_parse_optional_float_text(self.ids[f"t{prefix}_h"]) or "",
@@ -1192,6 +1202,7 @@ class ProbeScanPopup(ModalView):
             k_rapid=_parse_float_field(self.ids[f"t{prefix}_k"], 800.0),
             l_repeat=_parse_optional_float_text(self.ids[f"t{prefix}_l"]) or "",
             r_retract=_parse_optional_float_text(self.ids[f"t{prefix}_r"]) or "",
+            d_tip=_parse_optional_float_text(self.ids[f"t{prefix}_d"]) or "",
         )
 
     def on_probe_axis466(self):


### PR DESCRIPTION
When adding the probe scan tool I did not initially allow to override the current tip diameter, thinking it would not be necessary from those screens.

After discussing with @SergeBakharev this morning I realized it could actually be useful to probe some features (for instance if we want to know where the center of the tip was when the probe was triggered).

No changelog update since the tool hasn't been released yet.