### PR TITLE
Add script to update config defaults from firmware

### DIFF
--- a/carveracontroller/config_c1.json
+++ b/carveracontroller/config_c1.json
@@ -1,17 +1,17 @@
 [
-   {
+    {
         "type": "title",
         "title": "Vacuum",
         "section": "Basic"
-   },
+    },
     {
         "type": "numeric",
         "title": "Vacuum power",
         "desc": "Default vacuum power when open (50 - 100)",
         "section": "Basic",
-        "key": "switch.vacuum.default_on_value"
+        "key": "switch.vacuum.default_on_value",
+        "default": "80"
     },
-	
     {
         "type": "title",
         "title": "Light",
@@ -22,16 +22,17 @@
         "title": "Light on",
         "desc": "Whether to turn on light by default",
         "section": "Basic",
-        "key": "switch.light.startup_state"
+        "key": "switch.light.startup_state",
+        "default": "true"
     },
     {
         "type": "numeric",
         "title": "Light off minutes",
         "desc": "Turn off the light when idle for these minutes (0 means never)",
         "section": "Basic",
-        "key": "light.turn_off_min"
-    },	
-	
+        "key": "light.turn_off_min",
+        "default": "0.0"
+    },
     {
         "type": "title",
         "title": "Safety",
@@ -42,9 +43,9 @@
         "title": "Stop on open",
         "desc": "Stop when open the cover during machining",
         "section": "Basic",
-        "key": "stop_on_cover_open"
+        "key": "stop_on_cover_open",
+        "default": "false"
     },
-
     {
         "type": "title",
         "title": "Power management",
@@ -55,16 +56,17 @@
         "title": "Auto sleep",
         "desc": "Allow machine to enter sleep mode automatically",
         "section": "Basic",
-        "key": "power.auto_sleep"
+        "key": "power.auto_sleep",
+        "default": "false"
     },
     {
         "type": "numeric",
         "title": "Auto sleep minutes",
         "desc": "Enter sleep mode after these minutes (1 - 30)",
         "section": "Basic",
-        "key": "power.auto_sleep_min"
+        "key": "power.auto_sleep_min",
+        "default": "5"
     },
-
     {
         "type": "title",
         "title": "Main button",
@@ -76,10 +78,14 @@
         "desc": "Triggered after 3 seconds when pressing\nNone   ------Do Nothing\nSleep  ------Enter sleep mode\nRepeat------Repeat Last Job\nTool Change------Clamp/Unclamp Collet for Tool Changes (Community Firmware Only)",
         "section": "Basic",
         "key": "main_button_long_press_enable",
-        "options": ["None", "Sleep", "Repeat", "ToolChange"],
+        "options": [
+            "None",
+            "Sleep",
+            "Repeat",
+            "ToolChange"
+        ],
         "default": "None"
     },
-
     {
         "type": "title",
         "title": "Coordinates",
@@ -90,119 +96,136 @@
         "title": "Anchor1 X",
         "desc": "X Machine coordinates of anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor1_x"
-    },	
+        "key": "coordinate.anchor1_x",
+        "default": "-360.158"
+    },
     {
         "type": "numeric",
         "title": "Anchor1 Y",
         "desc": "Y Machine coordinates of anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor1_y"
-    },	
+        "key": "coordinate.anchor1_y",
+        "default": "-234.568"
+    },
     {
         "type": "numeric",
         "title": "Anchor2 X Offset",
         "desc": "Anchor2 X Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor2_offset_x"
-    },	
+        "key": "coordinate.anchor2_offset_x",
+        "default": "90.0"
+    },
     {
         "type": "numeric",
         "title": "Anchor2 Y Offset",
         "desc": "Anchor2 Y Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor2_offset_y"
+        "key": "coordinate.anchor2_offset_y",
+        "default": "45.0"
     },
