### PR TITLE
Probe scan: Use new M118.1 format + fix E param sign when probing angles

### DIFF
--- a/carveracontroller/addons/probe_scan/core/gcode.py
+++ b/carveracontroller/addons/probe_scan/core/gcode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import math
 import re
 from collections.abc import Callable, Sequence
 
@@ -74,34 +73,20 @@ def parse_probe_program(lines: Sequence[str]) -> str:
 
 RE_CMM_START = re.compile(r"CMMProbe\s+START\s+(\S+)\s+(.+)", re.IGNORECASE)
 RE_CMM_END = re.compile(r"CMMProbe\s+END\s*", re.IGNORECASE)
-_RE_FLOAT = re.compile(r"^[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?\s*$")
-_RE_RESULT_EQ = re.compile(
-    r"result\s*=\s*([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)",
-    re.IGNORECASE,
-)
+_RE_VAR_EQ = re.compile(r"#([0-9]+)\s*=\s*(-?[0-9]*\.?[0-9]+)")
 
 
-def extract_float_line(line: str) -> float | None:
-    """Parse a lone float line or firmware-style ``result = <float>``."""
-    s = line.strip()
-    if _RE_FLOAT.match(s):
-        try:
-            v = float(s)
-            if math.isnan(v) or math.isinf(v):
-                return None
-            return v
-        except ValueError:
-            return None
-    m = _RE_RESULT_EQ.search(s)
-    if m:
-        try:
-            v = float(m.group(1))
-        except ValueError:
-            return None
-        if math.isnan(v) or math.isinf(v):
-            return None
-        return v
-    return None
+def extract_result_line(line: str) -> tuple[str, float] | None:
+    """Parse an ``M118.1`` result line into ``(var_key, value)``.
+
+    ``var_key`` is the ``#`` variable index (without the ``#``) echoed by the
+    firmware (e.g. ``#151 = 12.345`` -> ``("151", 12.345)``). Returns ``None``
+    when the line is not a parseable variable result.
+    """
+    m = _RE_VAR_EQ.search(line.strip())
+    if not m:
+        return None
+    return m.group(1), float(m.group(2))
 
 
 def extract_probe_start_meta(line: str) -> tuple[str, list[str]] | None:
@@ -122,8 +107,8 @@ class M118ProbeCapture:
 
     def __init__(
         self,
-        on_complete: Callable[[str, list[float], list[str]], None],
-        on_abort: Callable[[str, list[float], list[str]], None] | None = None,
+        on_complete: Callable[[str, dict[str, float], list[str]], None],
+        on_abort: Callable[[str, dict[str, float], list[str]], None] | None = None,
     ):
         self._on_complete = on_complete
         self._on_abort = on_abort
@@ -132,7 +117,7 @@ class M118ProbeCapture:
         self._op: str | None = None
         self._expected: int = 0
         self._var_keys: list[str] = []
-        self._buf: list[float] = []
+        self._values: dict[str, float] = {}
 
     def prime_upstream(self, op: str, var_keys: list[str]) -> None:
         """Arm capture from outgoing G-code; ignores serial START while host-armed."""
@@ -152,7 +137,7 @@ class M118ProbeCapture:
         self._op = None
         self._expected = 0
         self._var_keys.clear()
-        self._buf.clear()
+        self._values.clear()
 
     def feed_line(self, msg_kind: int, line: str) -> None:
         if msg_kind == Controller.MSG_ERROR:
@@ -171,46 +156,37 @@ class M118ProbeCapture:
             if self._expected == 0 or not self._var_keys:
                 self.reset()
                 return
-            self._buf.clear()
+            self._values.clear()
             return
 
         if RE_CMM_END.search(s):
             # Stale END from a prior run can arrive right after prime_upstream.
-            if self._host_armed and not self._buf:
+            if self._host_armed and not self._values:
                 return
             if self._active and self._expected > 0:
-                if len(self._buf) < self._expected and self._on_abort is not None:
+                if len(self._values) < self._expected and self._on_abort is not None:
                     try:
