### PR TITLE
Warnings for missing key state when resuming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Enhancement: added green question mark help buttons to the UI that link to the relevant documentation page
 - Enhancement: Block sending the `reset` command over USB and show a popup directing the user to use the power switch instead
 - Enhancement: Initial Z1 support
+- Enhancement: Resume-at-line warns when the recovery sequence is missing a tool change, feed rate, or spindle speed
 - Fixed: Restore Keyboard Jogging state after Probing Popup is closed
 - Fixed: Confirmation dialogs no longer retain expanded layouts from laser and resume warnings
 - Fixed: Repeated firmware checks now happen just once
@@ -55,6 +56,7 @@
 - Fixed: Resume-at-line no longer treats the non-modal G53 command as the active work coordinate system
 - Fixed: Reject downloads whose content does not match the machine-provided MD5. Skip MD5 check when none is available, and defer .lz checks until after decompress
 - Fixed: Ensure complete XMODEM packets are written over Wi-Fi
+- Fixed: Confirm popup content now scrolls and sizes to its text
 - Change: Misleading "Download canceled by Controller!" MDI message is suppressed, in logs a message is recorded that cached version of the config.txt was used
 - Change: Remove remaining "Can not load config, Key:" messages from the MDI
 - Change: Resume playback will now use gcode loaded in the controller instead of cached local file

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -1047,6 +1047,29 @@ class Controller:
                 return True
         return False
 
+    def resume_playback_warnings(self, commands):
+        """
+        Inspect resume-at-line command preview and return missing-state warning keys.
+
+        Returns a list that may include:
+          - "tool_change": no M6 tool change in the recovery sequence
+          - "feed": no G1 F feed rate restored
+          - "spindle_speed": no M3 S spindle speed restored (skipped for laser/M321)
+        """
+        if not commands:
+            return ["tool_change", "feed", "spindle_speed"]
+
+        joined = "\n".join(commands).upper()
+        warnings = []
+        if not re.search(r"\bM0*6\b", joined):
+            warnings.append("tool_change")
+        if not re.search(r"\bG0*1\s+F\d", joined):
+            warnings.append("feed")
+        # Laser mode does not use spindle S recovery
+        if not re.search(r"\bM321\b", joined) and not re.search(r"\bM0*3\s+S\d", joined):
+            warnings.append("spindle_speed")
+        return warnings
+
     def playStartLineCommand(self, filename, start_line, preview=False, lines=None, has_ocodes=False):
         # Build the play command with proper formatting
         flag = " -O" if has_ocodes else ""

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -442,6 +442,9 @@ class BoxStencil(BoxLayout, StencilView):
 
 class ConfirmPopup(ModalView):
     showing = False
+    content_scroll = ObjectProperty(None)
+    lb_title = ObjectProperty(None)
+    lb_content = ObjectProperty(None)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -449,15 +452,29 @@ class ConfirmPopup(ModalView):
         self._default_size_hint = tuple(self.size_hint)
         self._default_pos_hint = dict(self.pos_hint)
         self._default_title_size_hint_y = self.lb_title.size_hint_y
+        self._default_content_halign = self.lb_content.halign
 
-    def on_open(self):
-        self.showing = True
+    def dismiss(self, *largs, **kwargs):
+        # Instant dismiss so layout defaults restore before the next open.
+        kwargs.setdefault("animation", False)
+        return super().dismiss(*largs, **kwargs)
 
-    def on_dismiss(self):
-        self.showing = False
+    def reset_layout_defaults(self):
         self.size_hint = self._default_size_hint
         self.pos_hint = dict(self._default_pos_hint)
         self.lb_title.size_hint_y = self._default_title_size_hint_y
+        self.lb_content.halign = self._default_content_halign
+        if self.content_scroll is not None:
+            self.content_scroll.scroll_y = 1
+
+    def on_open(self):
+        self.showing = True
+        if self.content_scroll is not None:
+            self.content_scroll.scroll_y = 1
+
+    def on_dismiss(self):
+        self.showing = False
+        self.reset_layout_defaults()
 
 
 class UnlockPopup(ModalView):
@@ -7120,6 +7137,22 @@ class Makera(RelativeLayout):
             False,
         )
 