-      {
+    {
         "type": "numeric",
         "title": "Tool Rack X Offset",
         "desc": "Tool 6 X Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.toolrack_offset_x"
+        "key": "coordinate.toolrack_offset_x",
+        "default": "356"
     },
     {
         "type": "numeric",
         "title": "Tool Rack Y Offset",
         "desc": "Tool 6 Y Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.toolrack_offset_y"
+        "key": "coordinate.toolrack_offset_y",
+        "default": "0.0"
     },
     {
         "type": "numeric",
         "title": "ATC Z",
         "desc": "ATC Z axis machine coordinates",
         "section": "Advanced",
-        "key": "coordinate.toolrack_z"
+        "key": "coordinate.toolrack_z",
+        "default": "-112.5"
     },
-     {
+    {
         "type": "numeric",
         "title": "Rotation X Offset",
         "desc": "Rotation module X Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_x"
+        "key": "coordinate.rotation_offset_x",
+        "default": "3.5"
     },
     {
         "type": "numeric",
         "title": "Rotation Y Offset",
         "desc": "Rotation module Y Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_y"
+        "key": "coordinate.rotation_offset_y",
+        "default": "37.5"
     },
     {
         "type": "numeric",
         "title": "Rotation Z Offset",
         "desc": "Rotation module Z Offset relative to chuck center",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_z"
+        "key": "coordinate.rotation_offset_z",
+        "default": "23"
     },
     {
         "type": "numeric",
         "title": "Anchor width",
         "desc": "Width of anchors",
         "section": "Advanced",
-        "key": "coordinate.anchor_width"
-    },	
+        "key": "coordinate.anchor_width",
+        "default": "15.0"
+    },
     {
         "type": "numeric",
         "title": "Anchor length",
         "desc": "Length of anchors",
         "section": "Advanced",
-        "key": "coordinate.anchor_length"
-    },	
+        "key": "coordinate.anchor_length",
+        "default": "100.0"
+    },
     {
         "type": "numeric",
         "title": "X Work Size",
         "desc": "Width of work area",
         "section": "Advanced",
-        "key": "coordinate.worksize_x"
-    },	
+        "key": "coordinate.worksize_x",
+        "default": "340.0"
+    },
     {
         "type": "numeric",
         "title": "Y Work Size",
         "desc": "Height of work area",
         "section": "Advanced",
-        "key": "coordinate.worksize_y"
-    },	
+        "key": "coordinate.worksize_y",
+        "default": "240.0"
+    },
     {
         "type": "numeric",
         "title": "X Clearance",
         "desc": "X Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_x"
-    },	
+        "key": "coordinate.clearance_x",
+        "default": "-75.0"
+    },
     {
         "type": "numeric",
         "title": "Y Clearance",
         "desc": "Y Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_y"
-    },	
+        "key": "coordinate.clearance_y",
+        "default": "-3.0"
+    },
     {
         "type": "numeric",
         "title": "Z Clearance",
         "desc": "Z Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_z"
+        "key": "coordinate.clearance_z",
+        "default": "-3.0"
     },
     {
         "type": "bool",
@@ -210,7 +233,7 @@
         "desc": "Enabled to precheck if gCode commands will exceed the travel limits",
         "section": "Advanced",
         "key": "soft_endstop.enable",
-        "default": "true"
+        "default": "True"
     },
     {
         "type": "numeric",
@@ -248,77 +271,87 @@
         "type": "title",
         "title": "Motion",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Default Feed Rate",
         "desc": "Feed rate when F parameter is not set (mm/min)",
         "section": "Advanced",
-        "key": "default_feed_rate"
-    },																
+        "key": "default_feed_rate",
+        "default": "1000"
+    },
     {
         "type": "numeric",
         "title": "Default Seek Rate",
         "desc": "Feed rate for G0 rapid mode (mm/min)",
         "section": "Advanced",
-        "key": "default_seek_rate"
-    },																
+        "key": "default_seek_rate",
+        "default": "3000"
+    },
     {
         "type": "numeric",
         "title": "Max X Speed",
         "desc": "Max feed rate for X axis (mm/min)",
         "section": "Advanced",
-        "key": "alpha_max_rate"
-    },																
+        "key": "alpha_max_rate",
+        "default": "3000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Y Speed",
         "desc": "Max feed rate for Y axis (mm/min)",
         "section": "Advanced",
-        "key": "beta_max_rate"
-    },																
+        "key": "beta_max_rate",
+        "default": "3000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Z Speed",
         "desc": "Max feed rate for Z axis (mm/min)",
         "section": "Advanced",
-        "key": "gamma_max_rate"
-    },																
+        "key": "gamma_max_rate",
+        "default": "2000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Rotation Speed",
         "desc": "Max rotation speed rate for A axis (degree/min)",
         "section": "Advanced",
-        "key": "delta_max_rate"
-    },																
+        "key": "delta_max_rate",
+        "default": "1800.0"
+    },
     {
         "type": "numeric",
         "title": "ATC Max Speed",
         "desc": "Max feed rate for auto tool changer (mm/min)",
         "section": "Advanced",
-        "key": "epsilon_max_rate"
-    },																
+        "key": "epsilon_max_rate",
+        "default": "100.0"
+    },
     {
         "type": "numeric",
         "title": "XYZ Acceleration",
         "desc": "Acceleration for X/Y/Z axis (mm/second/second)",
         "section": "Advanced",
-        "key": "acceleration"
-    },																
+        "key": "acceleration",
+        "default": "150"
+    },
     {
         "type": "numeric",
         "title": "Rotation Acceleration",
         "desc": "Acceleration for rotation axis (degree/second/second)",
         "section": "Advanced",
-        "key": "delta_acceleration"
-    },																
+        "key": "delta_acceleration",
+        "default": "360.0"
+    },
     {
         "type": "numeric",
         "title": "ATC Acceleration",
         "desc": "Acceleration for auto tool changer (mm/second/second)",
         "section": "Advanced",
-        "key": "epsilon_acceleration"
-    },	
+        "key": "epsilon_acceleration",
+        "default": "10.0"
+    },
     {
         "type": "bool",
         "title": "Skip move to path origin on playback start",
@@ -327,52 +360,55 @@
         "section": "Advanced",
         "key": "atc.skip_path_origin"
     },
