### PR TITLE
Add -O option when playing files that contain o-codes

### DIFF
--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -11,6 +11,7 @@ _O_KEYWORDS = (
     r"elseif|endwhile|endrepeat|endsub|endif|continue|"
     r"repeat|while|break|call|else|sub|do|if"
 )
+OCODE_PATTERN = re.compile(r"(?:^|\s)[Oo]\d+\s+(?:" + _O_KEYWORDS + r")\b")
 
 _MATH_KEYWORDS_COMPACT = r"xor|and|nor|mod|eq|ne|gt|ge|lt|le|or"
 _MATH_KEYWORDS_FUNCTIONS = r"sqrt|round|asin|acos|atan|sin|cos|tan|abs|fix|fup|ln|exp"

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -609,10 +609,11 @@ class Controller:
     def resumeCommand(self):
         self.executeCommand("resume\n")
 
-    def playCommand(self, filename):
-        play_command = "play %s\n" % filename.replace(" ", "\x01")
+    def playCommand(self, filename, has_ocodes=False):
+        flag = " -O" if has_ocodes else ""
+        play_command = "play %s%s\n" % (filename.replace(" ", "\x01"), flag)
         if "\\" in filename:
-            play_command = "play %s\n" % "/".join(filename.split("\\")).replace(" ", "\x01")
+            play_command = "play %s%s\n" % ("/".join(filename.split("\\")).replace(" ", "\x01"), flag)
         self.executeCommand(self.escape(play_command))
 
     def _binary_find_left(self, array, key):
@@ -1027,11 +1028,12 @@ class Controller:
                 last_line = line_num
         return last_line
 
-    def playStartLineCommand(self, filename, start_line, preview=False, lines=None):
+    def playStartLineCommand(self, filename, start_line, preview=False, lines=None, has_ocodes=False):
         # Build the play command with proper formatting
-        play_command = "play %s\n" % filename.replace(" ", "\x01")
+        flag = " -O" if has_ocodes else ""
+        play_command = "play %s%s\n" % (filename.replace(" ", "\x01"), flag)
         if "\\" in filename:
-            play_command = "play %s" % "/".join(filename.split("\\")).replace(" ", "\x01")
+            play_command = "play %s%s" % ("/".join(filename.split("\\")).replace(" ", "\x01"), flag)
 
         # Position to move to before start: last movement line before start_line (from loaded lines), then from GcodeViewer
         try:

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -193,6 +193,7 @@ from .CNC import (
     CNC,
     GCODE_DEFAULT_COLORS,
     LASER_TOOL_NUMBER,
+    OCODE_PATTERN,
     PROBE_3D_TOOL_NUMBER,
     ZPROBE_TOOL_NUMBER,
     escape_gcode_markup,
@@ -2908,6 +2909,7 @@ class Makera(RelativeLayout):
 
     used_tools = ListProperty()
     upcoming_tool = 0
+    file_has_ocodes = False
     tool_change_markers = []
 
     # Custom property to monitor CNC light state
@@ -3493,7 +3495,7 @@ class Makera(RelativeLayout):
             # Show confirmation dialog for beta resume playback feature
             self.open_resume_playback_confirm_popup(file_name, start_line)
         else:
-            self.controller.playCommand(file_name)
+            self.controller.playCommand(file_name, has_ocodes=self.file_has_ocodes)
 
     # -----------------------------------------------------------------------
     def apply(self, buffer=False):
@@ -6753,7 +6755,9 @@ class Makera(RelativeLayout):
             return
 
         try:
-            commands = self.controller.playStartLineCommand(file_name, start_line, preview=True, lines=self.lines)
+            commands = self.controller.playStartLineCommand(
+                file_name, start_line, preview=True, lines=self.lines, has_ocodes=self.file_has_ocodes
+            )
         except Exception as e:
             self.show_message_popup(tr._(f"Resume-at-line cannot run:\n\n{e}"), False)
             return
@@ -6779,7 +6783,9 @@ class Makera(RelativeLayout):
             self._show_resume_gcode_not_loaded_popup()
             return
         try:
-            self.controller.playStartLineCommand(file_name, start_line, lines=self.lines)
+            self.controller.playStartLineCommand(
+                file_name, start_line, lines=self.lines, has_ocodes=self.file_has_ocodes
+            )
         except Exception as e:
             self.show_message_popup(tr._(f"Resume-at-line failed:\n\n{e}"), False)
 
@@ -7043,6 +7049,7 @@ class Makera(RelativeLayout):
     def load_gcode_file(self, filepath):
         self.load_event.set()
         self.upcoming_tool = 0
+        self.file_has_ocodes = False
         self.used_tools = []
         self.tool_change_markers = []
         Clock.schedule_once(self.load_start)
@@ -7081,6 +7088,8 @@ class Makera(RelativeLayout):
             for line in self.lines:
                 if self.load_canceled:
                     break
+                if not self.file_has_ocodes and OCODE_PATTERN.search(line):
+                    self.file_has_ocodes = True
                 prev_tool = self.cnc.tool
                 self.cnc.parseLine(line, line_no)
                 if self.upcoming_tool == 0:


### PR DESCRIPTION
This PR adds the `-O` flag to the `play` command if the currently opened file contains o-codes.

Related to [this commit](https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/323/changes/dd190fc6de52d42d608e489898c27dd415d3a2d0) from https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/323 and should only be merged if we proceed with that solution.