### PR TITLE
M469.6 - New 4th axis calibration routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enhancement: Show tool change markers on the playback progress bar
 - Enhancement: Add grid visualization, ortho projection, view cube and color schemes selector to the G-Code viewer
 - Enhancement: Detect WHB04 pendant permission errors instead of silently ignoring pendant
+- Enhancement: New M469.6 4th Axis calibration routine finds the true 4th axis center now replaces the previous M469.4 4th axis head stock calibration
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/addons/probing/ProbingPopup.kv
+++ b/carveracontroller/addons/probing/ProbingPopup.kv
@@ -405,10 +405,10 @@
 
                             ProbeButton:
                                 
-                                tooltip_txt: 'Calibrate 4th Axis Center'
-                                tooltip_image: 'addons/probing/data/icons_1024x768/calibration/Calibrate_4th_Axis_Y_TT.png'
+                                tooltip_txt: 'Calibrate 4th Axis Center (M469.6)'
+                                tooltip_image: 'addons/probing/data/icons_1024x768/calibration/Calibrate_4th_Axis_M469.6_Front.png'
                                 on_press: root.on_callibration_probing_pressed("FourthY")
-                                image: 'addons/probing/data/icons_1024x768/calibration/Calibrate_4th_Axis_Y.png'
+                                image: 'addons/probing/data/icons_1024x768/calibration/Calibrate_4th_Axis_M469.6_Top.png'
                             ProbeButton:
                                 
                                 tooltip_txt: 'Calibrate 4th Axis Z offset'

--- a/carveracontroller/addons/probing/operations/Calibration/CalibrationOperation.py
+++ b/carveracontroller/addons/probing/operations/Calibration/CalibrationOperation.py
@@ -11,6 +11,7 @@ from carveracontroller.addons.probing.operations.SingleAxis.SingleAxisProbeParam
 
 class CalibrationOperationFourthY(OperationsBase):
     imagePath: str
+    ALLOWED_PARAMS = ("R", "C", "D", "Y", "Z", "I", "F")
 
     def __init__(self, title, requires_x, requires_y, invert_direction, image_path, **kwargs):
         self.title = title
@@ -20,13 +21,9 @@ class CalibrationOperationFourthY(OperationsBase):
         self.invert_direction = invert_direction
 
     def generate(self, input_config: dict[str, float]):
-        config = copy.deepcopy(input_config)
+        config = {key: input_config[key] for key in self.ALLOWED_PARAMS if key in input_config}
 
-        config[CalibrationParameterDefinitions.XAxisDistance.code] = ""
-        config[CalibrationParameterDefinitions.PinDiameter.code] = ""
-        config[CalibrationParameterDefinitions.ClearanceY.code] = ""
-
-        return "M469.4 " + self.config_to_gcode(config) + "\n Make sure 4th Axis and 3 axis probe are installed"
+        return "M469.6 " + self.config_to_gcode(config) + "\n Make sure 4th Axis and 3 axis probe are installed"
 
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:


### PR DESCRIPTION
New M469.6 4th Axis calibration routine finds the true 4th axis center now replaces the previous M469.4 4th axis head stock calibration. As per #647 
<img width="1024" height="691" alt="Screenshot 2026-07-11 at 11 11 09 pm" src="https://github.com/user-attachments/assets/d4050453-9b51-4941-bafa-a158e9edbdb2" />

