### PR TITLE
Verify XMODEM downloads against advertised MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed: Reject incomplete downloads that do not match the machine-provided MD5 checksum
 - Enhancement: Add multi-select to the remote file browser
 - Enhancement: Display error message in halt popup. Requires halt errors to start with "ERROR: " in the firmware
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - Fixed: Ignore unknown WHB04 button values without reconnecting or dropping valid paired inputs
 - Fixed: Resume-at-line restores feed rates from standalone and tightly packed F words before recovery moves
 - Fixed: Resume-at-line no longer treats the non-modal G53 command as the active work coordinate system
-- Fixed: Reject incomplete downloads that do not match the machine-provided MD5 checksum
+- Fixed: Reject downloads whose content does not match the machine-provided MD5. Skip MD5 check when none is available, and defer .lz checks until after decompress
 - Change: Misleading "Download canceled by Controller!" MDI message is suppressed, in logs a message is recorded that cached version of the config.txt was used
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file

--- a/carveracontroller/USBStream.py
+++ b/carveracontroller/USBStream.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import time
 
 import serial
@@ -20,11 +19,8 @@ class USBStream:
     # ----------------------------------------------------------------------
     def __init__(self, log_sent_receive=False):
         self.modem = XMODEM(self.getc, self.putc, "xmodem")
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(logging.WARNING)
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        handler.setFormatter(formatter)
-        self.modem.log.addHandler(handler)
+        # Rely on the app/Kivy root logger; do not attach extra StreamHandlers to
+        # the shared "xmodem.XMODEM" logger (USB+WiFi would duplicate every line).
         self.log_sent_receive = log_sent_receive
         self._send_log_buffer = b""
         self._recv_log_buffer = b""

--- a/carveracontroller/WIFIStream.py
+++ b/carveracontroller/WIFIStream.py
@@ -82,12 +82,8 @@ class WIFIStream:
     # ----------------------------------------------------------------------
     def __init__(self, log_sent_receive=False):
         self.modem = XMODEM(self.getc, self.putc, "xmodem8k")
-
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(logging.WARNING)
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        handler.setFormatter(formatter)
-        self.modem.log.addHandler(handler)
+        # Rely on the app/Kivy root logger; do not attach extra StreamHandlers to
+        # the shared "xmodem.XMODEM" logger (USB+WiFi would duplicate every line).
         self.log_sent_receive = log_sent_receive
         # Set by Controller when the communication protocol is selected.
         self.uses_framed_transfer = False

