### PR TITLE
update to use ERROR instead of ALARM in halt popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 [unreleased]
-- Enhancement: Display alarm message in halt popup
+- Enhancement: Display error message in halt popup. Requires halt errors to start with "ERROR: " in the firmware
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware
 - Enhancement: Improvements to saving changes in settings menu
 - Enhancement: Add syntax highlighting to the file viewer

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -1839,8 +1839,8 @@ class Controller:
                     self.continuous_jog_active = False
             elif "error" in line.lower() or "alarm" in line.lower():
                 self.log.put((self.MSG_ERROR, line))
-                if line.upper().startswith("ALARM:"):
-                    msg = line[len("ALARM:"):].strip()
+                if line.upper().startswith("ERROR:"):
+                    msg = line[len("ERROR:"):].strip()
                     if msg:
                         CNC.vars["alarm_message"] = msg
             else:


### PR DESCRIPTION
based on https://github.com/Carvera-Community/Carvera_Controller/pull/559
And to be used in conjunction with 
https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/325

I changed the firmware and controller to both use ERROR: as the prefix for displaying text in the halt popup.