### PR TITLE
Advanced TLO calibration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Enhancement: Add grid visualization, ortho projection, view cube and color schemes selector to the G-Code viewer
 - Enhancement: Detect WHB04 pendant permission errors instead of silently ignoring pendant
 - Enhancement: New M469.6 4th Axis calibration routine finds the true 4th axis center now replaces the previous M469.4 4th axis head stock calibration
+- Enhancement: Advanced TLO Calibration option. Here you can set the offset to use from tool setter, and/or the number of repeat probings to use
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -493,6 +493,16 @@ class Controller:
     def calibrateToolCommand(self):
         self.executeCommand("M491\n")
 
+    def calibrate_tool_advanced_command(self, repeat_count=1, x_offset=0.0, y_offset=0.0):
+        parts = ["M491"]
+        if x_offset != 0:
+            parts.append("X%g" % x_offset)
+        if y_offset != 0:
+            parts.append("Y%g" % y_offset)
+        if repeat_count != 1:
+            parts.append("R%d" % repeat_count)
+        self.executeCommand(" ".join(parts) + "\n")
+
     def clampToolCommand(self):
         self.executeCommand("M490.1\n")
 

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -218,6 +218,7 @@ from .Controller import (
 from .GcodeViewer import GCodeViewer
 from .ui import widget_helpers
 from .ui.PlayProgressBar import play_percent_from_line, tool_change_markers_to_percents
+from .ui.popups.adv_calibrate import AdvCalibratePopup
 from .ui.popups.set_position import (
     ChangeToolPopup,
     MoveAPopup,
@@ -3059,6 +3060,7 @@ class Makera(RelativeLayout):
         self.probing_popup = ProbingPopup(self.controller)
         self.probe_scan_popup = None
         self.facing_popup = FacingWizardPopup()
+        self.adv_calibrate_popup = AdvCalibratePopup()
         self.wcs_settings_popup = WCSSettingsPopup(self.controller, self.wcs_names)
         self.set_rotation_popup = SetRotationPopup(self.controller, self.cnc)
         self.comports_drop_down = DropDown(auto_width=False, width="250dp")
@@ -3407,6 +3409,13 @@ class Makera(RelativeLayout):
         self._pre_modal_keyboard_jog = self.keyboard_jog_control
         self.toggle_keyboard_jog_control(True)
         self.facing_popup.open()
+
+    def open_adv_calibrate_popup(self):
+        app = App.get_running_app()
+        if not app.is_community_firmware:
+            self.show_message_popup(tr._("Adv Calibrate requires the Community firmware."), False)
+            return
+        self.adv_calibrate_popup.open()
 
     def open_update_popup(self):
         self.upgrade_popup.check_button.disabled = False

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -17,6 +17,7 @@
 #:include ui/DropDownSplitter.kv
 #:include addons/probing/ProbingPopup.kv
 #:include ui/popups/set_position/set_position.kv
+#:include ui/popups/adv_calibrate/adv_calibrate.kv
 #:include addons/probe_scan/ui/ProbeScanPopup.kv
 #:include addons/facing/FacingWizardPopup.kv
 
@@ -855,6 +856,14 @@
         on_release:
             root.select('Third Item')
             app.root.controller.calibrateToolCommand()
+    Button:
+        text: tr._('Adv Calibrate')
+        size_hint_y: None
+        height: '40dp'
+        disabled: not app.is_community_firmware
+        on_release:
+            root.select('Third Item')
+            app.root.open_adv_calibrate_popup()
     Button:
         text: tr._('Drop')
         size_hint_y: None

--- a/carveracontroller/ui/popups/adv_calibrate/__init__.py
+++ b/carveracontroller/ui/popups/adv_calibrate/__init__.py
@@ -1,0 +1,3 @@
+from .adv_calibrate import AdvCalibratePopup, load_adv_calibrate_settings, save_adv_calibrate_settings
+
+__all__ = ["AdvCalibratePopup", "load_adv_calibrate_settings", "save_adv_calibrate_settings"]

--- a/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.kv
+++ b/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.kv
@@ -1,0 +1,98 @@
+#:import tr carveracontroller.__main__.tr
+
+<AdvCalibratePopup>:
+    size_hint: 0.55, 0.45
+    pos_hint: {"right": 0.75, "top": 0.7}
+    auto_dismiss: False
+    BoxLayout:
+        padding: '15dp'
+        orientation: 'vertical'
+        Label:
+            canvas.before:
+                Color:
+                    rgba: 45/255, 45/255, 45/255, 1
+                Rectangle:
+                    pos: self.pos
+                    size: self.size
+            size_hint_y: None
+            height: '30dp'
+            text: tr._('Advanced TLO Calibrate')
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
+        AnchorLayout:
+            anchor_x: 'center'
+            anchor_y: 'top'
+            BoxLayout:
+                orientation: 'vertical'
+                size_hint: None, None
+                width: dp(320)
+                height: self.minimum_height
+                spacing: dp(6)
+                padding: dp(1)
+
+                BoxLayout:
+                    size_hint_y: None
+                    height: dp(28)
+                    ProbeSettingLabel:
+                        label_text: tr._('Repeats (R):')
+                    ToolTipTextInput:
+                        id: txt_repeat
+                        size_hint_x: 0.55
+                        font_size: '14dp'
+                        hint_text: tr._("1")
+                        hint_text_color: (0.2, 0.5, 0.5, 0.5)
+                        tooltip_txt: tr._('Number of TLO measurement repeats. For facemills: probe once per cycle, rotate the face mill between cycles; the TLO uses the lowest cutting edge')
+                        tooltip_image: ''
+                        multiline: False
+                        halign: 'right'
+                        input_type: 'number'
+                        input_filter: 'int'
+
+                BoxLayout:
+                    size_hint_y: None
+                    height: dp(28)
+                    ProbeSettingLabel:
+                        label_text: tr._('X Offset:')
+                    ToolTipTextInput:
+                        id: txt_x_offset
+                        size_hint_x: 0.55
+                        font_size: '14dp'
+                        hint_text: tr._("0")
+                        hint_text_color: (0.2, 0.5, 0.5, 0.5)
+                        tooltip_txt: tr._('Offset the tool setter location by this amount (positive or negative) in X')
+                        tooltip_image: ''
+                        multiline: False
+                        halign: 'right'
+                        input_type: 'number'
+                        input_filter: 'float'
+
+                BoxLayout:
+                    size_hint_y: None
+                    height: dp(28)
+                    ProbeSettingLabel:
+                        label_text: tr._('Y Offset:')
+                    ToolTipTextInput:
+                        id: txt_y_offset
+                        size_hint_x: 0.55
+                        font_size: '14dp'
+                        hint_text: tr._("0")
+                        hint_text_color: (0.2, 0.5, 0.5, 0.5)
+                        tooltip_txt: tr._('Offset the tool setter location by this amount (positive or negative) in Y')
+                        tooltip_image: ''
+                        multiline: False
+                        halign: 'right'
+                        input_type: 'number'
+                        input_filter: 'float'
+
+        Widget:
+        BoxLayout:
+            spacing: '5dp'
+            size_hint_y: None
+            height: '40dp'
+            Button:
+                text: tr._('Cancel')
+                on_release: root.dismiss()
+            Button:
+                text: tr._('Run Calibration')
+                on_release: root.on_run_pressed()

--- a/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.kv
+++ b/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.kv
@@ -34,11 +34,15 @@
                 BoxLayout:
                     size_hint_y: None
                     height: dp(28)
+                    Widget:
                     ProbeSettingLabel:
+                        size_hint_x: None
+                        width: dp(130)
                         label_text: tr._('Repeats (R):')
                     ToolTipTextInput:
                         id: txt_repeat
-                        size_hint_x: 0.55
+                        size_hint_x: None
+                        width: dp(90)
                         font_size: '14dp'
                         hint_text: tr._("1")
                         hint_text_color: (0.2, 0.5, 0.5, 0.5)
@@ -48,15 +52,20 @@
                         halign: 'right'
                         input_type: 'number'
                         input_filter: 'int'
+                    Widget:
 
                 BoxLayout:
                     size_hint_y: None
                     height: dp(28)
+                    Widget:
                     ProbeSettingLabel:
+                        size_hint_x: None
+                        width: dp(130)
                         label_text: tr._('X Offset:')
                     ToolTipTextInput:
                         id: txt_x_offset
-                        size_hint_x: 0.55
+                        size_hint_x: None
+                        width: dp(90)
                         font_size: '14dp'
                         hint_text: tr._("0")
                         hint_text_color: (0.2, 0.5, 0.5, 0.5)
@@ -66,15 +75,20 @@
                         halign: 'right'
                         input_type: 'number'
                         input_filter: 'float'
+                    Widget:
 
                 BoxLayout:
                     size_hint_y: None
                     height: dp(28)
+                    Widget:
                     ProbeSettingLabel:
+                        size_hint_x: None
+                        width: dp(130)
                         label_text: tr._('Y Offset:')
                     ToolTipTextInput:
                         id: txt_y_offset
-                        size_hint_x: 0.55
+                        size_hint_x: None
+                        width: dp(90)
                         font_size: '14dp'
                         hint_text: tr._("0")
                         hint_text_color: (0.2, 0.5, 0.5, 0.5)
@@ -84,6 +98,7 @@
                         halign: 'right'
                         input_type: 'number'
                         input_filter: 'float'
+                    Widget:
 
         Widget:
         BoxLayout:

--- a/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.py
+++ b/carveracontroller/ui/popups/adv_calibrate/adv_calibrate.py
@@ -1,0 +1,97 @@
+"""Advanced tool calibration popup (M491 with optional parameters)."""
+
+from functools import partial
+from typing import Any
+
+from kivy.app import App
+from kivy.clock import Clock
+from kivy.uix.modalview import ModalView
+
+from carveracontroller.addons.probing.operations.ConfigUtils import ConfigUtils
+from carveracontroller.translation import tr
+from carveracontroller.ui import widget_helpers
+
+SETTINGS_FILENAME = "adv-calibrate-settings.json"
+
+
+def load_adv_calibrate_settings() -> dict[str, str]:
+    return ConfigUtils.load_config(SETTINGS_FILENAME)
+
+
+def save_adv_calibrate_settings(repeat: str, x_offset: str, y_offset: str) -> None:
+    ConfigUtils.save_config(
+        {
+            "repeat": repeat.strip(),
+            "x_offset": x_offset.strip(),
+            "y_offset": y_offset.strip(),
+        },
+        SETTINGS_FILENAME,
+    )
+
+
+def _show_error(message: str) -> None:
+    app = App.get_running_app()
+    Clock.schedule_once(partial(app.root.show_message_popup, message, False), 0)
+
+
+def _parse_optional_float(text: str, default: float) -> float:
+    stripped = text.strip().replace(",", ".")
+    if not stripped:
+        return default
+    return float(stripped)
+
+
+def _parse_optional_int(text: str, default: int) -> int:
+    stripped = text.strip().replace(",", ".")
+    if not stripped:
+        return default
+    return int(float(stripped))
+
+
+class AdvCalibratePopup(ModalView):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._auto_select_bound = False
+
+    def on_open(self) -> None:
+        super().on_open()
+        ids = self.ids
+        settings = load_adv_calibrate_settings()
+        ids.txt_repeat.text = settings.get("repeat", "")
+        ids.txt_x_offset.text = settings.get("x_offset", "")
+        ids.txt_y_offset.text = settings.get("y_offset", "")
+        if not self._auto_select_bound:
+            widget_helpers.bind_auto_select_to_text_input(ids.txt_repeat)
+            widget_helpers.bind_auto_select_to_text_input(ids.txt_x_offset)
+            widget_helpers.bind_auto_select_to_text_input(ids.txt_y_offset)
+            self._auto_select_bound = True
+
+    def _persist_settings(self) -> None:
+        ids = self.ids
+        save_adv_calibrate_settings(ids.txt_repeat.text, ids.txt_x_offset.text, ids.txt_y_offset.text)
+
+    def dismiss(self, *args: Any, **kwargs: Any) -> None:
+        self._persist_settings()
+        super().dismiss(*args, **kwargs)
+
+    def on_run_pressed(self) -> None:
+        ids = self.ids
+        try:
+            repeat_count = _parse_optional_int(ids.txt_repeat.text, 1)
+            x_offset = _parse_optional_float(ids.txt_x_offset.text, 0.0)
+            y_offset = _parse_optional_float(ids.txt_y_offset.text, 0.0)
+        except ValueError:
+            _show_error(tr._("Please enter valid numbers for all fields."))
+            return
+
+        if repeat_count < 1:
+            _show_error(tr._("Number of measurement repeats must be at least 1."))
+            return
+
+        app = App.get_running_app()
+        app.root.controller.calibrate_tool_advanced_command(
+            repeat_count=repeat_count,
+            x_offset=x_offset,
+            y_offset=y_offset,
+        )
+        self.dismiss()


### PR DESCRIPTION
#646 

Adds Advanced TLO Calibration dropdown option. Here you can set the offset to use from tool setter, and/or the number of repeat probings to use. Values used as saved/restored similar to the probing ui.

In future the same screen could get TDO sensor options (maybe gated based on a controlled setting)

<img width="1025" height="534" alt="Screenshot 2026-07-12 at 12 44 46 am" src="https://github.com/user-attachments/assets/2570ebe6-e1d5-4fc9-9cbe-f9a66c2c15ad" />


<img width="875" height="399" alt="Screenshot 2026-07-12 at 12 44 58 am" src="https://github.com/user-attachments/assets/5f456f7d-3b26-4a1a-b157-08a53c167ac2" />