+    def _resume_playback_warning_text(self, warning_keys):
+        """Build translated warning text for missing resume recovery state."""
+        messages = {
+            "tool_change": tr._("- No tool change (M6)"),
+            "feed": tr._("- No feed rate (F)"),
+            "spindle_speed": tr._("- No spindle speed (M3 S...)"),
+        }
+        lines = [messages[key] for key in warning_keys if key in messages]
+        if not lines:
+            return ""
+        return (
+            tr._("WARNING: The resume recovery sequence was unable to find important state prior to the resume line:\n")
+            + "\n".join(lines)
+            + "\n"
+        )
+
     def open_resume_playback_confirm_popup(self, file_name, start_line):
         if self.confirm_popup.showing:
             return
@@ -7136,13 +7169,17 @@ class Makera(RelativeLayout):
             self.show_message_popup(tr._(f"Resume-at-line cannot run:\n\n{e}"), False)
             return
         commands_preview = "\n".join(commands)
+        warning_text = self._resume_playback_warning_text(self.controller.resume_playback_warnings(commands))
 
         self.confirm_popup.size_hint = (0.8, 0.8)
         self.confirm_popup.pos_hint = {"center_x": 0.5, "center_y": 0.5}
-        self.confirm_popup.lb_title.text = tr._("Beta Feature: Resume Playback")
+        self.confirm_popup.lb_title.text = tr._("Resume Playback")
+        self.confirm_popup.lb_title.size_hint_y = None
+        self.confirm_popup.lb_content.halign = "left"
         self.confirm_popup.lb_content.text = (
-            tr._(
-                'The "resume playback at line" functionality is beta. Please be prepared to e-stop your machine if it doesn\'t move correctly.\n\nCommands that will be executed:\n'
+            warning_text
+            + tr._(
+                "The Controller will run the below commands to restart this file. Please be prepared to e-stop your machine if it doesn't move as expected.\n\n"
             )
             + commands_preview
         )

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -1463,28 +1463,41 @@
 <ConfirmPopup>:
     lb_title: lb_title
     lb_content: lb_content
+    content_scroll: content_scroll
     size_hint: 0.5, 0.4
     pos_hint: {"right": 0.75, "top": 0.7}
     auto_dismiss: False
     BoxLayout:
         padding: '15dp'
+        spacing: '8dp'
         orientation: 'vertical'
         Label:
-            size_hint_y: 0.4
+            size_hint_y: None
+            height: self.texture_size[1]
             id: lb_title
             text: tr._('Confirm Box')
             bold: True
             halign: 'center'
             valign: 'middle'
-            text_size: self.size
-        Label:
-            id: lb_content
-            text: tr._('Confirm to continue?')
-            halign: 'center'
-            valign: 'middle'
-            text_size: self.size
+            text_size: self.width, None
+        ScrollView:
+            id: content_scroll
+            do_scroll_x: False
+            bar_width: '10dp'
+            scroll_type: ['bars', 'content']
+            bar_inactive_color: 0.5, 0.5, 0.5, 0.5
+            Label:
+                id: lb_content
+                size_hint_y: None
+                # Fill the viewport when short so valign can center; grow and scroll when long.
+                height: max(self.texture_size[1], self.parent.height) if self.parent else self.texture_size[1]
+                text: tr._('Confirm to continue?')
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
         BoxLayout:
-            size_hint_y: 0.4
+            size_hint_y: None
+            height: '48dp'
             Button:
                 text: tr._('Cancel')
                 on_release:


### PR DESCRIPTION
To guard against something like https://github.com/Carvera-Community/Carvera_Controller/issues/528 re-occuring, this adds warnings to the top of the resume gcode preview if it's not able to find:
* current tool
* feed
* speed

It also adds scroll bars to the ConfirmPopup if the text can't fit into the popup:

<img width="875" height="603" alt="Screenshot 2026-07-25 at 6 42 24 pm" src="https://github.com/user-attachments/assets/0a05597d-65ec-4564-a48f-a53255156e1f" />

<img width="714" height="471" alt="Screenshot 2026-07-25 at 6 42 43 pm" src="https://github.com/user-attachments/assets/4cbb149d-d4e0-4136-a902-c642c4fc4e9a" />
