### PR TITLE
Reject blank required probing axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed: Treat blank conditionally required X/Y probing inputs as missing
 - Enhancement: Add multi-select to the remote file browser
 - Enhancement: Display error message in halt popup. Requires halt errors to start with "ERROR: " in the firmware
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware

--- a/carveracontroller/addons/probing/operations/Angle/AngleOperation.py
+++ b/carveracontroller/addons/probing/operations/Angle/AngleOperation.py
@@ -32,11 +32,11 @@ class AngleOperation(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = AngleParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = AngleParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         definition = AngleParameterDefinitions.ProbeDepth
         if not definition.code in config:

--- a/carveracontroller/addons/probing/operations/Bore/BoreOperation.py
+++ b/carveracontroller/addons/probing/operations/Bore/BoreOperation.py
@@ -29,11 +29,11 @@ class BoreOperation(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = BoreParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = BoreParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
 
         required_definitions = {

--- a/carveracontroller/addons/probing/operations/Boss/BossOperation.py
+++ b/carveracontroller/addons/probing/operations/Boss/BossOperation.py
@@ -29,11 +29,11 @@ class BossOperation(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = BossParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = BossParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         required_definitions = {
             name: value

--- a/carveracontroller/addons/probing/operations/ProbeTip/ProbeTipOperation.py
+++ b/carveracontroller/addons/probing/operations/ProbeTip/ProbeTipOperation.py
@@ -34,11 +34,11 @@ class ProbeTipOperationBore(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = ProbeTipParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = ProbeTipParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
 
         required_definitions = {
@@ -75,11 +75,11 @@ class ProbeTipOperationBoss(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = ProbeTipParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = ProbeTipParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
 
         required_definitions = {
@@ -116,11 +116,11 @@ class ProbeTipOperationAnchor(OperationsBase):
     def get_missing_config(self, config: dict[str, float]):
         if self.requires_x:
             definition = ProbeTipParameterDefinitions.XAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
         if self.requires_y:
             definition = ProbeTipParameterDefinitions.YAxisDistance
-            if not definition.code in config:
+            if definition.code not in config or not config[definition.code].strip():
                 return definition
 
         required_definitions = {

--- a/tests/unit/test_probing_required_axes.py
+++ b/tests/unit/test_probing_required_axes.py
@@ -1,0 +1,79 @@
+"""Tests for conditionally required probing axes."""
+
+import pytest
+
+from carveracontroller.addons.probing.operations.Angle.AngleOperation import AngleOperation
+from carveracontroller.addons.probing.operations.Angle.AngleParameterDefinitions import AngleParameterDefinitions
+from carveracontroller.addons.probing.operations.Bore.BoreOperation import BoreOperation
+from carveracontroller.addons.probing.operations.Bore.BoreParameterDefinitions import BoreParameterDefinitions
+from carveracontroller.addons.probing.operations.Boss.BossOperation import BossOperation
+from carveracontroller.addons.probing.operations.Boss.BossParameterDefinitions import BossParameterDefinitions
+from carveracontroller.addons.probing.operations.ProbeTip.ProbeTipOperation import (
+    ProbeTipOperationAnchor,
+    ProbeTipOperationBore,
+    ProbeTipOperationBoss,
+)
+from carveracontroller.addons.probing.operations.ProbeTip.ProbeTipParameterDefinitions import (
+    ProbeTipParameterDefinitions,
+)
+
+OPERATION_TYPES = (
+    (BoreOperation, ("",), BoreParameterDefinitions),
+    (BossOperation, ("",), BossParameterDefinitions),
+    (AngleOperation, (False, ""), AngleParameterDefinitions),
+    (ProbeTipOperationBore, (False, ""), ProbeTipParameterDefinitions),
+    (ProbeTipOperationBoss, (False, ""), ProbeTipParameterDefinitions),
+    (ProbeTipOperationAnchor, (False, ""), ProbeTipParameterDefinitions),
+)
+
+
+@pytest.mark.parametrize("blank_value", ["", "   "])
+@pytest.mark.parametrize(("operation_type", "extra_args", "definitions"), OPERATION_TYPES)
+@pytest.mark.parametrize(
+    ("requires_x", "requires_y", "axis_name"),
+    [
+        (True, False, "XAxisDistance"),
+        (False, True, "YAxisDistance"),
+    ],
+)
+def test_conditionally_required_axis_rejects_blank_value(
+    operation_type,
+    extra_args,
+    definitions,
+    requires_x,
+    requires_y,
+    axis_name,
+    blank_value,
+):
+    operation = operation_type("Test", requires_x, requires_y, *extra_args)
+    definition = getattr(definitions, axis_name)
+
+    missing = operation.get_missing_config({definition.code: blank_value})
+
+    assert missing is definition
+
+
+@pytest.mark.parametrize("configured_value", ["0", "12.5"])
+@pytest.mark.parametrize(("operation_type", "extra_args", "definitions"), OPERATION_TYPES)
+@pytest.mark.parametrize(
+    ("requires_x", "requires_y", "axis_name"),
+    [
+        (True, False, "XAxisDistance"),
+        (False, True, "YAxisDistance"),
+    ],
+)
+def test_conditionally_required_axis_accepts_numeric_string(
+    operation_type,
+    extra_args,
+    definitions,
+    requires_x,
+    requires_y,
+    axis_name,
+    configured_value,
+):
+    operation = operation_type("Test", requires_x, requires_y, *extra_args)
+    definition = getattr(definitions, axis_name)
+
+    missing = operation.get_missing_config({definition.code: configured_value})
+
+    assert missing is not definition


### PR DESCRIPTION
Closes #671

## Summary

- treat empty and whitespace-only X/Y values as missing when the selected operation conditionally requires that axis
- update Bore, Boss, Angle, and the three ProbeTip operation variants consistently
- retain valid numeric strings, including `"0"`
- add a matrix regression test and an unreleased changelog entry

This does not change which operations require which axes; it only makes the existing requirement check agree with the G-code formatter's treatment of blank values.

## Validation

Validated against `develop@2ea66c10e96d88013a04441134d3d4f8e8c88510` with Python 3.11:

- regression suite on the base: **24 failed, 24 passed** (every blank/whitespace case failed; every numeric-string control passed)
- regression suite with this change: **48 passed**
- `ruff check` passed for all changed Python files
- `git diff --check` passed

Targeted command:

```shell
poetry run python -m pytest -q tests/unit/test_probing_required_axes.py
```

## Changelog

`- Fixed: Treat blank conditionally required X/Y probing inputs as missing`

## Real branch verification

The repository's locked Poetry environment was installed from `poetry.lock`. The targeted suite passed on real fork commit [`74f380c9de46`](https://github.com/righteousgambit/Carvera_Controller/commit/74f380c9de466cc317653de86a361ffc0261f236), whose sole parent is pinned upstream `develop@2ea66c10e96d88013a04441134d3d4f8e8c88510`.

```shell
poetry run python -m pytest -q tests/unit/test_probing_required_axes.py
```

Result: **48 passed**.

Quality gates on the real branch:

- Ruff `check`: **passed**
- Ruff `format --check`: **passed**
- `git diff --check 2ea66c10e96d88013a04441134d3d4f8e8c88510..74f380c9de466cc317653de86a361ffc0261f236`: **passed**