### PR TITLE
Probing: Fix a crash if E is not provided when probing an angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[unreleased]
+Fixed: Prevent a probing modal crash if E is not provided when using the angle operation
+
 [2.2.0-RC1]
 - Enhancement: Read tool definitions from post-processor outputs and use them in the G-code viewer
 - Enhancement: Add multi-select to the remote file browser

--- a/carveracontroller/addons/probing/operations/Angle/AngleOperation.py
+++ b/carveracontroller/addons/probing/operations/Angle/AngleOperation.py
@@ -25,7 +25,12 @@ class AngleOperation(OperationsBase):
         if self.requires_y:
             config[AngleParameterDefinitions.XAxisDistance.code] = ""
 
-        super().apply_direction(AngleParameterDefinitions.ProbeDepth.code, config, self.invert_direction)
+        # Make sure the probe depth is set to the default value if it is not set.
+        depth = AngleParameterDefinitions.ProbeDepth
+        if not str(config.get(depth.code, "")).strip():
+            config[depth.code] = depth.default
+
+        super().apply_direction(depth.code, config, self.invert_direction)
 
         return "M465" + self.config_to_gcode(config)
 
@@ -38,9 +43,6 @@ class AngleOperation(OperationsBase):
             definition = AngleParameterDefinitions.YAxisDistance
             if definition.code not in config or not config[definition.code].strip():
                 return definition
-        definition = AngleParameterDefinitions.ProbeDepth
-        if not definition.code in config:
-            return definition
 
         required_definitions = {
             name: value

--- a/carveracontroller/addons/probing/operations/Angle/AngleParameterDefinitions.py
+++ b/carveracontroller/addons/probing/operations/Angle/AngleParameterDefinitions.py
@@ -54,6 +54,7 @@ class AngleParameterDefinitions:
         "Probe Depth",
         False,
         "how far below the top surface of the model to move down in order to probe on each side",
+        "2",
     )
 
     UseProbeNormallyClosed = ProbeSettingDefinition("I", "NC", False, "Probe is normally closed")

--- a/carveracontroller/addons/probing/operations/Angle/AngleSettings.kv
+++ b/carveracontroller/addons/probing/operations/Angle/AngleSettings.kv
@@ -57,7 +57,7 @@
                     id: ProbeDepth
                     size_hint_x: 0.4
                     font_size: '14dp'
-                    hint_text: tr._("0")
+                    hint_text: tr._("2")
 					hint_text_color: (0.2,0.5,0.5,0.5)
                     tooltip_txt: tr._('Distance along secondary axis to probe')
                     tooltip_image: ''

--- a/carveracontroller/addons/probing/operations/OperationsBase.py
+++ b/carveracontroller/addons/probing/operations/OperationsBase.py
@@ -22,9 +22,18 @@ class OperationsBase:
         return None
 
     def apply_direction(self, key, config: dict[str, float], is_opposite: bool):
-        if key in config and is_opposite:
-            # print(key + " in config and is_opposite " + str(is_opposite))
-            config[key] = str(float(config[key]) * -1)
+        if not is_opposite or key not in config:
+            return
+
+        raw = config[key]
+        if raw is None or not str(raw).strip():
+            return
+
+        try:
+            config[key] = str(float(raw) * -1)
+        except (TypeError, ValueError):
+            # Leave non-numeric values untouched; callers may still surface them via validation.
+            return
 
     @abstractmethod
     def get_missing_config(self, config: dict[str, float]):

