### PR TITLE
Usb reset warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,18 @@
+[unreleased]
 - Enhancement: Add multi-select to the remote file browser
 - Enhancement: Display error message in halt popup. Requires halt errors to start with "ERROR: " in the firmware
 - Enhancement: Add popup notice when using stock firmware instead of the Community Firmware
 - Enhancement: Improvements to saving changes in settings menu
 - Enhancement: Add syntax highlighting to the file viewer
-- Enhancement: Only re-render the G-Code viewer scene if something has changed
+- Enhancement: Only re-render the gcode viewer scene if something has changed
 - Enhancement: Add Facing wizard
 - Enhancement: Support gamepads as pendants
 - Enhancement: Added iPhone support
-- Enhancement: Improve Gcode viewer toolbar buttons layout
+- Enhancement: Improved gcode viewer toolbar buttons layout
 - Enhancement: Show current config probe tip diameter in probing panels
 - Enhancement: Add Probe Scan tool
 - Enhancement: Show tool change markers on the playback progress bar
-- Enhancement: Add grid visualization, ortho projection, view cube and color schemes selector to the G-Code viewer
+- Enhancement: Add grid visualization, ortho projection, view cube and color schemes selector to the gcode viewer
 - Enhancement: Detect WHB04 pendant permission errors instead of silently ignoring pendant
 - Enhancement: New M469.6 4th Axis calibration routine finds the true 4th axis center now replaces the previous M469.4 4th axis head stock calibration
 - Enhancement: Advanced TLO Calibration option. Here you can set the offset to use from tool setter, and/or the number of repeat probings to use
@@ -35,7 +36,7 @@
 - Fixed: Fix potential crashes due to an undefined FuncSetting key"
 - Fixed: Fix incorrect "No Pendant" in UI when pendant is working
 - Fixed: Fix invalid initial coordinates when resuming in the middle of a modal command
-- Fixed: 3D Visualisation of GCode movement would always show the initial movement as originating from the WCS Origin, this doesn't match reality. Now the Visualisation correctly shows the line as originating from above the first movement command at the configured clearance_z (default of MCS Z-3)
+- Fixed: 3D Visualisation of gcode movement would always show the initial movement as originating from the WCS Origin, this doesn't match reality. Now the Visualisation correctly shows the line as originating from above the first movement command at the configured clearance_z (default of MCS Z-3)
 - Fixed: When a USB connection was lost, the popup had a non-functioning reconnect button
 - Fixed: When connecting over USB the UI thread would freeze while it was opening the device
 - Fixed: USB higher-baud upgrade failed on Makera protocol (trailing newline in framed commands, race with config download, host baud switch). Upgrade now runs after config sync and verifies the link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Enhancement: Add a "Network..." option under Scan Wi-Fi in the connection dropdown to enter a machine network address
 - Enhancement: Reconnect supports USB as well as WiFi. Configure preferred method for app-launch auto-connect
 - Enhancement: added green question mark help buttons to the UI that link to the relevant documentation page
+- Enhancement: Block sending the `reset` command over USB and show a popup directing the user to use the power switch instead
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Repeated firmware checks now happen just once
 - Fixed: UI widget updates from the SerialMonitor() now dispatched via the main thread. This should reduce the number of RecycleView related crashes

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -237,6 +237,10 @@ class Controller:
             try:
                 if isinstance(line, str) and not line.endswith("\n"):
                     line += "\n"
+                # Soft `reset` over USB leaves the board powered (zombie state).
+                if isinstance(line, str) and self.connection_type == CONN_USB and line.lower().startswith("reset"):
+                    self._notify_usb_reset_blocked()
+                    return
                 payload = line.encode() if isinstance(line, str) else line
                 self.stream.send(self.comms.encode_command(payload))
                 if self.execCallback:
@@ -249,6 +253,16 @@ class Controller:
                     self.execCallback(new_line)
             except Exception:
                 self.log.put((Controller.MSG_ERROR, str(sys.exc_info()[1])))
+
+    def _notify_usb_reset_blocked(self):
+        if App is None or Clock is None:
+            return
+        app = App.get_running_app()
+        if app is None or getattr(app, "root", None) is None:
+            return
+        root = app.root
+        if hasattr(root, "show_usb_reset_blocked_popup"):
+            Clock.schedule_once(lambda dt: root.show_usb_reset_blocked_popup(), 0)
 
     def executeRealtime(self, char):
         """Send a single-byte realtime control through the active protocol."""

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5290,6 +5290,34 @@ class Makera(RelativeLayout):
         self.message_popup.btn_ok.disabled = btn_disabled
         self.message_popup.open()
 
+    def show_usb_reset_blocked_popup(self, *args):
+        content = BoxLayout(orientation="vertical", padding=dp(15))
+        lbl = Label(
+            text=tr._(
+                "As you are connected by USB, please use the power switch on the machine "
+                "to perform a reset.\n\n"
+                "The Makera control board design allows for the machine to "
+                "receive power over USB, which results in the machine being left in a "
+                "zombie-like state if a reset command is sent."
+            ),
+            halign="center",
+            valign="middle",
+        )
+        lbl.bind(size=lambda inst, val: setattr(inst, "text_size", val))
+        content.add_widget(lbl)
+        btns = BoxLayout(size_hint_y=0.35)
+        popup = Popup(
+            title=tr._("Cannot Reset Over USB"),
+            content=content,
+            size_hint=(0.55, 0.45),
+            auto_dismiss=False,
+        )
+        btn_ok = Button(text=tr._("Ok"))
+        btn_ok.bind(on_release=lambda *a: popup.dismiss())
+        btns.add_widget(btn_ok)
+        content.add_widget(btns)
+        popup.open()
+
     # -----------------------------------------------------------------------
     def compress_file(self, input_filename):
         try:


### PR DESCRIPTION
Block sending the `reset` command over USB and show a popup directing the user to use the power switch instead.

This UI is shown:

<img width="506" height="358" alt="Screenshot 2026-07-19 at 7 14 34 pm" src="https://github.com/user-attachments/assets/57484847-a04b-4cc9-b620-3c124dd881d8" />

Also cleans up changelog