### PR TITLE
Fix tools toggling when using tools outside of T1..T6 + laser range

### DIFF
--- a/carveracontroller/GcodeViewer.py
+++ b/carveracontroller/GcodeViewer.py
@@ -1159,8 +1159,9 @@ class GCodeViewer(Widget):
 
             # rendering line meshes
             self.linemesh["display_count"] = -1.0
-            # 0 means display all thing
-            self.linemesh["vertex_type_display"] = 0.0
+
+            # Show all tools by default (T1-T6 + laser + other tools)
+            self.linemesh["vertex_type_display"] = 11111111.0
 
             self.pointermesh["offset"] = (-self.lines_center[0], -self.lines_center[1], -self.lines_center[2])
 

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -7165,6 +7165,7 @@ class Makera(RelativeLayout):
         ]
         for tool_button in tool_buttons:
             tool_button.min_active = True
+        self.show_other_tools = True
         self.float_layout.hide_all.active = True
 
     def refresh_gcode_color_legend(self, *_args):
@@ -7185,7 +7186,11 @@ class Makera(RelativeLayout):
 
     # -----------------------------------------------------------------------
     def filter_tool(self):
-        mask = 0.0
+        # Build the mask for tool visibility
+        #   1..1_000_000 -> T1..T6 + laser (1 digit per tool)
+        #   10_000_000   -> Other tools without a button (T0, T7, T8, ...)
+        OTHER_TOOLS_FLAG = 10000000.0
+
         tool_buttons = [
             self.float_layout.t1,
             self.float_layout.t2,
@@ -7195,23 +7200,23 @@ class Makera(RelativeLayout):
             self.float_layout.t6,
             self.float_layout.laser,
         ]
-        enabled_tools = []
         visible_tools = []
         for index, tool_button in enumerate(tool_buttons, start=1):
-            if not tool_button.disabled:
-                enabled_tools.append(index)
-                if tool_button.min_active:
-                    visible_tools.append(index)
-        if len(enabled_tools) > 0 and enabled_tools == visible_tools:
-            self.float_layout.hide_all.active = True
-        else:
-            self.float_layout.hide_all.active = False
+            if not tool_button.disabled and tool_button.min_active:
+                visible_tools.append(index)
 
-        if len(enabled_tools) > 0 and len(visible_tools) == 0:
-            mask = 10000000.0
-        else:
-            for tool in visible_tools:
-                mask = mask + 10 ** (tool - 1)
+        show_other_tools = getattr(self, "show_other_tools", True)
+
+        # The show/hide-all button is "on" whenever anything is visible. Clicking
+        # it then hides everything, and shows everything when nothing is visible.
+        self.float_layout.hide_all.active = show_other_tools or len(visible_tools) > 0
+
+        mask = 0.0
+        for tool in visible_tools:
+            mask = mask + 10 ** (tool - 1)
+        if show_other_tools:
+            mask = mask + OTHER_TOOLS_FLAG
+
         self.gcode_viewer.set_display_mask(mask)
 
     # -----------------------------------------------------------------------

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -4281,23 +4281,24 @@
                                         icon: 'data/eye.png'
                                         disabled: app.selected_remote_filename == '' and app.selected_local_filename == ''
                                         on_release:
-                                            self.active = not self.active
                                             if self.active:\
-                                            t1.min_active = True;\
-                                            t2.min_active = True;\
-                                            t3.min_active = True;\
-                                            t4.min_active = True;\
-                                            t5.min_active = True;\
-                                            t6.min_active = True;\
-                                            laser.min_active = True;
-                                            else:\
                                             t1.min_active = False;\
                                             t2.min_active = False;\
                                             t3.min_active = False;\
                                             t4.min_active = False;\
                                             t5.min_active = False;\
                                             t6.min_active = False;\
-                                            laser.min_active = False;
+                                            laser.min_active = False;\
+                                            app.root.show_other_tools = False;
+                                            else:\
+                                            t1.min_active = True;\
+                                            t2.min_active = True;\
+                                            t3.min_active = True;\
+                                            t4.min_active = True;\
+                                            t5.min_active = True;\
+                                            t6.min_active = True;\
+                                            laser.min_active = True;\
+                                            app.root.show_other_tools = True;
                                             app.root.filter_tool()
                             BoxLayout:
                                 id: gcode_ctl_bar

--- a/carveracontroller/shaders/toolpath.glsl
+++ b/carveracontroller/shaders/toolpath.glsl
@@ -95,22 +95,19 @@ float mask_digit(float mask, float place)
 
 bool is_vertex_type_enabled(float vertex_type, float type_mask)
 {
+    // A set decimal digit means "show this tool"; mask 0 therefore hides all.
     float mask = floor(type_mask + 0.1);
     float vtype = floor(vertex_type + 0.1);
-    if (mask < 0.5) {
-        return true;
-    }
-    if (vtype < 0.5) {
-        return false;
-    }
-    if (abs(vtype - 1.0) < 0.5 && mask_digit(mask, 1.0) >= 1.0) return true;
-    if (abs(vtype - 2.0) < 0.5 && mask_digit(mask, 10.0) >= 1.0) return true;
-    if (abs(vtype - 3.0) < 0.5 && mask_digit(mask, 100.0) >= 1.0) return true;
-    if (abs(vtype - 4.0) < 0.5 && mask_digit(mask, 1000.0) >= 1.0) return true;
-    if (abs(vtype - 5.0) < 0.5 && mask_digit(mask, 10000.0) >= 1.0) return true;
-    if (abs(vtype - 6.0) < 0.5 && mask_digit(mask, 100000.0) >= 1.0) return true;
-    if (abs(vtype - 8888.0) < 0.5 && mask_digit(mask, 1000000.0) >= 1.0) return true;
-    return false;
+    // T1-T6 and the laser each have a dedicated toolbar button/digit.
+    if (abs(vtype - 1.0) < 0.5) return mask_digit(mask, 1.0) >= 1.0;
+    if (abs(vtype - 2.0) < 0.5) return mask_digit(mask, 10.0) >= 1.0;
+    if (abs(vtype - 3.0) < 0.5) return mask_digit(mask, 100.0) >= 1.0;
+    if (abs(vtype - 4.0) < 0.5) return mask_digit(mask, 1000.0) >= 1.0;
+    if (abs(vtype - 5.0) < 0.5) return mask_digit(mask, 10000.0) >= 1.0;
+    if (abs(vtype - 6.0) < 0.5) return mask_digit(mask, 100000.0) >= 1.0;
+    if (abs(vtype - 8888.0) < 0.5) return mask_digit(mask, 1000000.0) >= 1.0;
+    // Tools without a dedicated button (T0, T7, T8, ...) share the next digit.
+    return mask_digit(mask, 10000000.0) >= 1.0;
 }
 
 void main()


### PR DESCRIPTION
Fixes an issue present only on the dev branch (hence the missing changelog entry) related to the tools visibility controls.

Currently, hiding a tool will also hide tools outside of the T1..T6/laser range (for instance T7 or T8).

This also affects the "Toggle all" button which will hide everything but only show T1..T6/laser when clicking on it again (which means that once T7 or T8 disappears there is no way to get them back).

This PR should make it behave as in v2.1.0 again:
* toggling a tool will only show/hide the related tool
* the "toggle all" button will hide everything or show everything, including tools outside of the T1..T6/laser range

<img width="1739" height="980" alt="Recording 2026-07-09 at 23 17 45" src="https://github.com/user-attachments/assets/c3ecd805-4df5-49d6-8f0e-6166d5de9aca" />