--- a/carveracontroller/XMODEM.py
+++ b/carveracontroller/XMODEM.py
@@ -92,6 +92,7 @@ __copyright__ = ["Copyright (c) 2010 Wijnand Modderman", "Copyright (c) 1981 Chu
 __license__ = "MIT"
 __version__ = "0.4.5"
 
+import hashlib
 import logging
 import platform
 import sys
@@ -717,6 +718,8 @@ class XMODEM:
         cancel = 0
         retrans = retry + 1
         md5_received = False
+        expected_md5 = None
+        received_md5 = hashlib.md5()
 
         while True:
             if self.canceled:
@@ -732,9 +735,17 @@ class XMODEM:
                 if char in (SOH, STX):
                     break
                 if char == EOT:
-                    # We received an EOT, so send an ACK and return the
-                    # received data length.
+                    # ACK the transport-level completion before validating the
+                    # whole-file digest advertised in block zero.
                     self.putc(ACK)
+                    actual_md5 = received_md5.hexdigest().encode()
+                    if expected_md5 is None or actual_md5 != expected_md5:
+                        self.log.error(
+                            "Download error: MD5 mismatch (expected=%r, actual=%r)",
+                            expected_md5,
+                            actual_md5,
+                        )
+                        return None
                     self.log.info("Transmission complete, %d bytes", income_size)
                     return income_size
                 if char == CAN:
@@ -813,7 +824,9 @@ class XMODEM:
                     retrans = retry + 1
                     if sequence == 0 and not md5_received:
                         md5_received = True
-                        if md5.encode() == data[1 + is_stx : 33 + is_stx]:
+                        data_len = data[0] << 8 | data[1] if is_stx else data[0]
+                        expected_md5 = data[1 + is_stx : (data_len + 1 + is_stx)].lower()
+                        if md5.encode().lower() == expected_md5:
                             self.putc(CAN)
                             self.putc(CAN)
                             self.putc(CAN)
@@ -823,7 +836,9 @@ class XMODEM:
                     else:
                         income_size += len(data) - 1 - is_stx
                         data_len = data[0] << 8 | data[1] if is_stx else data[0]
-                        stream.write(data[1 + is_stx : (data_len + 1 + is_stx)])
+                        payload = data[1 + is_stx : (data_len + 1 + is_stx)]
+                        stream.write(payload)
+                        received_md5.update(payload)
                         success_count = success_count + 1
                         if callable(callback):
                             callback(packet_size, success_count, error_count)

--- a/carveracontroller/XMODEM.py
+++ b/carveracontroller/XMODEM.py
@@ -450,6 +450,9 @@ class XMODEM:
         self.bytesNeeded = 2
         self.expectedLength = 0
         self.FileRcvState = FileTransState.WAIT_MD5
+        # Hex digest advertised by the machine; set when a .lz payload defers verification
+        # until after decompress. Cleared at the start of each download and after checking.
+        self.deferred_download_md5 = None
 
     def clear_mode_set(self):
         self.mode_set = False
@@ -476,6 +479,65 @@ class XMODEM:
 
     def _send_file_trans_command(self, cmd: int, data: bytes) -> None:
         self.putc(build_frame(cmd, data))
+
+    @staticmethod
+    def _normalize_advertised_md5(expected_md5):
+        """Return lowercase hex digest, or None when the machine advertised nothing usable."""
+        if expected_md5 is None:
+            return None
+        if isinstance(expected_md5, (bytes, bytearray)):
+            advertised = bytes(expected_md5).decode("ascii", errors="replace")
+        else:
+            advertised = str(expected_md5)
+        advertised = advertised.strip().lower()
+        return advertised or None
+
+    def _finalize_download_integrity(self, expected_md5, received_md5, income_size, first_bytes=b""):
+        """
+        Apply download MD5 policy.
+
+        - Empty/missing advertised digest: skip check
+        - QuickLZ payload (``\\x00\\x00`` prefix): defer check until after decompress
+        - Otherwise: require the received bytes to match the advertised digest
+
+        Returns True when the transfer may be treated as successful.
+        """
+        self.deferred_download_md5 = None
+        actual = received_md5.hexdigest()
+        advertised = self._normalize_advertised_md5(expected_md5)
+
+        if advertised is None:
+            self.log.info(
+                "Download MD5 check skipped (none advertised by machine), actual=%s (%d bytes)",
+                actual,
+                income_size,
+            )
+            return True
+
+        if first_bytes[:2] == b"\x00\x00":
+            self.deferred_download_md5 = advertised
+            self.log.info(
+                "Download MD5 deferred until decompress (advertised=%s, compressed actual=%s, %d bytes)",
+                advertised,
+                actual,
+                income_size,
+            )
+            return True
+
+        if actual != advertised:
+            self.log.error(
+                "Download error: MD5 mismatch (expected=%s, actual=%s)",
+                advertised,
+                actual,
+            )
+            return False
+
+        self.log.info(
+            "Download MD5 matched advertised digest: %s (%d bytes)",
+            actual,
+            income_size,
+        )
+        return True
 
     def recv_packet(self, timeout=0.5):
         """Read one Makera frame into ``self.packetData``. Returns 1 on success."""
@@ -538,6 +600,10 @@ class XMODEM:
         total_packet = 0
         sequence = 0
         income_size = 0
+        expected_md5 = None
+        received_md5 = hashlib.md5()
+        first_bytes = bytearray()
+        self.deferred_download_md5 = None
         while True:
             if self.canceled:
                 self._send_file_trans_command(PTYPE_FILE_CAN, b"")
@@ -565,7 +631,11 @@ class XMODEM:
                         if cmd_type == PTYPE_FILE_DATA and sequence == seq:
                             data_len = ((self.packetData[0] << 8) | self.packetData[1]) - 7
                             income_size += data_len
-                            stream.write(self.packetData[7 : (data_len + 7)])
+                            payload = self.packetData[7 : (data_len + 7)]
+                            stream.write(payload)
+                            received_md5.update(payload)
+                            if len(first_bytes) < 2:
+                                first_bytes.extend(payload[: 2 - len(first_bytes)])
                             if sequence < total_packet:
                                 sequence += 1
                                 data = sequence.to_bytes(4, byteorder="big", signed=False)
@@ -578,6 +648,10 @@ class XMODEM:
                             if seq == total_packet:
                                 self._send_file_trans_command(PTYPE_FILE_END, b"")
                                 self.FileRcvState = FileTransState.WAIT_MD5
+                                if not self._finalize_download_integrity(
+                                    expected_md5, received_md5, income_size, first_bytes
+                                ):
+                                    return None
                                 self.log.info("Transmission complete, %d bytes", income_size)
                                 return income_size
                         else:
@@ -612,7 +686,8 @@ class XMODEM:
                     if self.packetData:
                         if cmd_type == PTYPE_FILE_MD5:
                             md5new = self.packetData[3 : len(self.packetData) - 2]
-                            if (md5.encode() == md5new) and md5 != "":
+                            expected_md5 = bytes(md5new).lower()
+                            if md5 and expected_md5 and md5.encode().lower() == expected_md5:
                                 self._send_file_trans_command(PTYPE_FILE_CAN, b"")
                                 return 0
                             self._send_file_trans_command(PTYPE_FILE_VIEW, b"")
@@ -1016,6 +1091,8 @@ class XMODEM:
         md5_received = False
         expected_md5 = None
         received_md5 = hashlib.md5()
+        first_bytes = bytearray()
+        self.deferred_download_md5 = None
 
         while True:
             if self.canceled:
@@ -1031,16 +1108,9 @@ class XMODEM:
                 if char in (SOH, STX):
                     break
                 if char == EOT:
-                    # ACK the transport-level completion before validating the
-                    # whole-file digest advertised in block zero.
+                    # ACK for wire compatibility, then apply local MD5 policy.
                     self.putc(ACK)
-                    actual_md5 = received_md5.hexdigest().encode()
-                    if expected_md5 is None or actual_md5 != expected_md5:
-                        self.log.error(
-                            "Download error: MD5 mismatch (expected=%r, actual=%r)",
-                            expected_md5,
-                            actual_md5,
-                        )
+                    if not self._finalize_download_integrity(expected_md5, received_md5, income_size, first_bytes):
                         return None
                     self.log.info("Transmission complete, %d bytes", income_size)
                     return income_size
@@ -1122,7 +1192,7 @@ class XMODEM:
                         md5_received = True
                         data_len = data[0] << 8 | data[1] if is_stx else data[0]
                         expected_md5 = data[1 + is_stx : (data_len + 1 + is_stx)].lower()
-                        if md5.encode().lower() == expected_md5:
+                        if md5 and expected_md5 and md5.encode().lower() == expected_md5:
                             self.putc(CAN)
                             self.putc(CAN)
                             self.putc(CAN)
@@ -1135,6 +1205,8 @@ class XMODEM:
                         payload = data[1 + is_stx : (data_len + 1 + is_stx)]
                         stream.write(payload)
                         received_md5.update(payload)
+                        if len(first_bytes) < 2:
+                            first_bytes.extend(payload[: 2 - len(first_bytes)])
                         success_count = success_count + 1
                         if callable(callback):
                             callback(packet_size, success_count, error_count)

--- a/carveracontroller/XMODEM.py
+++ b/carveracontroller/XMODEM.py
@@ -453,6 +453,7 @@ class XMODEM:
         # Hex digest advertised by the machine; set when a .lz payload defers verification
         # until after decompress. Cleared at the start of each download and after checking.
         self.deferred_download_md5 = None
+        self.download_md5_failed = False
 
     def clear_mode_set(self):
         self.mode_set = False
@@ -503,6 +504,7 @@ class XMODEM:
         Returns True when the transfer may be treated as successful.
         """
         self.deferred_download_md5 = None
+        self.download_md5_failed = False
         actual = received_md5.hexdigest()
         advertised = self._normalize_advertised_md5(expected_md5)
 
@@ -525,6 +527,7 @@ class XMODEM:
             return True
 
         if actual != advertised:
+            self.download_md5_failed = True
             self.log.error(
                 "Download error: MD5 mismatch (expected=%s, actual=%s)",
                 advertised,
@@ -604,6 +607,7 @@ class XMODEM:
         received_md5 = hashlib.md5()
         first_bytes = bytearray()
         self.deferred_download_md5 = None
+        self.download_md5_failed = False
         while True:
             if self.canceled:
                 self._send_file_trans_command(PTYPE_FILE_CAN, b"")
@@ -1093,6 +1097,7 @@ class XMODEM:
         received_md5 = hashlib.md5()
         first_bytes = bytearray()
         self.deferred_download_md5 = None
+        self.download_md5_failed = False
 
         while True:
             if self.canceled:

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5388,6 +5388,37 @@ class Makera(RelativeLayout):
             return None
 
     # -----------------------------------------------------------------------
+    def _verify_deferred_download_md5(self, filepath):
+        """Verify a machine-advertised MD5 after .lz decompress. Returns False on mismatch."""
+        modem = getattr(getattr(self.controller, "stream", None), "modem", None)
+        expected = getattr(modem, "deferred_download_md5", None) if modem is not None else None
+        if modem is not None:
+            modem.deferred_download_md5 = None
+        if not expected:
+            return True
+
+        actual = Utils.md5(filepath)
+        if actual.lower() == expected.lower():
+            logger.info("Download MD5 matched after decompress: %s", actual)
+            return True
+
+        logger.error(
+            "Download error: MD5 mismatch after decompress (expected=%s, actual=%s)",
+            expected,
+            actual,
+        )
+        try:
+            if os.path.exists(filepath):
+                os.remove(filepath)
+        except OSError:
+            pass
+        Clock.schedule_once(
+            partial(self.show_message_popup, tr._("Download file error!"), False),
+            0,
+        )
+        return False
+
+    # -----------------------------------------------------------------------
     def decompress_file(self, input_filename, output_filename):
         try:
             # 打开输入文件和输出文件
@@ -7386,6 +7417,8 @@ class Makera(RelativeLayout):
                 lzpath = lzpath + ".lz"
                 shutil.copyfile(filepath, lzpath)
                 if not self.decompress_file(lzpath, filepath):
+                    return
+                if not self._verify_deferred_download_md5(filepath):
                     return
 
             self.cnc.init()

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -4829,11 +4829,30 @@ class Makera(RelativeLayout):
             if os.path.exists(tmp_filename):
                 os.remove(tmp_filename)
             # show message popup
+            md5_failed = bool(
+                getattr(getattr(getattr(self.controller, "stream", None), "modem", None), "download_md5_failed", False)
+            )
             if was_config_download:
                 Clock.schedule_once(partial(self.finishLoadConfig, False), 0.1)
-                Clock.schedule_once(partial(self.show_message_popup, tr._("Download config file error!"), False), 0.2)
+                error_msg = (
+                    tr._(
+                        "Download config file error! The file MD5 hash doesn't match what is expected. "
+                        "Possibly corruption occured during transfer or on SD card."
+                    )
+                    if md5_failed
+                    else tr._("Download config file error!")
+                )
+                Clock.schedule_once(partial(self.show_message_popup, error_msg, False), 0.2)
             else:
-                Clock.schedule_once(partial(self.show_message_popup, tr._("Download file error!"), False), 0)
+                error_msg = (
+                    tr._(
+                        "Download file error! MD5 hash doesn't match what is expected. "
+                        "Possible corruption during transfer or on SD card."
+                    )
+                    if md5_failed
+                    else tr._("Download file error!")
+                )
+                Clock.schedule_once(partial(self.show_message_popup, error_msg, False), 0)
         elif download_result >= 0:
             if download_result > 0:
                 # download success
@@ -5413,7 +5432,14 @@ class Makera(RelativeLayout):
         except OSError:
             pass
         Clock.schedule_once(
-            partial(self.show_message_popup, tr._("Download file error!"), False),
+            partial(
+                self.show_message_popup,
+                tr._(
+                    "Download file error! MD5 hash doesn't match what is expected. "
+                    "Possible corruption during transfer or on SD card."
+                ),
+                False,
+            ),
             0,
         )
         return False

--- a/tests/unit/test_xmodem_download_integrity.py
+++ b/tests/unit/test_xmodem_download_integrity.py
@@ -1,0 +1,73 @@
+"""Tests for whole-file integrity checks in XMODEM downloads."""
+
+import hashlib
+from io import BytesIO
+
+from carveracontroller.XMODEM import ACK, CAN, CRC, EOT, XMODEM
+
+
+def _packet(modem, sequence, payload):
+    packet_size = 8192
+    header = modem._make_send_header(packet_size, sequence)
+    data = bytes([len(payload) >> 8, len(payload) & 0xFF]) + payload.ljust(packet_size, modem.pad)
+    checksum = modem._make_send_checksum(1, data)
+    return bytes(header + data + checksum)
+
+
+def _receive(expected_payload, received_payload, local_md5=""):
+    transport = BytesIO()
+    writes = []
+
+    def getc(size, timeout=0.5):
+        return transport.read(size) or None
+
+    def putc(data, timeout=0.5):
+        writes.append(data)
+        return len(data)
+
+    modem = XMODEM(getc, putc, "xmodem8k")
+    expected_md5 = hashlib.md5(expected_payload).hexdigest().encode()
+    transport.write(_packet(modem, 0, expected_md5))
+    if received_payload:
+        transport.write(_packet(modem, 1, received_payload))
+    transport.write(EOT)
+    transport.seek(0)
+
+    output = BytesIO()
+    result = modem.recv(output, md5=local_md5)
+    return result, output.getvalue(), writes
+
+
+def test_recv_accepts_download_matching_block_zero_md5():
+    payload = b"G0 X1 Y2\nM2\n"
+
+    result, output, writes = _receive(payload, payload)
+
+    assert result is not None
+    assert result > 0
+    assert output == payload
+    assert writes == [CRC, ACK, ACK, ACK]
+
+
+def test_recv_short_circuits_when_uppercase_local_md5_matches_block_zero():
+    payload = b"G0 X1 Y2\nM2\n"
+    local_md5 = hashlib.md5(payload).hexdigest().upper()
+
+    result, output, writes = _receive(payload, payload, local_md5=local_md5)
+
+    assert result == 0
+    assert output == b""
+    assert writes == [CRC, CAN, CAN, CAN]
+
+
+def test_recv_rejects_eot_when_download_does_not_match_block_zero_md5():
+    expected_payload = b"G0 X1 Y2\nG1 X3 Y4\nM2\n"
+    truncated_payload = b"G0 X1 Y2\n"
+
+    result, output, writes = _receive(expected_payload, truncated_payload)
+
+    assert result is None
+    assert output == truncated_payload
+    # Transport completion remains wire-compatible even though the local
+    # artifact is rejected after its whole-file digest is checked.
+    assert writes == [CRC, ACK, ACK, ACK]

--- a/tests/unit/test_xmodem_download_integrity.py
+++ b/tests/unit/test_xmodem_download_integrity.py
@@ -1,8 +1,17 @@
-"""Tests for whole-file integrity checks in XMODEM downloads."""
+"""Tests for download MD5 integrity in legacy and Makera framed transfers."""
 
 import hashlib
+import logging
 from io import BytesIO
 
+from carveracontroller.protocols.framing import (
+    PTYPE_FILE_CAN,
+    PTYPE_FILE_DATA,
+    PTYPE_FILE_END,
+    PTYPE_FILE_MD5,
+    PTYPE_FILE_VIEW,
+    build_frame,
+)
 from carveracontroller.XMODEM import ACK, CAN, CRC, EOT, XMODEM
 
 
@@ -14,7 +23,7 @@ def _packet(modem, sequence, payload):
     return bytes(header + data + checksum)
 
 
-def _receive(expected_payload, received_payload, local_md5=""):
+def _receive_legacy(advertised_payload, received_payload, local_md5="", advertised_md5=None):
     transport = BytesIO()
     writes = []
 
@@ -26,48 +35,179 @@ def _receive(expected_payload, received_payload, local_md5=""):
         return len(data)
 
     modem = XMODEM(getc, putc, "xmodem8k")
-    expected_md5 = hashlib.md5(expected_payload).hexdigest().encode()
-    transport.write(_packet(modem, 0, expected_md5))
+    if advertised_md5 is None:
+        advertised_md5 = hashlib.md5(advertised_payload).hexdigest().encode()
+    transport.write(_packet(modem, 0, advertised_md5))
     if received_payload:
         transport.write(_packet(modem, 1, received_payload))
     transport.write(EOT)
     transport.seek(0)
 
     output = BytesIO()
-    result = modem.recv(output, md5=local_md5)
-    return result, output.getvalue(), writes
+    result = modem.recv_legacy(output, md5=local_md5)
+    return result, output.getvalue(), writes, modem
 
 
-def test_recv_accepts_download_matching_block_zero_md5():
+def _receive_framed(advertised_payload, received_payload, local_md5="", advertised_md5=None):
+    transport = BytesIO()
+    writes = []
+
+    def getc(size, timeout=0.5):
+        return transport.read(size) or None
+
+    def putc(data, timeout=0.5):
+        writes.append(data)
+        return len(data)
+
+    modem = XMODEM(getc, putc, "xmodem8k")
+    if advertised_md5 is None:
+        advertised_md5 = hashlib.md5(advertised_payload).hexdigest().encode()
+    transport.write(build_frame(PTYPE_FILE_MD5, advertised_md5))
+    transport.write(build_frame(PTYPE_FILE_VIEW, (1).to_bytes(4, "big") + (8192).to_bytes(2, "big")))
+    transport.write(build_frame(PTYPE_FILE_DATA, (1).to_bytes(4, "big") + received_payload))
+    transport.seek(0)
+
+    output = BytesIO()
+    result = modem.recv(output, md5=local_md5, retry=5)
+    return result, output.getvalue(), writes, modem
+
+
+def test_legacy_accepts_matching_md5():
     payload = b"G0 X1 Y2\nM2\n"
 
-    result, output, writes = _receive(payload, payload)
+    result, output, writes, modem = _receive_legacy(payload, payload)
 
-    assert result is not None
-    assert result > 0
+    assert result is not None and result > 0
     assert output == payload
     assert writes == [CRC, ACK, ACK, ACK]
+    assert modem.deferred_download_md5 is None
 
 
-def test_recv_short_circuits_when_uppercase_local_md5_matches_block_zero():
+def test_legacy_short_circuits_when_uppercase_local_md5_matches():
     payload = b"G0 X1 Y2\nM2\n"
     local_md5 = hashlib.md5(payload).hexdigest().upper()
 
-    result, output, writes = _receive(payload, payload, local_md5=local_md5)
+    result, output, writes, modem = _receive_legacy(payload, payload, local_md5=local_md5)
 
     assert result == 0
     assert output == b""
     assert writes == [CRC, CAN, CAN, CAN]
 
 
-def test_recv_rejects_eot_when_download_does_not_match_block_zero_md5():
-    expected_payload = b"G0 X1 Y2\nG1 X3 Y4\nM2\n"
-    truncated_payload = b"G0 X1 Y2\n"
+def test_legacy_rejects_plain_md5_mismatch():
+    expected = b"G0 X1 Y2\nG1 X3 Y4\nM2\n"
+    truncated = b"G0 X1 Y2\n"
 
-    result, output, writes = _receive(expected_payload, truncated_payload)
+    result, output, writes, modem = _receive_legacy(expected, truncated)
 
     assert result is None
-    assert output == truncated_payload
-    # Transport completion remains wire-compatible even though the local
-    # artifact is rejected after its whole-file digest is checked.
+    assert output == truncated
     assert writes == [CRC, ACK, ACK, ACK]
+    assert modem.deferred_download_md5 is None
+
+
+def test_legacy_skips_check_when_advertised_md5_empty(caplog):
+    payload = b"G0 X1 Y2\nM2\n"
+
+    with caplog.at_level(logging.INFO, logger="xmodem.XMODEM"):
+        result, output, writes, modem = _receive_legacy(payload, payload, advertised_md5=b"")
+
+    assert result is not None and result > 0
+    assert output == payload
+    assert modem.deferred_download_md5 is None
+    assert any("skipped" in record.getMessage() for record in caplog.records)
+
+
+def test_legacy_defers_md5_check_for_lz_payload():
+    advertised_for = b"original uncompressed content"
+    lz_payload = b"\x00\x00" + b"compressed-bytes"
+    advertised = hashlib.md5(advertised_for).hexdigest()
+
+    result, output, writes, modem = _receive_legacy(advertised_for, lz_payload)
+
+    assert result is not None and result > 0
+    assert output == lz_payload
+    assert modem.deferred_download_md5 == advertised
+
+
+def test_framed_accepts_matching_md5():
+    payload = b"G0 X1 Y2\nM2\n"
+
+    result, output, writes, modem = _receive_framed(payload, payload)
+
+    assert result == len(payload)
+    assert output == payload
+    assert any(frame[4] == PTYPE_FILE_END for frame in writes)
+    assert modem.deferred_download_md5 is None
+
+
+def test_framed_rejects_plain_md5_mismatch():
+    expected = b"G0 X1 Y2\nG1 X3 Y4\nM2\n"
+    truncated = b"G0 X1 Y2\n"
+
+    result, output, writes, modem = _receive_framed(expected, truncated)
+
+    assert result is None
+    assert output == truncated
+    assert modem.deferred_download_md5 is None
+
+
+def test_framed_skips_check_when_advertised_md5_empty(caplog):
+    payload = b"G0 X1 Y2\nM2\n"
+
+    with caplog.at_level(logging.INFO, logger="xmodem.XMODEM"):
+        result, output, writes, modem = _receive_framed(payload, payload, advertised_md5=b"")
+
+    assert result == len(payload)
+    assert output == payload
+    assert modem.deferred_download_md5 is None
+    assert any("skipped" in record.getMessage() for record in caplog.records)
+
+
+def test_framed_defers_md5_check_for_lz_payload():
+    advertised_for = b"original uncompressed content"
+    lz_payload = b"\x00\x00" + b"compressed-bytes"
+    advertised = hashlib.md5(advertised_for).hexdigest()
+
+    result, output, writes, modem = _receive_framed(advertised_for, lz_payload)
+
+    assert result == len(lz_payload)
+    assert output == lz_payload
+    assert modem.deferred_download_md5 == advertised
+
+
+def test_framed_short_circuits_when_uppercase_local_md5_matches():
+    payload = b"G0 X1 Y2\nM2\n"
+    local_md5 = hashlib.md5(payload).hexdigest().upper()
+
+    result, output, writes, modem = _receive_framed(payload, payload, local_md5=local_md5)
+
+    assert result == 0
+    assert output == b""
+    assert len(writes) == 1
+    assert writes[0][4] == PTYPE_FILE_CAN
+
+
+def test_finalize_download_integrity_policies():
+    modem = XMODEM(lambda *_: None, lambda *_: 1, "xmodem8k")
+    received = hashlib.md5()
+    received.update(b"abc")
+
+    assert modem._finalize_download_integrity(b"", received, 3, b"abc") is True
+    assert modem.deferred_download_md5 is None
+
+    lz_received = hashlib.md5()
+    lz_received.update(b"\x00\x00data")
+    advertised = hashlib.md5(b"plain").hexdigest().encode()
+    assert modem._finalize_download_integrity(advertised, lz_received, 6, b"\x00\x00data") is True
+    assert modem.deferred_download_md5 == advertised.decode()
+
+    plain = hashlib.md5()
+    plain.update(b"plain")
+    assert modem._finalize_download_integrity(advertised, plain, 5, b"plain") is True
+    assert modem.deferred_download_md5 is None
+
+    wrong = hashlib.md5()
+    wrong.update(b"other")
+    assert modem._finalize_download_integrity(advertised, wrong, 5, b"other") is False
+    assert modem.deferred_download_md5 is None


### PR DESCRIPTION
Closes #666

## What changed

- Retain the whole-file MD5 advertised by XMODEM block zero.
- Hash each actual, unpadded payload slice as it is written.
- At EOT, keep the existing ACK behavior but reject the local artifact with `None` when the advertised digest is absent or does not match.
- Normalize hexadecimal digest comparisons so an uppercase local MD5 still takes the existing cache shortcut.
- Add deterministic tests for a matching transfer, a prematurely terminated/truncated transfer, and the uppercase-local-MD5 shortcut (`0`, empty output, three CAN writes).
- Document the integrity fix in the changelog.

## Protocol compatibility

The receiver continues to ACK EOT on the wire. The behavioral change is local: a transfer whose bytes do not match the machine-advertised MD5 is no longer reported as successful to `download_file()`.

## Validation

Pinned `develop` (`2ea66c10e96d88013a04441134d3d4f8e8c88510`) against the new tests:

```text
2 failed, 1 passed
```

The truncated-transfer assertion observes `8192` instead of `None`; the uppercase-local-MD5 test observes a completed transfer instead of the cache short-circuit.

Corrected implementation:

```text
3 passed
```

Quality checks:

```text
ruff check carveracontroller/XMODEM.py tests/unit/test_xmodem_download_integrity.py
ruff format --check carveracontroller/XMODEM.py tests/unit/test_xmodem_download_integrity.py
python -m compileall -q carveracontroller/XMODEM.py tests/unit/test_xmodem_download_integrity.py
git diff --check HEAD^ HEAD
```

## Real branch verification

The repository's locked Poetry environment was installed from `poetry.lock`. The targeted suite passed on real fork commit [`f96ceccf1615`](https://github.com/righteousgambit/Carvera_Controller/commit/f96ceccf161516a5e02c2eb995b1b7661aba644b), whose sole parent is pinned upstream `develop@2ea66c10e96d88013a04441134d3d4f8e8c88510`.

```shell
poetry run python -m pytest -q tests/unit/test_xmodem_download_integrity.py
```

Result: **3 passed**.

Quality gates on the real branch:

- Ruff `check`: **passed**
- Ruff `format --check`: **passed**
- `git diff --check 2ea66c10e96d88013a04441134d3d4f8e8c88510..f96ceccf161516a5e02c2eb995b1b7661aba644b`: **passed**