-	
     {
         "type": "title",
         "title": "WIFI",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "string",
         "title": "Machine WiFi Name",
         "desc": "Machine name that is shown in the WiFi list",
         "section": "Advanced",
-        "key": "wifi.machine_name"
-    },		
-	
+        "key": "wifi.machine_name",
+        "default": "CARVERA_01001"
+    },
     {
         "type": "title",
         "title": "ATC Motion",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Homing Retract",
         "desc": "Retract distance after homing (mm)",
         "section": "Advanced",
-        "key": "atc.homing_retract_mm"
-    },															
+        "key": "atc.homing_retract_mm",
+        "default": "0.4"
+    },
     {
         "type": "numeric",
         "title": "Action Distance",
         "desc": "Action distance when drop tool (mm)",
         "section": "Advanced",
-        "key": "atc.action_mm"
+        "key": "atc.action_mm",
+        "default": "1.6"
     },
-   {
+    {
         "type": "numeric",
         "title": "Detect speed",
         "desc": "Tool detect speed (mm / second)",
         "section": "Advanced",
-        "key": "atc.detector.detect_rate_mm_s"
+        "key": "atc.detector.detect_rate_mm_s",
+        "default": "20"
     },
-   {
+    {
         "type": "numeric",
         "title": "Detect Distance",
         "desc": "Tool detect back and forth distance (mm)",
         "section": "Advanced",
-        "key": "atc.detector.detect_travel_mm"
+        "key": "atc.detector.detect_travel_mm",
+        "default": "5"
     },
     {
         "type": "numeric",
@@ -387,118 +423,133 @@
         "title": "Safe Z",
         "desc": "Safety Z height when clamping tool",
         "section": "Advanced",
-        "key": "atc.safe_z_mm"
-    },															
+        "key": "atc.safe_z_mm",
+        "default": "-20.0"
+    },
     {
         "type": "numeric",
         "title": "Safe Z Empty",
         "desc": "Safety Z height when not clamping tool",
         "section": "Advanced",
-        "key": "atc.safe_z_empty_mm"
-    },	
+        "key": "atc.safe_z_empty_mm",
+        "default": "-50.0"
+    },
     {
         "type": "numeric",
         "title": "Safe Z Offset",
         "desc": "Z offset when slowing down ATC speed",
         "section": "Advanced",
-        "key": "atc.safe_z_offset_mm"
-    },			
+        "key": "atc.safe_z_offset_mm",
+        "default": "15.0"
+    },
     {
         "type": "numeric",
         "title": "Fast ATC Speed",
         "desc": "Z axis fast speed When doing ATC",
         "section": "Advanced",
-        "key": "atc.fast_z_rate_mm_m"
-    },		
+        "key": "atc.fast_z_rate_mm_m",
+        "default": "1000"
+    },
     {
         "type": "numeric",
         "title": "Slow ATC Speed",
         "desc": "Z axis slow speed when doing ATC",
         "section": "Advanced",
-        "key": "atc.slow_z_rate_mm_m"
-    },	
+        "key": "atc.slow_z_rate_mm_m",
+        "default": "200"
+    },
     {
         "type": "numeric",
         "title": "Margin Scan Speed",
         "desc": "X and Y speed when scaning margin",
         "section": "Advanced",
-        "key": "atc.margin_rate_mm_m"
-    },		
+        "key": "atc.margin_rate_mm_m",
+        "default": "1000.0"
+    },
     {
         "type": "numeric",
         "title": "Probe Fast Speed",
         "desc": "Z axis fast speed when doing calibrate",
         "section": "Advanced",
-        "key": "atc.probe.fast_rate_mm_m"
-    },			
+        "key": "atc.probe.fast_rate_mm_m",
+        "default": "500"
+    },
     {
         "type": "numeric",
         "title": "Probe Slow Speed",
         "desc": "Z axis slow speed when doing calibrate",
         "section": "Advanced",
-        "key": "atc.probe.slow_rate_mm_m"
-    },			
+        "key": "atc.probe.slow_rate_mm_m",
+        "default": "100"
+    },
     {
         "type": "numeric",
         "title": "Probe Retract",
         "desc": "Retract distance when hitting probe",
         "section": "Advanced",
-        "key": "atc.probe.retract_mm"
+        "key": "atc.probe.retract_mm",
+        "default": "2"
     },