-                        self._on_abort(
-                            self._op or "",
-                            list(self._buf),
-                            list(self._var_keys),
-                        )
+                        self._on_abort(self._op or "", dict(self._values), list(self._var_keys))
                     except Exception:
                         _logger.exception("M118 probe capture abort callback")
             self.reset()
             return
 
         if self._active and self._op:
-            v = extract_float_line(s)
-            if v is not None and len(self._buf) < self._expected:
-                self._buf.append(v)
-                if len(self._buf) == self._expected:
-                    try:
-                        self._on_complete(self._op, list(self._buf), list(self._var_keys))
-                    except Exception:
-                        _logger.exception("M118 probe capture callback")
-                    self.reset()
-
-
-def map_values_to_dict(op: str, values: list[float], var_keys: list[str] | None = None) -> dict[str, float]:
-    """Map captured floats to # variable indices in order."""
-    keys = var_keys if var_keys else VAR_SETS.get(op.upper(), [])
-    out: dict[str, float] = {}
-    for i, k in enumerate(keys):
-        if i < len(values):
-            out[k] = values[i]
-    return out
+            parsed = extract_result_line(s)
+            if parsed is None:
+                return
+            key, v = parsed
+            # Ignore echoes for variables we didn't request or already captured.
+            if key not in self._var_keys or key in self._values:
+                return
+            self._values[key] = v
+            if len(self._values) == self._expected:
+                try:
+                    self._on_complete(self._op, dict(self._values), list(self._var_keys))
+                except Exception:
+                    _logger.exception("M118 probe capture callback")
+                self.reset()
 
 
 def _fmt(v: float | int | str) -> str:

--- a/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.py
+++ b/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.py
@@ -62,7 +62,6 @@ from ..core.gcode import (
     build_m465,
     build_m466,
     extract_probe_start_meta,
-    map_values_to_dict,
     split_execute_lines,
 )
 from ..core.io_export import export_csv, export_dxf, export_json
@@ -536,22 +535,21 @@ class ProbeScanPopup(ModalView):
         for ln in lines:
             self.controller.executeCommand(ln + "\n")
 
-    def _on_probe_values(self, op: str, values: list[float], var_keys: list[str]):
+    def _on_probe_values(self, op: str, values: dict[str, float], var_keys: list[str]):
         self._runner.pre_complete()
         saved_token = self._runner.get_active_token()
 
         def _ui(_dt):
             if not self._runner.is_token_valid(saved_token):
                 return
-            vd = map_values_to_dict(op, values, var_keys)
-            if self._append_probe_result(op, vd, var_keys):
+            if self._append_probe_result(op, values, var_keys):
                 self._runner.complete()
             else:
                 self._runner.cancel()
 
         Clock.schedule_once(_ui, 0)
 
-    def _on_probe_abort(self, op: str, values: list[float], var_keys: list[str]) -> None:
+    def _on_probe_abort(self, op: str, values: dict[str, float], var_keys: list[str]) -> None:
         self._runner.pre_complete()
         saved_token = self._runner.get_active_token()
 
@@ -1316,8 +1314,9 @@ class ProbeScanPopup(ModalView):
             else:
                 self._toast_need_probing_option()
                 return
-            e_o = _parse_optional_float_text(self.ids.t465_e)
-            e_cmd = _signed_distance_for_command(e_o) if e_o is not None else ""
+            e_field = self.ids.t465_e
+            e_val = _parse_optional_float_text(e_field) or e_field.hint_text.strip().replace(",", ".") or "2"
+            e_cmd = _distance_for_command(e_val, negate=(v in ("above", "right")))
             opts = self._read_common_probe_opts("465")
             self._run_gcode_program(build_m465(x=xs_cmd, y=ys_cmd, e=e_cmd, **opts))
         except Exception as e:


### PR DESCRIPTION
`M118.1`  will now return `#<variable> = <result>`  instead of `result = <result>` (see [this firmware PR](https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/349)).

Since the probe scan feature was parsing the results from this command it also has to be updated. It's actually a bit cleaner this way since we won't rely on the results order anymore.

I also fixed an issue I noticed when probing angles where the E parameter was not inverted properly.