### PR TITLE
Send complete XMODEM frames over Wi-Fi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed: Ensure complete XMODEM packets are written over Wi-Fi
 - Enhancement: Add multi-select to the remote file browser
 - Enhancement: Display error message in halt popup. Requires halt errors to start with "ERROR: " in the firmware
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware

--- a/carveracontroller/WIFIStream.py
+++ b/carveracontroller/WIFIStream.py
@@ -158,7 +158,8 @@ class WIFIStream:
         return None
 
     def putc(self, data, timeout=0.5):
-        return self.socket.send(data) or None
+        self.socket.sendall(data)
+        return len(data)
 
     def upload(self, filename, local_md5, callback):
         # do upload

--- a/tests/unit/test_wifi_stream.py
+++ b/tests/unit/test_wifi_stream.py
@@ -1,5 +1,8 @@
 """Tests for WIFIStream socket write semantics."""
 
+import struct
+
+from carveracontroller.protocols.framing import PTYPE_FILE_DATA, build_frame
 from carveracontroller.WIFIStream import WIFIStream
 from carveracontroller.XMODEM import XMODEM
 
@@ -31,11 +34,16 @@ def _xmodem8k_frame():
     return bytes(modem._make_send_header(8192, 1) + framed_payload + modem._make_send_checksum(1, framed_payload))
 
 
-def test_putc_sends_the_complete_xmodem_frame_and_returns_its_length():
+def _makera_file_data_frame():
+    """Full Makera FILE_DATA frame as emitted by XMODEM.send() via putc."""
+    seq = struct.pack(">I", 1)
+    file_data = b"x" * 8192
+    return build_frame(PTYPE_FILE_DATA, seq + file_data)
+
+
+def _assert_putc_writes_complete_frame(frame):
     stream = WIFIStream.__new__(WIFIStream)
     stream.socket = DeterministicShortWriteSocket(short_write_size=2048)
-    frame = _xmodem8k_frame()
-    assert len(frame) == 8199, "fixture must model a complete xmodem8k frame"
 
     result = stream.putc(frame)
 
@@ -44,3 +52,15 @@ def test_putc_sends_the_complete_xmodem_frame_and_returns_its_length():
     assert stream.socket.send_calls == 0
     assert stream.socket.sendall_calls == 1
     assert result == len(frame)
+
+
+def test_putc_sends_the_complete_xmodem_frame_and_returns_its_length():
+    frame = _xmodem8k_frame()
+    assert len(frame) == 8199, "fixture must model a complete xmodem8k frame"
+    _assert_putc_writes_complete_frame(frame)
+
+
+def test_putc_sends_the_complete_makera_file_data_frame_and_returns_its_length():
+    frame = _makera_file_data_frame()
+    assert len(frame) == 8205, "fixture must model a complete Makera FILE_DATA frame"
+    _assert_putc_writes_complete_frame(frame)

--- a/tests/unit/test_wifi_stream.py
+++ b/tests/unit/test_wifi_stream.py
@@ -1,0 +1,46 @@
+"""Tests for WIFIStream socket write semantics."""
+
+from carveracontroller.WIFIStream import WIFIStream
+from carveracontroller.XMODEM import XMODEM
+
+
+class DeterministicShortWriteSocket:
+    """Socket double that accepts only a prefix from each ``send`` call."""
+
+    def __init__(self, short_write_size):
+        self.short_write_size = short_write_size
+        self.send_calls = 0
+        self.sendall_calls = 0
+        self.wire = bytearray()
+
+    def send(self, data):
+        self.send_calls += 1
+        accepted = min(self.short_write_size, len(data))
+        self.wire.extend(data[:accepted])
+        return accepted
+
+    def sendall(self, data):
+        self.sendall_calls += 1
+        self.wire.extend(data)
+
+
+def _xmodem8k_frame():
+    modem = XMODEM(lambda _size, _timeout=0.5: None, lambda data, _timeout=0.5: len(data))
+    payload = b"x" * 8192
+    framed_payload = bytes([len(payload) >> 8, len(payload) & 0xFF]) + payload
+    return bytes(modem._make_send_header(8192, 1) + framed_payload + modem._make_send_checksum(1, framed_payload))
+
+
+def test_putc_sends_the_complete_xmodem_frame_and_returns_its_length():
+    stream = WIFIStream.__new__(WIFIStream)
+    stream.socket = DeterministicShortWriteSocket(short_write_size=2048)
+    frame = _xmodem8k_frame()
+    assert len(frame) == 8199, "fixture must model a complete xmodem8k frame"
+
+    result = stream.putc(frame)
+
+    assert len(stream.socket.wire) == len(frame)
+    assert bytes(stream.socket.wire) == frame
+    assert stream.socket.send_calls == 0
+    assert stream.socket.sendall_calls == 1
+    assert result == len(frame)


### PR DESCRIPTION
Closes #667

## What changed

- Replace the one-shot `socket.send()` in `WIFIStream.putc()` with `socket.sendall()`.
- Return `len(data)` after `sendall()` completes, preserving the XMODEM callback's integer success contract.
- Add a deterministic regression built from a valid 8,199-byte XMODEM-8K CRC frame.
- Document the Wi-Fi transfer reliability fix in the changelog.

## Why `sendall()`

Python documents that [`socket.send()`](https://docs.python.org/3.11/library/socket.html#socket.socket.send) may send only part of the supplied data and leaves the remainder to the application. [`socket.sendall()`](https://docs.python.org/3.11/library/socket.html#socket.socket.sendall) continues until all bytes have been sent or an error occurs, which is the contract `XMODEM.send()` expects from this callback.

## Impact and compatibility

The wire format and XMODEM CRC behavior are unchanged. This closes a reliability gap that could cause retries, timeouts, or transfer failure after a partial socket write. CRC validation prevents a truncated frame from being silently accepted, so the change does not claim to fix demonstrated undetected corruption.

## Validation

Pinned `develop` (`2ea66c10e96d88013a04441134d3d4f8e8c88510`) against the new regression:

```text
F                                                                        [100%]
E       AssertionError: assert 2048 == 8199
1 failed
```

Corrected implementation:

```text
.                                                                        [100%]
1 passed
```

The passing test verifies all of the following:

- the simulated wire receives all 8,199 bytes in order;
- `send()` is never called;
- `sendall()` is called exactly once; and
- `putc()` returns `8199`.

Quality checks:

```text
ruff check carveracontroller/WIFIStream.py tests/unit/test_wifi_stream.py
ruff format --check carveracontroller/WIFIStream.py tests/unit/test_wifi_stream.py
python -m compileall -q carveracontroller/WIFIStream.py tests/unit/test_wifi_stream.py
git diff --check HEAD^ HEAD
```

## Real branch verification

The repository's locked Poetry environment was installed from `poetry.lock`. The targeted suite passed on real fork commit [`8c9bb6c8ba77`](https://github.com/righteousgambit/Carvera_Controller/commit/8c9bb6c8ba771e47e1101e23b2864001d15ea20d), whose sole parent is pinned upstream `develop@2ea66c10e96d88013a04441134d3d4f8e8c88510`.

```shell
poetry run python -m pytest -q tests/unit/test_wifi_stream.py
```

Result: **1 passed**.

Quality gates on the real branch:

- Ruff `check`: **passed**
- Ruff `format --check`: **passed**
- `git diff --check 2ea66c10e96d88013a04441134d3d4f8e8c88510..8c9bb6c8ba771e47e1101e23b2864001d15ea20d`: **passed**