### PR TITLE
fix 3D Visualisation of GCode to originatation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed: Fix potential crashes due to an undefined FuncSetting key"
 - Fixed: Fix incorrect "No Pendant" in UI when pendant is working
 - Fixed: Fix invalid initial coordinates when resuming in the middle of a modal command
+- Fixed: 3D Visualisation of GCode movement would always show the initial movement as originating from the WCS Origin, this doesn't match reality. Now the Visualisation correctly shows the line as originating from above the first movement command at the configured clearance_z (default of MCS Z-3)
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file
 

--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -154,6 +154,9 @@ class CNC:
         "anchor_length",
         "worksize_x",
         "worksize_y",
+        "clearance_x",
+        "clearance_y",
+        "clearance_z",
         "rotation_offset_x",
         "rotation_offset_y",
     ]
@@ -327,6 +330,12 @@ class CNC:
         self.totalTime = 0.0
         self.coordinates = []
         self.last_xyz = (-10000, -10000, -10000)
+        self.has_motion = False
+
+    # ----------------------------------------------------------------------
+    def _safe_z_wcs(self):
+        """WCS Z equivalent of coordinate.clearance_z (MCS clearance height from config.txt)."""
+        return float(CNC.vars.get("clearance_z", -3.0)) - CNC.vars.get("wcoz", 0.0)
 
     # ----------------------------------------------------------------------
     def resetMargins(self):
@@ -360,6 +369,21 @@ class CNC:
 
         # calculate path
         xyzs = self.motionPath()
+
+        if len(xyzs) > 0 and not self.has_motion:
+            # Parser assumes the machine starts at WCS origin; skip visualising
+            # travel from that assumed position on the first motion command.
+            self.has_motion = True
+            if self.gcode in (0, 1, 2, 3):
+                end = xyzs[-1]
+                if not self.z_command:
+                    # Playback reaches clearance height (coordinate.clearance_z) before the first XY move.
+                    safe_z = self._safe_z_wcs()
+                    end = (end[0], end[1], safe_z, end[3])
+                    self.zval = safe_z
+                xyzs = [end]
+            elif self.gcode in (81, 82, 83, 85, 86, 89) and len(xyzs) > 1:
+                xyzs = xyzs[1:]
 
         if len(xyzs) > 0:
             for xyz in xyzs:
@@ -398,6 +422,7 @@ class CNC:
     def motionStart(self, cmds):
         self.mval = 0  # reset m command
         self.tool_cmd = False
+        self.z_command = False
         for cmd in cmds:
             c = cmd[0].upper()
             try:
@@ -418,6 +443,7 @@ class CNC:
                 self.dy = self.yval - self.y
 
             elif c == "Z":
+                self.z_command = True
                 self.zval = value * self.unit
                 if not self.absolute:
                     self.zval += self.z


### PR DESCRIPTION
Resolves #645

3D Visualisation of GCode movement would previously always show the initial movement as originating from the WCS Origin, this doesn't match reality. Now the Visualisation correctly shows the line as originating from above the first movement command at the configured clearance_z (default of MCS Z-3).

Before:
<img width="1050" height="711" alt="Screenshot 2026-07-11 at 11 42 55 pm" src="https://github.com/user-attachments/assets/8b4bfac0-1948-4ece-a082-c376b8bc0025" />



After:
<img width="1055" height="708" alt="Screenshot 2026-07-11 at 11 41 59 pm" src="https://github.com/user-attachments/assets/5be26b64-c83f-49fe-9776-ffda42b0ce08" />
