### PR TITLE
Fix unhandled ValueError causing WHB04 pendant feedrate crash Issue #620

### DIFF
--- a/carveracontroller/addons/pendant/pendant.py
+++ b/carveracontroller/addons/pendant/pendant.py
@@ -143,7 +143,15 @@ if WHB04_SUPPORTED:
             daemon.set_display_position(whb04.Axis.Y, self._cnc.vars["wy"])
             daemon.set_display_position(whb04.Axis.Z, self._cnc.vars["wz"])
             daemon.set_display_position(whb04.Axis.A, self._cnc.vars["wa"])
-            daemon.set_display_feedrate(self._cnc.vars["curfeed"])
+            # daemon.set_display_feedrate(self._cnc.vars["curfeed"])
+            # rbeard-ewa fix unhandled exception for bad feedrate
+            try:
+              raw_feed = float(self._cnc.vars.get("curfeed", 0))
+              safe_feed = max(0.0, min(raw_feed, 9999.0))
+              daemon.set_display_feedrate(safe_feed)
+            except ValueError:
+              pass
+            # end of feedrate fix
             daemon.set_display_spindle_speed(self._cnc.vars["curspindle"])
             
             # Update the step indicator to reflect current jog mode


### PR DESCRIPTION
The Issue:
When executing dynamic 4th-axis toolpaths (such as continuous rotary finishing operations), the machine's internal curfeed variable can spike significantly as the firmware dynamically calculates angular rotational speed to maintain a constant linear surface speed. Values can easily fluctuate between single digits and 8000+ mid-operation.

When the background Kivy loop (_handle_display_update in pendant.py) polls this curfeed value and passes it to the WHB04 driver, it occasionally exceeds the formatting limits of the physical  display. The driver explicitly raises a ValueError("Feedrate outside range"). Because this exception was unhandled in the clock callback, it would bubble up and completely crash the Kivy main loop, killing the controller UI while the machine was running.

The Fix:

Safely parsed the curfeed variable.
Clamped the raw feedrate to 9999.0 (the maximum displayable value for the 4-digit WHB04 segment).
Wrapped the daemon.set_display_feedrate() call in a try...except ValueError block.
If the driver still rejects the value, the exception is caught silently. This allows the Kivy event loop to continue polling and keeps the UI (and the other functioning coordinate readouts on the pendant) completely stable.

Testing Performed:
Validated locally on a Carvera Air running continuous 4th-axis multi-operation toolpaths via DeskProto.
Confirmed the Kivy UI loop remained perfectly stable during extreme curfeed fluctuations and finished the complete cut without a single crash.

Fixes #620