### PR TITLE
Added Help Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file
 - Change: Upgrade screen now will show the letter "c" at the end of the current firmware version if it's present. This indicates that it's Community firmware
+- Enhancement: added green question mark help buttons to the UI that link to the relavent documentation page
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Enhancement: Log connect and manual disconnect with the connection method and address
 - Enhancement: Add a "Network..." option under Scan Wi-Fi in the connection dropdown to enter a machine network address
 - Enhancement: Reconnect supports USB as well as WiFi. Configure preferred method for app-launch auto-connect
-- Enhancement: added green question mark help buttons to the UI that link to the relavent documentation page
+- Enhancement: added green question mark help buttons to the UI that link to the relevant documentation page
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes
@@ -48,7 +48,7 @@
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file
 - Change: Upgrade screen now will show the letter "c" at the end of the current firmware version if it's present. This indicates that it's Community firmware
 - Change: Auto-connect on app launch now is only performed if auto-reconnect is enabled
-- Change: Reconnect uses the last successful connection method. On fresh app launch it uses the configured prefered connection method
+- Change: Reconnect uses the last successful connection method. On fresh app launch it uses the configured preferred connection method
 - Change: USB devices in connection dropdown are filtered to only show devices specifically with the FTDI chip found on the Makera machines
 - Change: USB devices are now selected and stored by stable VID:PID:serial identity (instead of generic COM path)
 

--- a/carveracontroller/addons/facing/FacingWizardPopup.kv
+++ b/carveracontroller/addons/facing/FacingWizardPopup.kv
@@ -638,3 +638,6 @@
                     font_size: dp(12)
                     text: tr._('Close')
                     on_release: root.dismiss()
+
+                HelpButton:
+                    helpPath: "https://carvera-community.gitbook.io/docs/controller/features/facing-widget"

--- a/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.kv
+++ b/carveracontroller/addons/probe_scan/ui/ProbeScanPopup.kv
@@ -999,6 +999,8 @@
                     text: tr._('Close')
                     size_hint_x: 1
                     on_release: root.dismiss()
+                HelpButton:
+                    helpPath: "https://carvera-community.gitbook.io/docs/controller/features/probe_scan"
 
         BoxLayout:
             id: probing_banner

--- a/carveracontroller/addons/probing/ProbingPopup.kv
+++ b/carveracontroller/addons/probing/ProbingPopup.kv
@@ -664,17 +664,14 @@
             Label:
                 size_hint_min_x: dp(90)
                 padding: '5dp'
-                halign: 'center'
+                halign: 'right'
                 valign: 'middle'
                 text_size: self.size
                 multiline: False
                 text: tr._('Note: Most of these operations require a true 3 axis probe, not the manual probe supplied with the Carvera. See the documentation for more info')
 
-            Button:
-                text: "More Info"
-                size_hint_x: None
-                width: dp(100)
-                on_release: root.open_probe_info_url()
+            HelpButton:
+                helpPath: "https://carvera-community.gitbook.io/docs/firmware/features/3d-probe-support"
         
         BoxLayout:
             spacing: '5dp'

--- a/carveracontroller/addons/probing/ProbingPopup.py
+++ b/carveracontroller/addons/probing/ProbingPopup.py
@@ -30,8 +30,6 @@ from .preview.ProbingPreviewPopup import ProbingPreviewPopup
 
 logger = logging.getLogger(__name__)
 
-import webbrowser
-
 from kivy.app import App
 
 
@@ -64,9 +62,6 @@ class ProbingPopup(ModalView):
     def allows_external_jog(self) -> bool:
         """Allow keyboard/pendant jog while the probing screen is open."""
         return self._is_open
-
-    def open_probe_info_url(self):
-        webbrowser.open("https://carvera-community.gitbook.io/docs/firmware/features/3d-probe-support")
 
     def delayed_bind(self, dt):
         self.outside_corner_settings = self.ids.outside_corner_settings

--- a/carveracontroller/addons/probing/operations/Angle/AngleSettings.kv
+++ b/carveracontroller/addons/probing/operations/Angle/AngleSettings.kv
@@ -254,3 +254,11 @@
                             size: self.size
                     active: root.get_setting('UseProbeNormallyClosed') == "1"
                     on_active: root.setting_changed('UseProbeNormallyClosed', "1" if self.active else "0")
+            BoxLayout:
+                ProbeSettingLabel:
+                    label_text: 'More Info:'
+                    hint_text: ''
+                BoxLayout:
+                    size_hint_x: 0.4
+                    HelpButton:
+                        helpPath: "https://carvera-community.gitbook.io/docs/controller/features/wcs-rotation#clearing-a-rotation"

