### PR TITLE
Fix color scheme panel intercepting menu interactions when hidden

### DIFF
--- a/carveracontroller/ui/GcodeColorSchemePanel.py
+++ b/carveracontroller/ui/GcodeColorSchemePanel.py
@@ -178,6 +178,24 @@ def _make_legend_row(entry):
 class GcodeColorSchemePanel(BoxLayout):
     """Dropdown plus scrollable legend for the active toolpath color scheme."""
 
+    def _is_hidden(self):
+        return not self.opacity
+
+    def on_touch_down(self, touch):
+        if self._is_hidden():
+            return False
+        return super().on_touch_down(touch)
+
+    def on_touch_move(self, touch):
+        if self._is_hidden():
+            return False
+        return super().on_touch_move(touch)
+
+    def on_touch_up(self, touch):
+        if self._is_hidden():
+            return False
+        return super().on_touch_up(touch)
+
     def refresh(self, makera_root):
         legend_box = self.ids.legend_box
         legend_box.clear_widgets()


### PR DESCRIPTION
I already fixed [a similar issue a while ago](https://github.com/Carvera-Community/Carvera_Controller/pull/600) that caused the 3D viewer control buttons to prevent opening the app menu dropdown when hidden. The color scheme panel that was added afterwards is now doing the same thing because even when an element height is set to 0 and disabled its children still have an height and eat click events.

Last time I also set the height of the children to 0 to fix it but in this case it was easier to just override the touch events and always return `False` when they are hidden ([default is `True` when an element is disabled](https://github.com/kivy/kivy/blob/20d74dcd30f143abbd1aa94c76bafc5bd934d5bd/kivy/uix/widget.py#L586-L587) for some reason) so they don't intercept anything anymore.