-		
     {
         "type": "title",
         "title": "Laser",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Test Power",
         "desc": "Laser power when doing test(0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_test_power"
-    },		
+        "key": "laser_module_test_power",
+        "default": "0.01"
+    },
     {
         "type": "numeric",
         "title": "Max Laser Power",
         "desc": "Max laser power (0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_maximum_power"
-    },		
+        "key": "laser_module_maximum_power",
+        "default": "1.0"
+    },
     {
         "type": "numeric",
         "title": "Min Laser Power",
         "desc": "Min laser power (0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_minimum_power"
-    },		
+        "key": "laser_module_minimum_power",
+        "default": "0.0"
+    },
     {
         "type": "numeric",
         "title": "Offset X",
         "desc": "Laser module x offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_x"
-    },		
+        "key": "laser_module_offset_x",
+        "default": "-37.3"
+    },
     {
         "type": "numeric",
         "title": "Offset Y",
         "desc": "Laser module y offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_y"
-    },		
+        "key": "laser_module_offset_y",
+        "default": "4.8"
+    },
     {
         "type": "numeric",
         "title": "Offset Z",
         "desc": "Laser module z offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_z"
+        "key": "laser_module_offset_z",
+        "default": "-45.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown power",
         "desc": "Laser module cooldown power",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_laser"
+        "key": "temperatureswitch.spindle.cooldown_power_laser",
+        "default": "80.0"
     },
     {
         "type": "bool",
@@ -508,48 +559,51 @@
         "key": "laser_module_clustering",
         "default": "false"
     },
-
     {
         "type": "title",
         "title": "Z Probe",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Slow Speed",
         "desc": "Z probe slow speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.slow_feedrate"
-    },		
+        "key": "zprobe.slow_feedrate",
+        "default": "0.8"
+    },
     {
         "type": "numeric",
         "title": "Fast Speed",
         "desc": "Z probe fast speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.fast_feedrate"
-    },		
+        "key": "zprobe.fast_feedrate",
+        "default": "5"
+    },
     {
         "type": "numeric",
         "title": "Return Speed",
         "desc": "Z probe return speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.return_feedrate"
-    },		
+        "key": "zprobe.return_feedrate",
+        "default": "20"
+    },
     {
         "type": "numeric",
         "title": "Probe Height",
         "desc": "How much above bed to start probe",
         "section": "Advanced",
-        "key": "zprobe.probe_height"
-    },		
+        "key": "zprobe.probe_height",
+        "default": "2"
+    },
     {
         "type": "numeric",
         "title": "Max Z",
         "desc": "Max action distance when doing z probe",
         "section": "Advanced",
-        "key": "zprobe.max_z"
-    },	
-	
+        "key": "zprobe.max_z",
+        "default": "100"
+    },
     {
         "type": "title",
         "title": "Spindle",
@@ -560,7 +614,8 @@
         "title": "Default RPM",
         "desc": "Default RPM value in case no RPM is provided",
         "section": "Advanced",
-        "key": "spindle.default_rpm"
+        "key": "spindle.default_rpm",
+        "default": "10000"
     },
     {
         "type": "numeric",
@@ -575,37 +630,41 @@
         "title": "Cooldown Threshold",
         "desc": "Temperature to turn on or off spindle fan",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.threshold_temp"
+        "key": "temperatureswitch.spindle.threshold_temp",
+        "default": "35.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown Fan Start Power",
         "desc": "Cooldown fan start power percentage (50 - 100)",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_init"
+        "key": "temperatureswitch.spindle.cooldown_power_init",
+        "default": "50.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown Fan Step",
         "desc": "Cooldown fan start power increase step per degree",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_step"
-    },	
+        "key": "temperatureswitch.spindle.cooldown_power_step",
+        "default": "10.0"
+    },
     {
         "type": "numeric",
         "title": "Cooldown Delay",
         "desc": "Stop cooldown after these seconds",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_delay"
-    },				
-	{
+        "key": "temperatureswitch.spindle.cooldown_delay",
+        "default": "180"
+    },
+    {
         "type": "numeric",
         "title": "Temperature Alarm Threshold",
         "desc": "Alarm and halt machine when overheated",
         "section": "Advanced",
-        "key": "temperature_control.spindle.max_temp"
+        "key": "temperature_control.spindle.max_temp",
+        "default": "60"
     },
-
     {
         "type": "title",
         "title": "Wireless Probe",
@@ -616,16 +675,17 @@
         "title": "Charge Start Voltage",
         "desc": "Wireless probe charge start voltage",
         "section": "Advanced",
-        "key": "wp.min_voltage"
+        "key": "wp.min_voltage",
+        "default": "3.6"
     },
     {
         "type": "numeric",
         "title": "Charge Cut-Off Voltage",
         "desc": "Wireless probe charge cut-off voltage",
         "section": "Advanced",
-        "key": "wp.max_voltage"
+        "key": "wp.max_voltage",
+        "default": "4.1"
     },