--- a/carveracontroller/addons/probing/operations/Calibration/CalibrationSettings.kv
+++ b/carveracontroller/addons/probing/operations/Calibration/CalibrationSettings.kv
@@ -180,3 +180,11 @@
                             size: self.size
                     active: root.get_setting('UseProbeNormallyClosed') == "1"
                     on_active: root.setting_changed('UseProbeNormallyClosed', "1" if self.active else "0")
+            BoxLayout:
+                ProbeSettingLabel:
+                    label_text: 'More Info:'
+                    hint_text: ''
+                BoxLayout:
+                    size_hint_x: 0.4
+                    HelpButton:
+                        helpPath: "https://carvera-community.gitbook.io/docs/firmware/supported-commands/mcodes/self-calibration"

--- a/carveracontroller/addons/probing/operations/FourthAxis/FourthAxisSettings.kv
+++ b/carveracontroller/addons/probing/operations/FourthAxis/FourthAxisSettings.kv
@@ -156,3 +156,12 @@
                             size: self.size
                     active: root.get_setting('SaveAOffset') == "1"
                     on_active: root.setting_changed('SaveAOffset', "1" if self.active else "0")
+            BoxLayout:
+                ProbeSettingLabel:
+                    label_text: 'More Info:'
+                    hint_text: ''
+                BoxLayout:
+                    size_hint_x: 0.4
+                    HelpButton:
+                        halign: 'center'
+                        helpPath: "https://carvera-community.gitbook.io/docs/firmware/supported-commands/mcodes/self-calibration"

--- a/carveracontroller/addons/tooltips/Tooltips.kv
+++ b/carveracontroller/addons/tooltips/Tooltips.kv
@@ -80,3 +80,28 @@
         Rectangle:
             size: self.size
             pos: self.pos
+
+<HelpButton>
+    id: help_button
+    orientation: 'vertical'
+    halign: 'center'
+    pos_hint: {'center_x': 0.5, 'center_y': 0.5}
+    size_hint: None, None
+    height: self.parent.height
+    width: self.parent.height * 2
+    state_image: self.background_normal if self.state == 'normal' else self.background_down
+    disabled_image: self.background_disabled_normal if self.state == 'normal' else self.background_disabled_down
+    canvas:
+        Color:
+            rgba: 0, 1, 0, 1
+        BorderImage:
+            border: self.border
+            pos: self.pos
+            size: self.size
+            source: self.disabled_image if self.disabled else self.state_image
+    Image:
+        id: image
+        source: root.image_source
+        fit_mode: 'scale-down'
+        size_hint: 0.3,0.3
+        pos_hint: {'center_x': 0.5, 'center_y': 0.5}

--- a/carveracontroller/addons/tooltips/Tooltips.py
+++ b/carveracontroller/addons/tooltips/Tooltips.py
@@ -5,7 +5,7 @@ from kivy.clock import Clock
 from kivy.compat import string_types
 from kivy.core.window import Window
 from kivy.factory import Factory
-from kivy.properties import BooleanProperty, NumericProperty, ObjectProperty, StringProperty
+from kivy.properties import BooleanProperty, NumericProperty, ObjectProperty, StringProperty, ListProperty
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.uix.dropdown import DropDown
@@ -15,7 +15,8 @@ from kivy.uix.popup import Popup
 from kivy.uix.spinner import Spinner
 from kivy.uix.switch import Switch
 from kivy.uix.textinput import TextInput
-
+from kivy.uix.behaviors import ButtonBehavior
+import webbrowser
 
 class Tooltip(BoxLayout):
     pass
@@ -823,3 +824,24 @@ class ToolTipLabel(Label):
 
     def display_tooltip(self, *args):
         Window.add_widget(self._tooltip)
+
+class HelpButton(ButtonBehavior, BoxLayout):
+    image_source = StringProperty('data/open_iconic_UI/oi--question-mark.png')
+    helpPath = StringProperty("https://carvera-community.gitbook.io/docs")
+    background_normal = StringProperty('atlas://data/images/defaulttheme/button')
+    background_down = StringProperty('atlas://data/images/defaulttheme/button_pressed')
+    background_disabled_normal = StringProperty('atlas://data/images/defaulttheme/button_disabled')
+    background_disabled_down = StringProperty('atlas://data/images/defaulttheme/button_disabled_pressed')
+    border = ListProperty([16, 16, 16, 16])
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.bind(on_release=self.open_link)
+        fbind = self.fbind
+
+
+    def open_link(self, *args):
+        webbrowser.open(self.helpPath)
+    
+    
+

--- a/carveracontroller/addons/tooltips/Tooltips.py
+++ b/carveracontroller/addons/tooltips/Tooltips.py
@@ -1,11 +1,13 @@
 import sys
