### PR TITLE
Fix potential crashes due to an undefined FuncSetting key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed: Disable trackpad being treated as touchscreen on Linux
 - Fixed: Jogging was incorrectly blocked/allowed under certain conditions
 - Fixed: GCode parser: Do not set tool number to 7 after M321
+- Fixed: Fix potential crashes due to an undefined FuncSetting key"
 - Fixed: Fix incorrect "No Pendant" in UI when pendant is working
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file

--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -282,10 +282,12 @@ class CNC:
         "st_cover": 0,
         "st_tool_sensor": 0,
         "st_e_stop": 0,
+        # Machine model/feature flags updated from status or model command
+        "MachineModel": 1,
+        "FuncSetting": 0,
+        "inch_mode": 0,
+        "absolute_mode": 0,
     }
-
-    # for feed override testing
-    # FIXME will not be needed after Grbl v1.0
 
     # ----------------------------------------------------------------------
     def __init__(self):

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -1300,11 +1300,6 @@ class Controller:
             CNC.vars["FuncSetting"] = int(d["C"][1])
             CNC.vars["inch_mode"] = int(d["C"][2])
             CNC.vars["absolute_mode"] = int(d["C"][3])
-        else:
-            CNC.vars["MachineModel"] = 1
-            CNC.vars["FuncSetting"] = 0
-            CNC.vars["inch_mode"] = 0
-            CNC.vars["absolute_mode"] = 0
         if CNC.vars["inch_mode"] != 999:
             if CNC.vars["inch_mode"] == 1:
                 CNC.UnitScale = 25.4

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3974,9 +3974,18 @@ class Makera(RelativeLayout):
                                 self.controller._baud_upgrade_attempted = True
                                 self.controller.request_baud_upgrade(int(baud_str))
 
-                    remote_model = re.search("del = [a-zA-Z0-9]+", line)
+                    remote_model = re.search(r"model = (\w+), (\d+), (\d+), (\d+)", line)
                     if remote_model != None:
-                        detected_model = remote_model[0].split("=")[1]
+                        detected_model = remote_model.group(1)
+                        CNC.vars["MachineModel"] = int(remote_model.group(2))
+                        CNC.vars["FuncSetting"] = int(remote_model.group(3))
+                        logger.info(
+                            f"Machine information: "
+                            f"Model: {detected_model}, "
+                            f"Model ID: {CNC.vars['MachineModel']}, "
+                            f"FuncSetting: {CNC.vars['FuncSetting']}, "
+                            f"Extra: {remote_model.group(4)}"
+                        )
                         Clock.schedule_once(partial(self.setUIForModel, detected_model), 0)
 
                     remote_filetype = re.search("ftype = [a-zA-Z0-9]+", line)


### PR DESCRIPTION
An user on Discord reported they got the following error message when connecting to the matchine with their CA1:

<img width="697" height="680" alt="image" src="https://github.com/user-attachments/assets/c7345cf9-976f-4586-81f6-f8f529b5a9d3" />


I think this can happen if the controller receives the response to the model query before receiving the first status update since `setUIForModel` will then try to access `CNC.vars["FuncSetting"]` before it is actually set.

This PR does two things:
- it sets default value in CNC.vars for a few missing keys, including `FuncSetting` so that, in worst case, the app won't crash
- it also sets the value of `CNC.vars["FuncSetting"]` (and `CNC.vars["MachineModel"]`) using the response of the model query so that we are guaranteed  it is set when `setUIForModel` is called

---

For reference here is the code of the firmware that defines the response of the model query:

```cpp
void SimpleShell::model_command( string parameters, StreamOutput *stream )
{		    	
	switch (THEKERNEL->factory_set->MachineModel)
	{
		case CARVERA:			
			stream->printf("model = %s, %d, %d, %d\n", "C1", THEKERNEL->factory_set->MachineModel, THEKERNEL->factory_set->FuncSetting, THEKERNEL->probe_addr);
			break;
		case CARVERA_AIR:			
			stream->printf("model = %s, %d, %d, %d\n", "CA1", THEKERNEL->factory_set->MachineModel, THEKERNEL->factory_set->FuncSetting, THEKERNEL->probe_addr);
            if(THEKERNEL->is_flex_compensation_load_error()) {
                stream->printf("ERROR: Could not load flex compensation data\n");
            }
            break;
		default:			
			stream->printf("model = %s, %d, %d, %d\n", "C1", THEKERNEL->factory_set->MachineModel, THEKERNEL->factory_set->FuncSetting, THEKERNEL->probe_addr);
			break;
	}
    if(THEKERNEL->is_config_load_error()) {
        stream->printf("ERROR: config file had errors during boot, see SD\n");
    }
}
```

Which gives on my CA1:

<img width="672" height="37" alt="image" src="https://github.com/user-attachments/assets/ce32059c-26ea-49f5-9055-077900695f03" />