-
     {
         "type": "string",
         "title": "Restore to default settings",
@@ -646,6 +706,8 @@
         "desc": "config.txt, flex_compensation.dat, etc. will be backed up to your computer",
         "section": "Backup",
         "key": "backup",
-        "options": ["Back up files now"]
+        "options": [
+            "Back up files now"
+        ]
     }
 ]

--- a/carveracontroller/config_ca1.json
+++ b/carveracontroller/config_ca1.json
@@ -9,16 +9,17 @@
         "title": "Light on",
         "desc": "Whether to turn on light by default",
         "section": "Basic",
-        "key": "switch.light.startup_state"
+        "key": "switch.light.startup_state",
+        "default": "true"
     },
     {
         "type": "numeric",
         "title": "Light off minutes",
         "desc": "Turn off the light when idle for these minutes (0 means never)",
         "section": "Basic",
-        "key": "light.turn_off_min"
-    },	
-	
+        "key": "light.turn_off_min",
+        "default": "0.0"
+    },
     {
         "type": "title",
         "title": "Safety",
@@ -29,9 +30,9 @@
         "title": "Stop on open",
         "desc": "Stop when open the cover during machining",
         "section": "Basic",
-        "key": "stop_on_cover_open"
+        "key": "stop_on_cover_open",
+        "default": "false"
     },
-
     {
         "type": "title",
         "title": "Power management",
@@ -42,16 +43,17 @@
         "title": "Auto sleep",
         "desc": "Allow machine to enter sleep mode automatically",
         "section": "Basic",
-        "key": "power.auto_sleep"
+        "key": "power.auto_sleep",
+        "default": "false"
     },
     {
         "type": "numeric",
         "title": "Auto sleep minutes",
         "desc": "Enter sleep mode after these minutes (1 - 30)",
         "section": "Basic",
-        "key": "power.auto_sleep_min"
+        "key": "power.auto_sleep_min",
+        "default": "5"
     },
-
     {
         "type": "title",
         "title": "Main button",
@@ -63,10 +65,14 @@
         "desc": "Triggered after 3 seconds when pressing\nNone   ------Do Nothing\nSleep  ------Enter sleep mode\nRepeat------Repeat Last Job\nTool Change------Clamp/Unclamp Collet for Tool Changes (Community Firmware Only)",
         "section": "Basic",
         "key": "main_button_long_press_enable",
-        "options": ["None", "Sleep", "Repeat", "ToolChange"],
+        "options": [
+            "None",
+            "Sleep",
+            "Repeat",
+            "ToolChange"
+        ],
         "default": "None"
     },
-
     {
         "type": "bool",
         "title": "Beeper on",
@@ -75,7 +81,6 @@
         "key": "switch.beep.enable",
         "default": "true"
     },
-
     {
         "type": "title",
         "title": "Coordinates",
@@ -86,29 +91,33 @@
         "title": "Anchor1 X",
         "desc": "X Machine coordinates of anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor1_x"
-    },	
+        "key": "coordinate.anchor1_x",
+        "default": "-291.0"
+    },
     {
         "type": "numeric",
         "title": "Anchor1 Y",
         "desc": "Y Machine coordinates of anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor1_y"
-    },	
+        "key": "coordinate.anchor1_y",
+        "default": "-203.0"
+    },
     {
         "type": "numeric",
         "title": "Anchor2 X Offset",
         "desc": "Anchor2 X Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor2_offset_x"
-    },	
+        "key": "coordinate.anchor2_offset_x",
+        "default": "88.5"
+    },
     {
         "type": "numeric",
         "title": "Anchor2 Y Offset",
         "desc": "Anchor2 Y Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.anchor2_offset_y"
-    },    
+        "key": "coordinate.anchor2_offset_y",
+        "default": "45.0"
+    },
     {
         "type": "numeric",
         "title": "Reference Tool MCS Z",
@@ -117,75 +126,85 @@
         "key": "coordinate.reference_tool_mz",
         "default": "-115.34"
     },