+import webbrowser
 
 from kivy.app import App
 from kivy.clock import Clock
 from kivy.compat import string_types
 from kivy.core.window import Window
 from kivy.factory import Factory
-from kivy.properties import BooleanProperty, NumericProperty, ObjectProperty, StringProperty, ListProperty
+from kivy.properties import BooleanProperty, ListProperty, NumericProperty, ObjectProperty, StringProperty
+from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.button import Button
 from kivy.uix.dropdown import DropDown
@@ -15,8 +17,7 @@ from kivy.uix.popup import Popup
 from kivy.uix.spinner import Spinner
 from kivy.uix.switch import Switch
 from kivy.uix.textinput import TextInput
-from kivy.uix.behaviors import ButtonBehavior
-import webbrowser
+
 
 class Tooltip(BoxLayout):
     pass
@@ -825,13 +826,14 @@ class ToolTipLabel(Label):
     def display_tooltip(self, *args):
         Window.add_widget(self._tooltip)
 
+
 class HelpButton(ButtonBehavior, BoxLayout):
-    image_source = StringProperty('data/open_iconic_UI/oi--question-mark.png')
+    image_source = StringProperty("data/open_iconic_UI/oi--question-mark.png")
     helpPath = StringProperty("https://carvera-community.gitbook.io/docs")
-    background_normal = StringProperty('atlas://data/images/defaulttheme/button')
-    background_down = StringProperty('atlas://data/images/defaulttheme/button_pressed')
-    background_disabled_normal = StringProperty('atlas://data/images/defaulttheme/button_disabled')
-    background_disabled_down = StringProperty('atlas://data/images/defaulttheme/button_disabled_pressed')
+    background_normal = StringProperty("atlas://data/images/defaulttheme/button")
+    background_down = StringProperty("atlas://data/images/defaulttheme/button_pressed")
+    background_disabled_normal = StringProperty("atlas://data/images/defaulttheme/button_disabled")
+    background_disabled_down = StringProperty("atlas://data/images/defaulttheme/button_disabled_pressed")
     border = ListProperty([16, 16, 16, 16])
 
     def __init__(self, **kwargs):
@@ -839,9 +841,5 @@ class HelpButton(ButtonBehavior, BoxLayout):
         self.bind(on_release=self.open_link)
         fbind = self.fbind
 
-
     def open_link(self, *args):
         webbrowser.open(self.helpPath)
-    
-    
-

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3794,11 +3794,6 @@
                                                 text: tr._('Macro 3')
                                                 height: '35dp'
                                                 on_release: app.root.run_macro(3)
-                                        GridBoxLayout:
-                                            size_hint: 0.25,1        
-                                            HelpButton:
-                                                size_hint: 1,1
-                                                helpPath: "https://carvera-community.gitbook.io/docs/controller/features/macros"
 
                             Widget:
                                 size_hint_y: 0.15
@@ -3928,7 +3923,7 @@
                                             size: self.size
                                             radius: [dp(12),]
                                     GridLayout:
-                                        cols: 3
+                                        cols: 2
                                         rows: 2
                                         spacing: '3dp'
                                         GridBoxLayout:
@@ -3963,12 +3958,7 @@
                                                 state: app.jog_pendant_enable
                                                 height: '35dp'
                                                 on_release: app.root.toggle_pendant_jog_control()
-                                        GridBoxLayout:
-                                            size_hint_x: 0.15
-                                            HelpButton:
-                                                size_hint: 1,1
-                                                helpPath: "https://carvera-community.gitbook.io/docs/controller/features/jogging-controls"
-
+                                        
                         BoxLayout:
                             disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
                             padding: '25dp'

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3770,7 +3770,7 @@
                                             size: self.size
                                             radius: [dp(12),]
                                     GridLayout:
-                                        cols: 4
+                                        cols: 3
                                         rows: 1
                                         spacing: '3dp'
                                         GridBoxLayout:
@@ -3942,15 +3942,12 @@
                                                 height: '35dp'
                                                 on_release: app.root.toggle_jog_mode()
                                         GridBoxLayout:
-                                            size_hint_x: 0.15
-                                        GridBoxLayout:
                                             ToggleButton:
                                                 id: kb_jog_btn
                                                 text: tr._('Keyboard Jogging')
                                                 height: '35dp'
                                                 state: app.jog_keyboard_enable
                                                 on_release: app.root.toggle_keyboard_jog_control()
-                                    
                                         GridBoxLayout:
                                             ToggleButton:
                                                 id: pendant_jogging_en_btn
@@ -3958,7 +3955,7 @@
                                                 state: app.jog_pendant_enable
                                                 height: '35dp'
                                                 on_release: app.root.toggle_pendant_jog_control()
