### PR TITLE
Unlock Control Buttons while Running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Change: Reconnect uses the last successful connection method. On fresh app launch it uses the configured preferred connection method
 - Change: USB devices in connection dropdown are filtered to only show devices specifically with the FTDI chip found on the Makera machines
 - Change: USB devices are now selected and stored by stable VID:PID:serial identity (instead of generic COM path)
+- Change: Machine Light, and Ext. Control buttons now usable while machine is in Run, Tool or Paused states
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3759,12 +3759,12 @@
                                         tooltip_radius: 30 
                                 GridBoxLayout:
                         BoxLayout:
-                            disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
                             orientation: 'vertical'
                             padding: '10dp'
                             Widget:
                                 size_hint_y: 0.15
                             BoxLayout:
+                                disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
                                 orientation: 'vertical'
                                 padding: '3dp'
                                 size_hint_y: 0.3
@@ -3807,7 +3807,9 @@
                             Widget:
                                 size_hint_y: 0.15
                             BoxLayout:
-                                disabled: app.state != 'Idle'
+                                # Enabled for Idle/Run/Tool/Pause so Light & Ext. Control stay usable mid-job.
+                                # Other buttons below keep their own Idle-only disabled rules.
+                                disabled: app.state != 'Idle' and app.state != 'Run' and app.state != 'Tool' and app.state != 'Pause'
                                 orientation: 'vertical'
                                 padding: '3dp'
                                 size_hint_min_y: '176dp'  # 35dp button x4 + 10dp spacing between buttons x 3 + 3dp padding top + 3dp padding bottom
@@ -3827,14 +3829,17 @@
                                         spacing: dp(3)
                                         GridBoxLayout:
                                             SmallRoundButton:
+                                                disabled: app.state != 'Idle'
                                                 text: tr._('Unlock')
                                                 on_release: root.controller.unlock()
                                         GridBoxLayout:
                                             SmallRoundButton:
+                                                disabled: app.state != 'Idle'
                                                 text: tr._('Reset')
                                                 on_release: root.controller.reset()
                                         GridBoxLayout:
                                             SmallRoundButton:
+                                                disabled: app.state != 'Idle'
                                                 text: tr._('Home')
                                                 on_release: root.controller.home()
                                         GridBoxLayout:
@@ -3874,6 +3879,7 @@
                                             Spinner:
                                                 center: 0.5, 0.5
                                                 height: '35dp'
+                                                disabled: app.state != 'Idle'
                                                 text: tr._('Goto...')
                                                 values: 'Clearance', 'Work Origin', 'Path Origin', 'Anchor1', 'Anchor2'
                                                 on_text:
@@ -3881,11 +3887,12 @@
                                                     if self.text != tr._("Goto..."): self.text = tr._('Goto...')
                                         GridBoxLayout:
                                             SmallRoundButton:
+                                                disabled: app.state != 'Idle'
                                                 text: tr._('Set Origin')
                                                 on_release: root.coord_popup.origin_popup.open()
                                         GridBoxLayout:
                                             SmallRoundButton:
-                                                disabled: not app.is_community_firmware
+                                                disabled: not app.is_community_firmware or app.state != 'Idle'
                                                 text: tr._('Probing...')
                                                 on_release: app.root.open_probing_popup()
 
@@ -3918,6 +3925,7 @@
                             Widget:
                                 size_hint_y: 0.1
                             BoxLayout:
+                                disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
                                 orientation: 'vertical'
                                 padding: '3dp'
                                 size_hint_y: 0.5


### PR DESCRIPTION
Change: Machine Light, and Ext. Control buttons now usable while machine is in Run, Tool or Paused states

<img width="1062" height="688" alt="Screenshot 2026-07-20 at 5 36 42 pm" src="https://github.com/user-attachments/assets/1d49b1fc-a213-4de0-8f15-816e86dfbfbb" />
