### PR TITLE
Fix resume-at-line WCS recovery after G53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enhancement: Advanced TLO Calibration option. Here you can set the offset to use from tool setter, and/or the number of repeat probings to use
 - Enhancement: Added a warning popup if the controller version is lower than the firmware. This is not a supported config
 - Enhancement: Added Auto Ext. Out toggle to spindle dropdown and Config and Run screen. This can be used to automatically run a vacuum or compressor when the spindle is running
+- Fixed: Resume-at-line no longer treats the non-modal G53 command as the active work coordinate system
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -1121,7 +1121,6 @@ class Controller:
 
             # Search for WCS coordinate space - find the last one used
             wcs_commands = [
-                ("G53", self._find_command_line_number(lines, start_line, "G53")),
                 ("G54", self._find_command_line_number(lines, start_line, "G54")),
                 ("G55", self._find_command_line_number(lines, start_line, "G55")),
                 ("G56", self._find_command_line_number(lines, start_line, "G56")),

--- a/tests/unit/test_resume_wcs.py
+++ b/tests/unit/test_resume_wcs.py
@@ -1,0 +1,20 @@
+"""Tests for resume-at-line work coordinate system recovery."""
+
+from carveracontroller.Controller import Controller
+
+
+def test_g53_does_not_replace_active_work_coordinate_system():
+    controller = Controller.__new__(Controller)
+    controller._get_line_position_from_gcode_viewer = lambda _line: (None, None, None, None)
+    lines = [
+        "G55\n",
+        "G53 G0 Z-2\n",
+        "G1 X10 F100\n",
+        "G1 X20\n",
+    ]
+
+    commands = controller.playStartLineCommand("job.nc", 4, preview=True, lines=lines)
+
+    assert "buffer G55" in commands
+    assert "buffer G53" not in commands
+    assert "buffer G53 G0 Z-2" in commands


### PR DESCRIPTION
Closes #665

## Summary

Exclude non-modal `G53` from resume-at-line's active-WCS search while preserving the controller's explicit `G53 G0 Z-2` recovery move.

## Changes

- Remove `G53` from the modal WCS candidates used by `playStartLineCommand()`.
- Add a regression test with `G55` followed by a `G53` machine-coordinate move.
- Add an unreleased changelog entry.

## Why

`G53` applies machine coordinates to its associated movement; it does not select a persistent coordinate system. Treating it as the most recent WCS can prevent resume-at-line from restoring the program's actual `G54`-`G59.3` state.

This is state-dependent: if the machine already retains the intended WCS, behavior may be unchanged. The fix removes that dependency and makes resume reconstruction deterministic.

## Validation

- Regression against the pinned `develop` implementation: `1 failed` because the preview contained bare `buffer G53` and omitted the expected `buffer G55`.
- With this change, using the same exact-ref sparse harness: `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/carvera-test-stubs:. pytest -q tests/unit/test_resume_wcs.py` -> `1 passed`.
- `ruff check carveracontroller/Controller.py tests/unit` -> passed.
- `git diff --check develop...HEAD` -> passed.

## Real branch verification

The repository's locked Poetry environment was installed from `poetry.lock`. The targeted suite passed on real fork commit [`d989beb58eaa`](https://github.com/righteousgambit/Carvera_Controller/commit/d989beb58eaafc7792eead19cff4a89fabb8f3a6), whose sole parent is pinned upstream `develop@2ea66c10e96d88013a04441134d3d4f8e8c88510`.

```shell
poetry run pytest -q tests/unit/test_resume_wcs.py
```

Result: **1 passed**.

Quality gates on the real branch:

- Ruff `check`: **passed**
- Ruff `format --check`: **passed**
- `git diff --check 2ea66c10e96d88013a04441134d3d4f8e8c88510..d989beb58eaafc7792eead19cff4a89fabb8f3a6`: **passed**