### PR TITLE
Improve controller text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Change: USB devices in connection dropdown are filtered to only show devices specifically with the FTDI chip found on the Makera machines
 - Change: USB devices are now selected and stored by stable VID:PID:serial identity (instead of generic COM path)
 - Change: Machine Light, and Ext. Control buttons now usable while machine is in Run, Tool or Paused states
+- Change: Text properly fits into popup boxes based on actual box size
 
 [2.1.0]
 - Enhancement: Add right-click menu option to clear resume-at-line setting

--- a/carveracontroller/addons/facing/FacingWizardPopup.py
+++ b/carveracontroller/addons/facing/FacingWizardPopup.py
@@ -249,18 +249,17 @@ class FacingWizardPopup(ModalView):
             return
         list_h = min(dp(280), max(dp(120), len(names) * dp(46)))
         outer = BoxLayout(orientation="vertical", padding=dp(12), spacing=dp(8))
-        outer.add_widget(
-            Label(
-                text=tr._("Tap a preset to load."),
-                size_hint_y=None,
-                height=dp(32),
-                font_size=dp(12),
-                color=(0.75, 0.76, 0.8, 1),
-                text_size=(root.width * 0.5, None),
-                halign="left",
-                valign="top",
-            )
+        lbl = Label(
+            text=tr._("Tap a preset to load."),
+            size_hint_y=None,
+            height=dp(32),
+            font_size=dp(12),
+            color=(0.75, 0.76, 0.8, 1),
+            halign="left",
+            valign="top",
         )
+        lbl.bind(size=lambda inst, val: setattr(inst, "text_size", val))
+        outer.add_widget(lbl)
         scroll = ScrollView(
             size_hint_y=None,
             height=list_h,
@@ -313,18 +312,17 @@ class FacingWizardPopup(ModalView):
             return
         list_h = min(dp(280), max(dp(120), len(names) * dp(46)))
         outer = BoxLayout(orientation="vertical", padding=dp(12), spacing=dp(8))
-        outer.add_widget(
-            Label(
-                text=tr._("Tap a preset to delete."),
-                size_hint_y=None,
-                height=dp(32),
-                font_size=dp(12),
-                color=(0.75, 0.76, 0.8, 1),
-                text_size=(root.width * 0.5, None),
-                halign="left",
-                valign="top",
-            )
+        lbl = Label(
+            text=tr._("Tap a preset to delete."),
+            size_hint_y=None,
+            height=dp(32),
+            font_size=dp(12),
+            color=(0.75, 0.76, 0.8, 1),
+            halign="left",
+            valign="top",
         )
+        lbl.bind(size=lambda inst, val: setattr(inst, "text_size", val))
+        outer.add_widget(lbl)
         scroll = ScrollView(
             size_hint_y=None,
             height=list_h,

--- a/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
+++ b/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
@@ -18,6 +18,9 @@
                     id: lb_title
                     text: root.title
                     bold: True
+                    halign: 'center'
+                    valign: 'middle'
+                    text_size: self.size
                 Label:
                     id: lb_preview
                     text: root.probe_preview_label

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5294,11 +5294,11 @@ class Makera(RelativeLayout):
         content = BoxLayout(orientation="vertical", padding=dp(15))
         lbl = Label(
             text=tr._(
-                "As you are connected by USB, please use the power switch on the machine "
+                "As you are connected over USB, please disconnect the USB cable, then use the power switch on the machine "
                 "to perform a reset.\n\n"
-                "The Makera control board design allows for the machine to "
-                "receive power over USB, which results in the machine being left in a "
-                "zombie-like state if a reset command is sent."
+                "The Makera control board design allows the machine to "
+                "receive power over USB, which results in it being left in a "
+                "zombie-like state if a reset command is sent using the Controller."
             ),
             halign="center",
             valign="middle",

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1343,6 +1343,9 @@
             size_hint_y: 0.4
             text: tr._('Select Language')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             orientation: 'vertical'
             Label:
@@ -1375,6 +1378,9 @@
             id: lb_title
             text: tr._('Input Box')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             orientation: 'vertical'
             Label:
@@ -1412,6 +1418,9 @@
             id: lb_title1
             text: tr._('Input Box')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             orientation: 'vertical'
             Label:
@@ -1427,6 +1436,9 @@
             id: lb_title2
             text: tr._('Input Box')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             orientation: 'vertical'
             Label:
@@ -1462,9 +1474,15 @@
             id: lb_title
             text: tr._('Confirm Box')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         Label:
             id: lb_content
             text: tr._('Confirm to continue?')
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: 0.4
             Button:
@@ -1493,9 +1511,15 @@
             id: lb_title
             text: tr._('Machine Is Halted')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         Label:
             id: lb_content
             text: tr._('Choose unlock option:')
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: 0.4
             Button:
@@ -1534,6 +1558,9 @@
             id: lb_title
             text: tr._('A probing tool needs to be selected to locate your workpiece')
             bold: True
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: 0.4
             Button:
@@ -1564,6 +1591,9 @@
         Label:
             id: lb_content
             text: tr._('Confirm to continue?')
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             id: btn_ok
             size_hint_y: 0.4
@@ -1582,6 +1612,9 @@
         Label:
             id: lb_content
             text: tr._('Connection lost. Attempting to reconnect...')
+            halign: 'center'
+            valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: 0.4
             spacing: '10dp'
@@ -1608,6 +1641,8 @@
             id: progress_label
             text: root.progress_text
             halign: 'center'
+            valign: 'middle'
+            text_size: self.size
 
         ProgressBar:
             id: progress_bar
@@ -1833,6 +1868,7 @@
             text: tr._('Z Probe Config')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: None
             height: '50dp'
@@ -1916,6 +1952,7 @@
             text: tr._('XYZ Probe At Current Position')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: None
             height: '25dp'
@@ -1991,6 +2028,7 @@
             text: tr._('Pairing Wireless Probe')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         BoxLayout:
             size_hint_y: None
             height: '25dp'
@@ -2055,6 +2093,7 @@
             text: tr._('Auto Leveling Config')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         Label:
             size_hint_y: None
             height: '10dp'
@@ -4599,6 +4638,7 @@
             text: tr._('WCS Settings')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         
         ScrollView:
             GridLayout:
@@ -5493,6 +5533,7 @@
             text: tr._('Set Rotation')
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         
         BoxLayout:
             padding: '15dp'

--- a/carveracontroller/ui/popups/set_position/set_position.kv
+++ b/carveracontroller/ui/popups/set_position/set_position.kv
@@ -22,6 +22,7 @@
             text: root.title
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         BoxLayout:
             padding: '15dp'
             orientation: 'vertical'
@@ -77,6 +78,7 @@
             text: root.title
             halign: 'left'
             valign: 'middle'
+            text_size: self.size
         BoxLayout:
             padding: '15dp'
             orientation: 'vertical'


### PR DESCRIPTION
Change: Text properly fits into popup boxes based on actual box size

Before:

<img width="1013" height="559" alt="Screenshot 2026-07-20 at 6 09 24 pm" src="https://github.com/user-attachments/assets/8cf732ed-d667-406d-b854-65f01f10dc8d" />

After:
<img width="477" height="263" alt="Screenshot 2026-07-20 at 6 05 55 pm" src="https://github.com/user-attachments/assets/033fc91c-cec9-4e91-929f-5c3c2a193be2" />



Also better usb-reset text:
<img width="589" height="267" alt="Screenshot 2026-07-20 at 6 11 07 pm" src="https://github.com/user-attachments/assets/c04704d5-23b5-4386-ae90-5c39c4b7fe60" />