-     {
+    {
         "type": "numeric",
         "title": "Rotation X Offset",
         "desc": "Rotation module X Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_x"
+        "key": "coordinate.rotation_offset_x",
+        "default": "41.5"
     },
     {
         "type": "numeric",
         "title": "Rotation Y Offset",
         "desc": "Rotation module Y Offset relative to anchor1",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_y"
+        "key": "coordinate.rotation_offset_y",
+        "default": "82.5"
     },
     {
         "type": "numeric",
         "title": "Rotation Z Offset",
         "desc": "Rotation module Z Offset relative to chuck center",
         "section": "Advanced",
-        "key": "coordinate.rotation_offset_z"
+        "key": "coordinate.rotation_offset_z",
+        "default": "23.0"
     },
     {
         "type": "numeric",
         "title": "Anchor width",
         "desc": "Width of anchors",
         "section": "Advanced",
-        "key": "coordinate.anchor_width"
-    },	
+        "key": "coordinate.anchor_width",
+        "default": "15.0"
+    },
     {
         "type": "numeric",
         "title": "Anchor length",
         "desc": "Length of anchors",
         "section": "Advanced",
-        "key": "coordinate.anchor_length"
-    },	
+        "key": "coordinate.anchor_length",
+        "default": "100.0"
+    },
     {
         "type": "numeric",
         "title": "X Work Size",
         "desc": "Width of work area",
         "section": "Advanced",
-        "key": "coordinate.worksize_x"
-    },	
+        "key": "coordinate.worksize_x",
+        "default": "300.0"
+    },
     {
         "type": "numeric",
         "title": "Y Work Size",
         "desc": "Height of work area",
         "section": "Advanced",
-        "key": "coordinate.worksize_y"
-    },	
+        "key": "coordinate.worksize_y",
+        "default": "200.0"
+    },
     {
         "type": "numeric",
         "title": "X Clearance",
         "desc": "X Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_x"
-    },	
+        "key": "coordinate.clearance_x",
+        "default": "-5.0"
+    },
     {
         "type": "numeric",
         "title": "Y Clearance",
         "desc": "Y Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_y"
-    },	
+        "key": "coordinate.clearance_y",
+        "default": "-21.0"
+    },
     {
         "type": "numeric",
         "title": "Z Clearance",
         "desc": "Z Machine coordinates for clearance",
         "section": "Advanced",
-        "key": "coordinate.clearance_z"
+        "key": "coordinate.clearance_z",
+        "default": "-3.0"
     },
     {
         "type": "bool",
@@ -231,63 +250,70 @@
         "type": "title",
         "title": "Motion",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Default Feed Rate",
         "desc": "Feed rate when F parameter is not set (mm/min)",
         "section": "Advanced",
-        "key": "default_feed_rate"
-    },																
+        "key": "default_feed_rate",
+        "default": "1000"
+    },
     {
         "type": "numeric",
         "title": "Default Seek Rate",
         "desc": "Feed rate for G0 rapid mode (mm/min)",
         "section": "Advanced",
-        "key": "default_seek_rate"
-    },																
+        "key": "default_seek_rate",
+        "default": "3000"
+    },
     {
         "type": "numeric",
         "title": "Max X Speed",
         "desc": "Max feed rate for X axis (mm/min)",
         "section": "Advanced",
-        "key": "alpha_max_rate"
-    },																
+        "key": "alpha_max_rate",
+        "default": "3000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Y Speed",
         "desc": "Max feed rate for Y axis (mm/min)",
         "section": "Advanced",
-        "key": "beta_max_rate"
-    },																
+        "key": "beta_max_rate",
+        "default": "3000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Z Speed",
         "desc": "Max feed rate for Z axis (mm/min)",
         "section": "Advanced",
-        "key": "gamma_max_rate"
-    },																
+        "key": "gamma_max_rate",
+        "default": "2000.0"
+    },
     {
         "type": "numeric",
         "title": "Max Rotation Speed",
         "desc": "Max rotation speed rate for A axis (degree/min)",
         "section": "Advanced",
         "key": "delta_max_rate",
-        "default": "2400"
-    },																
+        "default": "1800.0"
+    },
     {
         "type": "numeric",
         "title": "XYZ Acceleration",
         "desc": "Acceleration for X/Y/Z axis (mm/second/second)",
         "section": "Advanced",
-        "key": "acceleration"
-    },																
+        "key": "acceleration",
+        "default": "150"
+    },
     {
         "type": "numeric",
         "title": "Rotation Acceleration",
         "desc": "Acceleration for rotation axis (degree/second/second)",
         "section": "Advanced",
-        "key": "delta_acceleration"
+        "key": "delta_acceleration",
+        "default": "360.0"
     },
     {
         "type": "bool",
@@ -301,68 +327,75 @@
         "type": "title",
         "title": "WIFI",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "string",
         "title": "Machine WiFi Name",
         "desc": "Machine name that is shown in the WiFi list",
         "section": "Advanced",
-        "key": "wifi.machine_name"
-    },		
-		
+        "key": "wifi.machine_name",
+        "default": "CARVERA_AIR_01001"
+    },
     {
         "type": "title",
         "title": "Laser",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Test Power",
         "desc": "Laser power when doing test(0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_test_power"
-    },		
+        "key": "laser_module_test_power",
+        "default": "0.01"
+    },
     {
         "type": "numeric",
         "title": "Max Laser Power",
         "desc": "Max laser power (0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_maximum_power"
-    },		
+        "key": "laser_module_maximum_power",
+        "default": "1.0"
+    },
     {
         "type": "numeric",
         "title": "Min Laser Power",
         "desc": "Min laser power (0 - 1)",
         "section": "Advanced",
-        "key": "laser_module_minimum_power"
-    },		
+        "key": "laser_module_minimum_power",
+        "default": "0.0"
+    },
     {
         "type": "numeric",
         "title": "Offset X",
         "desc": "Laser module x offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_x"
-    },		
+        "key": "laser_module_offset_x",
+        "default": "0"
+    },
     {
         "type": "numeric",
         "title": "Offset Y",
         "desc": "Laser module y offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_y"
-    },		
+        "key": "laser_module_offset_y",
+        "default": "0"
+    },
     {
         "type": "numeric",
         "title": "Offset Z",
         "desc": "Laser module z offset relative to spindle",
         "section": "Advanced",
-        "key": "laser_module_offset_z"
+        "key": "laser_module_offset_z",
+        "default": "-7.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown power",
         "desc": "Laser module cooldown power",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_laser"
+        "key": "temperatureswitch.spindle.cooldown_power_laser",
+        "default": "30.0"
     },
     {
         "type": "bool",
@@ -372,48 +405,51 @@
         "key": "laser_module_clustering",
         "default": "false"
     },