-                                        
+
                         BoxLayout:
                             disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
                             padding: '25dp'

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -514,6 +514,12 @@
         on_release:
             root.select('Third Item')
             app.root.controller.clearAutoLeveling()
+    BoxLayout:
+        size_hint_y: None
+        height: '48dp'
+        HelpButton:
+            helpPath: "https://carvera-community.gitbook.io/docs/controller/features/auto-leveling"
+
 
 
 <ADropDown>:
@@ -1499,6 +1505,12 @@
                     root.dismiss()
                     if root.unlock_safe_z:\
                     root.unlock_safe_z()
+            BoxLayout:
+                size_hint_x: 0.25
+                HelpButton:
+                    size_hint: 1,1
+                    helpPath: "https://carvera-community.gitbook.io/docs/controller/common-error-messages"
+
 
 <SelectAndCalibrateProbePopup>:
     lb_title: lb_title
@@ -1727,6 +1739,7 @@
                         id: btn_ok
                         text: tr._('Ok')
                         on_release: root.on_ok_pressed()
+                    
 
         TabbedPanelItem:
             text: tr._('Set By XYZ Probe')
@@ -3757,7 +3770,7 @@
                                             size: self.size
                                             radius: [dp(12),]
                                     GridLayout:
-                                        cols: 3
+                                        cols: 4
                                         rows: 1
                                         spacing: '3dp'
                                         GridBoxLayout:
@@ -3781,6 +3794,12 @@
                                                 text: tr._('Macro 3')
                                                 height: '35dp'
                                                 on_release: app.root.run_macro(3)
+                                        GridBoxLayout:
+                                            size_hint: 0.25,1        
+                                            HelpButton:
+                                                size_hint: 1,1
+                                                helpPath: "https://carvera-community.gitbook.io/docs/controller/features/macros"
+
                             Widget:
                                 size_hint_y: 0.15
                             BoxLayout:
@@ -3909,7 +3928,7 @@
                                             size: self.size
                                             radius: [dp(12),]
                                     GridLayout:
-                                        cols: 2
+                                        cols: 3
                                         rows: 2
                                         spacing: '3dp'
                                         GridBoxLayout:
@@ -3927,7 +3946,8 @@
                                                 text: tr._('Jog Mode:Step')
                                                 height: '35dp'
                                                 on_release: app.root.toggle_jog_mode()
-
+                                        GridBoxLayout:
+                                            size_hint_x: 0.15
                                         GridBoxLayout:
                                             ToggleButton:
                                                 id: kb_jog_btn
@@ -3943,6 +3963,11 @@
                                                 state: app.jog_pendant_enable
                                                 height: '35dp'
                                                 on_release: app.root.toggle_pendant_jog_control()
+                                        GridBoxLayout:
+                                            size_hint_x: 0.15
+                                            HelpButton:
+                                                size_hint: 1,1
+                                                helpPath: "https://carvera-community.gitbook.io/docs/controller/features/jogging-controls"
 
                         BoxLayout:
                             disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
@@ -5435,6 +5460,11 @@
                 on_release:
                     root.apply_changes()
                     root.dismiss()
+            BoxLayout:
+                size_hint_x: 0.2
+                HelpButton:
+                    helpPath: "https://carvera-community.gitbook.io/docs/controller/features/workspace-management"
+
 
 <SetRotationPopup>:
     size_hint: 0.5, 0.4
@@ -5497,6 +5527,11 @@
                 text: tr._('Ok')
                 on_release:
                     on_release: root.on_ok_pressed()
+            BoxLayout:
+                size_hint_x: 0.2
+                HelpButton:
+                    helpPath: "https://carvera-community.gitbook.io/docs/controller/features/wcs-rotation"
+
 
 # Solid disabled look (no faded theme atlas / no ghost text): mute bg + text vs enabled row.
 <OpaqueDisabledButton@Button>:


### PR DESCRIPTION
This PR adds a new button type, the HelpButton that links to the relevant page of the gitbooks documentation. 

<img width="1948" height="1316" alt="image" src="https://github.com/user-attachments/assets/f98667ad-0add-4a80-b648-51a5ebb4a07c" />

<img width="1172" height="648" alt="image" src="https://github.com/user-attachments/assets/dca7090d-af91-4227-bb6d-7223f1a53bfc" />


I am unsure on the buttons on the main control page as they are a bit intrusive
<img width="1948" height="1314" alt="image" src="https://github.com/user-attachments/assets/8fea02a8-79ff-41a3-89ce-8c898348088c" />





To implement a new help button in the controller:

<img width="1670" height="204" alt="image" src="https://github.com/user-attachments/assets/bd99f35f-aee2-4dd8-bfb2-47ef814a1047" />