--- a/tests/unit/test_probing_apply_direction.py
+++ b/tests/unit/test_probing_apply_direction.py
@@ -1,0 +1,108 @@
+"""Tests for OperationsBase.apply_direction and callers that invert axis values."""
+
+import pytest
+
+from carveracontroller.addons.probing.operations.Angle.AngleOperation import AngleOperation
+from carveracontroller.addons.probing.operations.Angle.AngleParameterDefinitions import AngleParameterDefinitions
+from carveracontroller.addons.probing.operations.OperationsBase import OperationsBase
+
+
+class _DirectionOp(OperationsBase):
+    def generate(self, config):
+        return ""
+
+    def get_missing_config(self, config):
+        return None
+
+
+@pytest.mark.parametrize("key", ["X", "Y", "Z", "E"])
+@pytest.mark.parametrize("blank_value", ["", "   "])
+def test_apply_direction_skips_blank_values(key, blank_value):
+    op = _DirectionOp("test")
+    config = {key: blank_value}
+
+    op.apply_direction(key, config, True)
+
+    assert config[key] == blank_value
+
+
+@pytest.mark.parametrize("key", ["X", "Y", "Z", "E"])
+def test_apply_direction_negates_numeric_string(key):
+    op = _DirectionOp("test")
+    config = {key: "2.5"}
+
+    op.apply_direction(key, config, True)
+
+    assert config[key] == "-2.5"
+
+
+@pytest.mark.parametrize("key", ["X", "Y", "Z", "E"])
+def test_apply_direction_leaves_value_when_not_opposite(key):
+    op = _DirectionOp("test")
+    config = {key: "2.5"}
+
+    op.apply_direction(key, config, False)
+
+    assert config[key] == "2.5"
+
+
+def test_apply_direction_skips_missing_key():
+    op = _DirectionOp("test")
+    config = {"X": "2.5"}
+
+    op.apply_direction("Y", config, True)
+
+    assert config == {"X": "2.5"}
+
+
+def test_apply_direction_skips_non_numeric_value():
+    op = _DirectionOp("test")
+    config = {"X": "abc"}
+
+    op.apply_direction("X", config, True)
+
+    assert config["X"] == "abc"
+
+
+@pytest.mark.parametrize("blank_value", ["", "   "])
+def test_angle_generate_uses_negated_default_when_inverted_and_blank(blank_value):
+    op = AngleOperation("Angle - X Above", True, False, True, "")
+    inverted = AngleParameterDefinitions.ProbeDepth
+    config = {
+        AngleParameterDefinitions.XAxisDistance.code: "10",
+        inverted.code: blank_value,
+    }
+
+    assert op.get_missing_config(config) is None
+    gcode = op.generate(config)
+
+    assert gcode.startswith("M465")
+    assert f"{inverted.code}-2.0" in gcode
+
+
+@pytest.mark.parametrize("blank_value", ["", "   "])
+def test_angle_generate_uses_default_when_not_inverted_and_blank(blank_value):
+    op = AngleOperation("Angle - X Below", True, False, False, "")
+    depth = AngleParameterDefinitions.ProbeDepth
+    config = {
+        AngleParameterDefinitions.XAxisDistance.code: "10",
+        depth.code: blank_value,
+    }
+
+    gcode = op.generate(config)
+
+    assert gcode.startswith("M465")
+    assert f"{depth.code}2" in gcode
+
+
+def test_angle_generate_negates_inverted_value():
+    op = AngleOperation("Angle - X Above", True, False, True, "")
+    inverted = AngleParameterDefinitions.ProbeDepth
+    config = {
+        AngleParameterDefinitions.XAxisDistance.code: "10",
+        inverted.code: "3",
+    }
+
+    gcode = op.generate(config)
+
+    assert f"{inverted.code}-3.0" in gcode


### PR DESCRIPTION
The following crash was reported on Discord when using the probing modal:

```
[INFO   ] [Base        ] Leaving application in progress...
 Traceback (most recent call last):
   File "__main__.py", line 13, in <module>
   File "carveracontroller/main.py", line 8186, in main
   File "kivy/app.py", line 956, in run
   File "kivy/base.py", line 574, in runTouchApp
   File "kivy/base.py", line 339, in mainloop
   File "kivy/base.py", line 383, in idle
   File "kivy/base.py", line 334, in dispatch_input
   File "kivy/base.py", line 263, in post_dispatch_input
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/core/window/__init__.py", line 1709, in on_motion
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/core/window/__init__.py", line 1726, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/modalview.py", line 266, in on_touch_down
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/widget.py", line 589, in on_touch_down
   File "kivy/_event.pyx", line 731, in kivy._event.EventDispatcher.dispatch
   File "kivy/uix/behaviors/button.py", line 151, in on_touch_down
   File "kivy/_event.pyx", line 727, in kivy._event.EventDispatcher.dispatch
   File "kivy/_event.pyx", line 1307, in kivy._event.EventObservers.dispatch
   File "kivy/_event.pyx", line 1191, in kivy._event.EventObservers._dispatch
   File "kivy/lang/builder.py", line 60, in custom_callback
   File "/tmp/.mount_carverhPOikB/usr/bin/_internal/carveracontroller/addons/probing/ProbingPopup.kv", line 319, in <module>
     on_press: root.on_angle_probing_pressed("XAbove")
 ^^^^^^^^^^^
   File "carveracontroller/addons/probing/ProbingPopup.py", line 129, in on_angle_probing_pressed
   File "carveracontroller/addons/probing/ProbingPopup.py", line 150, in show_preview
   File "carveracontroller/addons/probing/operations/Angle/AngleOperation.py", line 28, in generate
   File "carveracontroller/addons/probing/operations/OperationsBase.py", line 27, in apply_direction
 ValueError: could not convert string to float: ''
[PYI-3302043:ERROR] Failed to execute script '__main__' due to unhandled exception!
```

I was able to reproduce it by just removing the "E" value when probing an angle with an inverted direction.

The value is optional in the firmware but is required for those inverted directions so the controller just takes the current value and inverts it, which doesn't work when it is not set.

I hesitated to make the value mandatory but went for the same default as the firmware (2mm) instead.