-
     {
         "type": "title",
         "title": "Z Probe",
         "section": "Advanced"
-    },	
+    },
     {
         "type": "numeric",
         "title": "Slow Speed",
         "desc": "Z probe slow speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.slow_feedrate"
-    },		
+        "key": "zprobe.slow_feedrate",
+        "default": "0.8"
+    },
     {
         "type": "numeric",
         "title": "Fast Speed",
         "desc": "Z probe fast speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.fast_feedrate"
-    },		
+        "key": "zprobe.fast_feedrate",
+        "default": "5"
+    },
     {
         "type": "numeric",
         "title": "Return Speed",
         "desc": "Z probe return speed (mm/s)",
         "section": "Advanced",
-        "key": "zprobe.return_feedrate"
-    },		
+        "key": "zprobe.return_feedrate",
+        "default": "20"
+    },
     {
         "type": "numeric",
         "title": "Probe Height",
         "desc": "How much above bed to start probe",
         "section": "Advanced",
-        "key": "zprobe.probe_height"
-    },		
+        "key": "zprobe.probe_height",
+        "default": "2"
+    },
     {
         "type": "numeric",
         "title": "Max Z",
         "desc": "Max action distance when doing z probe",
         "section": "Advanced",
-        "key": "zprobe.max_z"
-    },	
-	
+        "key": "zprobe.max_z",
+        "default": "100"
+    },
     {
         "type": "title",
         "title": "Spindle",
@@ -424,7 +460,8 @@
         "title": "Default RPM",
         "desc": "Default RPM value in case no RPM is provided",
         "section": "Advanced",
-        "key": "spindle.default_rpm"
+        "key": "spindle.default_rpm",
+        "default": "10000"
     },
     {
         "type": "numeric",
@@ -439,38 +476,41 @@
         "title": "Cooldown Threshold",
         "desc": "Temperature to turn on or off spindle fan",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.threshold_temp"
+        "key": "temperatureswitch.spindle.threshold_temp",
+        "default": "35.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown Fan Start Power",
         "desc": "Cooldown fan start power percentage (50 - 100)",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_init"
+        "key": "temperatureswitch.spindle.cooldown_power_init",
+        "default": "50.0"
     },
     {
         "type": "numeric",
         "title": "Cooldown Fan Step",
         "desc": "Cooldown fan start power increase step per degree",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_power_step"
-    },	
+        "key": "temperatureswitch.spindle.cooldown_power_step",
+        "default": "10.0"
+    },
     {
         "type": "numeric",
         "title": "Cooldown Delay",
         "desc": "Stop cooldown after these seconds",
         "section": "Advanced",
-        "key": "temperatureswitch.spindle.cooldown_delay"
-    },				
-	{
+        "key": "temperatureswitch.spindle.cooldown_delay",
+        "default": "180"
+    },
+    {
         "type": "numeric",
         "title": "Temperature Alarm Threshold",
         "desc": "Alarm and halt machine when overheated",
         "section": "Advanced",
-        "key": "temperature_control.spindle.max_temp"
+        "key": "temperature_control.spindle.max_temp",
+        "default": "70"
     },
-    
-
     {
         "type": "string",
         "title": "Restore to default settings",
@@ -491,6 +531,8 @@
         "desc": "config.txt, flex_compensation.dat, etc. will be backed up to your computer",
         "section": "Backup",
         "key": "backup",
-        "options": ["Back up files now"]
+        "options": [
+            "Back up files now"
+        ]
     }
 ]

--- a/scripts/update_firmware_config_defaults.py
+++ b/scripts/update_firmware_config_defaults.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT_PATH = Path(__file__).resolve().parents[1]
+DEFAULT_C1_JSON = ROOT_PATH / "carveracontroller" / "config_c1.json"
+DEFAULT_CA1_JSON = ROOT_PATH / "carveracontroller" / "config_ca1.json"
+SKIPPED_SETTING_TYPES = {"button", "title"}
+SKIPPED_SETTING_KEYS = {"restore", "default", "backup"}
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    path: Path
+    changed: int
+    unchanged: int
+    missing: tuple[str, ...]
+    written: bool
+
+
+def parse_config_defaults(config_path: Path) -> dict[str, str]:
+    defaults: dict[str, str] = {}
+
+    for raw_line in config_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+
+        key, value = parts
+        defaults[key] = value.strip()
+
+    return defaults
+
+
+def iter_setting_items(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from iter_setting_items(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_setting_items(child)
+
+
+def update_json_defaults(
+    json_path: Path,
+    defaults: dict[str, str],
+    *,
+    check: bool = False,
+) -> UpdateResult:
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    changed = 0
+    unchanged = 0
+    missing: list[str] = []
+
+    for setting in iter_setting_items(data):
+        key = setting.get("key")
+        if not isinstance(key, str):
+            continue
+        if key in SKIPPED_SETTING_KEYS:
+            continue
+        if setting.get("type") in SKIPPED_SETTING_TYPES:
+            continue
+
+        if key not in defaults:
+            missing.append(key)
+            continue
+
+        default = defaults[key]
+        if setting.get("default") == default:
+            unchanged += 1
+            continue
+
+        setting["default"] = default
+        changed += 1
+
+    written = False
+    if changed and not check:
+        json_path.write_text(json.dumps(data, indent=4) + "\n", encoding="utf-8")
+        written = True
+
+    return UpdateResult(
+        path=json_path,
+        changed=changed,
+        unchanged=unchanged,
+        missing=tuple(sorted(missing)),
+        written=written,
+    )
+
+
+def update_default_files(
+    config_default_path: Path,
+    config2_default_path: Path,
+    *,
+    c1_json_path: Path = DEFAULT_C1_JSON,
+    ca1_json_path: Path = DEFAULT_CA1_JSON,
+    check: bool = False,
+) -> dict[str, UpdateResult]:
+    c1_defaults = parse_config_defaults(config_default_path)
+    ca1_defaults = parse_config_defaults(config2_default_path)
+
+    return {
+        "C1": update_json_defaults(c1_json_path, c1_defaults, check=check),
+        "CA1": update_json_defaults(ca1_json_path, ca1_defaults, check=check),
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Set controller JSON default values from firmware config files. "
+            "C1 uses config.default; CA1 uses config2.default."
+        )
+    )
+    parser.add_argument("config_default", type=Path, help="Firmware src/config.default path")
+    parser.add_argument("config2_default", type=Path, help="Firmware src/config2.default path")
+    parser.add_argument(
+        "--c1-json",
+        type=Path,
+        default=DEFAULT_C1_JSON,
+        help=f"Controller C1 settings JSON path, default: {DEFAULT_C1_JSON}",
+    )
+    parser.add_argument(
+        "--ca1-json",
+        type=Path,
+        default=DEFAULT_CA1_JSON,
+        help=f"Controller CA1 settings JSON path, default: {DEFAULT_CA1_JSON}",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report pending changes without writing JSON files; exits 1 if changes are needed.",
+    )
+    parser.add_argument(
+        "--strict-missing",
+        action="store_true",
+        help="Exit 1 if any controller setting key has no active firmware config assignment.",
+    )
+    return parser
+
+
+def print_results(results: dict[str, UpdateResult]) -> None:
+    for model, result in results.items():
+        action = "would update" if not result.written and result.changed else "updated"
+        if not result.changed:
+            action = "up to date"
+        print(
+            f"{model}: {action} {result.changed} defaults in {result.path} "
+            f"({result.unchanged} already matched)"
+        )
+        if result.missing:
+            print(f"{model}: no active firmware default for: {', '.join(result.missing)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    results = update_default_files(
+        args.config_default,
+        args.config2_default,
+        c1_json_path=args.c1_json,
+        ca1_json_path=args.ca1_json,
+        check=args.check,
+    )
+    print_results(results)
+
+    has_changes = any(result.changed for result in results.values())
+    has_missing = any(result.missing for result in results.values())
+    if (args.check and has_changes) or (args.strict_missing and has_missing):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
I got annoyed by having to include config values that are equal to the firmware's defaults in the `config.txt` on the SD, so here's a vibe-coded script to auto-update the JSONs from the firmware's `config.default`/`config2.default` and avoid the `Load config error, Key: <something>` noise.