### PR TITLE
CMM Workbench: Fix some timeout issues and improve unexpected states detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[unreleased]
+- Fixed: Fix some timeout issues with the CMM workbench when using the Makera protocol and improve unexpected states detection
+
 [2.2.0-RC1]
 - Enhancement: Read tool definitions from post-processor outputs and use them in the G-code viewer
 - Enhancement: Add multi-select to the remote file browser

--- a/carveracontroller/addons/cmm_workbench/core/gcode.py
+++ b/carveracontroller/addons/cmm_workbench/core/gcode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 
 from carveracontroller.Controller import Controller
 
@@ -29,7 +30,18 @@ VAR_SETS: dict[str, list[str]] = {
 }
 
 
-def build_m118_echo_tail(op: str, result_vars: Sequence[str] | None = None) -> str:
+@dataclass(frozen=True)
+class ProbeProgram:
+    """A probe run split into phases so they can be sent at different times.
+    Sending everything at once can cause timeout issues when using the Makera protocol.
+    """
+
+    setup: list[str]
+    probe: str
+    tail: list[str]
+
+
+def build_m118_echo_tail(op: str, result_vars: Sequence[str] | None = None) -> list[str]:
     """Append START, M118.1 P# for each variable, then END."""
     if result_vars is not None:
         vars_ = [str(v).strip() for v in result_vars if str(v).strip()]
@@ -46,14 +58,7 @@ def build_m118_echo_tail(op: str, result_vars: Sequence[str] | None = None) -> s
     for v in vars_:
         lines.append(f"M118.1 P#{v}")
     lines.append("M118 CMMProbe END")
-    return "\n".join(lines)
-
-
-def merge_probe_program(head: str, op: str, *, result_vars: Sequence[str] | None = None) -> str:
-    """Join head G-code (may be multi-line) with echo tail for ``op``."""
-    head = head.strip()
-    tail = build_m118_echo_tail(op, result_vars=result_vars)
-    return f"{head}\n{tail}\n"
+    return lines
 
 
 def parse_cmm_start_remainder(remainder: str) -> tuple[list[str], int]:
@@ -212,7 +217,7 @@ def _build_probe_cmd(
     l_repeat: str = "",
     r_retract: str = "",
     result_vars: list[str] | None = None,
-) -> str:
+) -> ProbeProgram:
     parts = [op]
     parts.extend(w for w in axis_words if w)
     parts.append(f"F{_fmt(f_probe)}")
@@ -226,8 +231,11 @@ def _build_probe_cmd(
     rw = _word("R", r_retract)
     if rw:
         parts.append(rw)
-    head = "\n".join(["G21", "G90", "G17", "G94", " ".join(parts)])
-    return merge_probe_program(head, op, result_vars=result_vars)
+    return ProbeProgram(
+        setup=["G21", "G90", "G17", "G94"],
+        probe=" ".join(parts),
+        tail=build_m118_echo_tail(op, result_vars=result_vars),
+    )
 
 
 def build_m466(
@@ -242,7 +250,7 @@ def build_m466(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     xw, yw = _word("X", x), _word("Y", y)
     result_vars: list[str] = []
     if xw:
@@ -273,7 +281,7 @@ def build_m461(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     xw, yw = _word("X", x), _word("Y", y)
     result_vars: list[str] = []
     if xw:
@@ -305,7 +313,7 @@ def build_m462(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     xw, yw = _word("X", x), _word("Y", y)
     result_vars: list[str] = []
     if xw:
@@ -336,7 +344,7 @@ def build_m463(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     return _build_probe_cmd(
         "M463",
         [f"X{_fmt(x)}", f"Y{_fmt(y)}", _word("E", e), _word("H", h), _word("C", c)],
@@ -360,7 +368,7 @@ def build_m464(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     return _build_probe_cmd(
         "M464",
         [f"X{_fmt(x)}", f"Y{_fmt(y)}", _word("E", e), _word("H", h), _word("C", c)],
@@ -384,7 +392,7 @@ def build_m465(
     k_rapid: float = 800.0,
     l_repeat: str = "",
     r_retract: str = "",
-) -> str:
+) -> ProbeProgram:
     return _build_probe_cmd(
         "M465",
         [_word("X", x), _word("Y", y), _word("E", e), _word("H", h), _word("C", c)],
@@ -394,12 +402,3 @@ def build_m465(
         l_repeat=l_repeat,
         r_retract=r_retract,
     )
-
-
-def split_execute_lines(program: str) -> list[str]:
-    out: list[str] = []
-    for ln in program.replace("\r\n", "\n").split("\n"):
-        s = ln.strip()
-        if s and not s.startswith(";"):
-            out.append(s)
-    return out

--- a/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
+++ b/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
@@ -22,7 +22,7 @@ from kivy.uix.togglebutton import ToggleButton
 
 from carveracontroller.addons.probing.operations.ConfigUtils import get_machine_config_hint
 from carveracontroller.CNC import CNC
-from carveracontroller.Controller import Controller
+from carveracontroller.Controller import NOT_CONNECTED, Controller
 from carveracontroller.main import is_ios
 from carveracontroller.serial_listeners import (
     register_serial_listener,
@@ -55,6 +55,7 @@ from ..core.gcode import (
     PROBE_VAR_CENTER_Y,
     PROBE_VAR_CENTER_Z,
     M118ProbeCapture,
+    ProbeProgram,
     build_m461,
     build_m462,
     build_m463,
@@ -62,7 +63,6 @@ from ..core.gcode import (
     build_m465,
     build_m466,
     extract_probe_start_meta,
-    split_execute_lines,
 )
 from ..core.io_export import export_csv, export_dxf, export_json
 from ..core.session import CMMWorkbenchFeature, CMMWorkbenchSession, FeatureKind
@@ -237,9 +237,10 @@ class CMMWorkbenchPopup(ModalView):
             set_status_text=lambda v: setattr(self, "probing_status_text", v),
             on_is_probing_changed=self._on_probe_is_probing_changed,
             controller_abort=self.controller.abortCommand,
-            idle_ok=self._idle_ok,
+            get_state=self._machine_state,
+            execute_line=self._execute_line,
+            on_aborted=self._on_probe_aborted,
         )
-        self._runner.set_on_timeout(self._on_probe_timeout_toast)
 
     def on_kv_post(self, base_widget):
         super().on_kv_post(base_widget)
@@ -384,7 +385,7 @@ class CMMWorkbenchPopup(ModalView):
             self._on_probe_values,
             on_abort=self._on_probe_abort,
         )
-        self._listener_handle = register_serial_listener(self._capture.feed_line)
+        self._listener_handle = register_serial_listener(self._on_serial_line)
         Clock.schedule_interval(self._tick_wcs_live, 0.35)
         Clock.schedule_once(lambda _dt: self._tick_wcs_live(), 0.05)
         Clock.schedule_once(lambda _dt: self._sync_manual_wcs_fields_from_machine(), 0.08)
@@ -443,19 +444,24 @@ class CMMWorkbenchPopup(ModalView):
         except Exception:
             logger.debug("Could not apply probing lock to feature rows", exc_info=True)
 
-    def _on_probe_timeout_toast(self) -> None:
+    def _on_serial_line(self, msg_kind: int, line: str) -> None:
+        # An error line means the machine gave up on the run; without this the UI
+        # would stay locked until the timeout.
+        if msg_kind == Controller.MSG_ERROR and self.is_probing:
+            self._runner.abort(tr._("Probe stopped: machine reported an error."))
+            return
+        if self._capture is not None:
+            self._capture.feed_line(msg_kind, line)
+
+    def _on_probe_aborted(self, reason: str) -> None:
         if self._capture is not None:
             self._capture.reset()
-        self._toast(tr._("Probe timed out."))
+        self._toast(reason)
 
     def _cancel_probe_run(self) -> None:
         if self._capture is not None:
             self._capture.reset()
         self._runner.cancel(abort_machine=True)
-
-    def _start_probing(self) -> None:
-        self._dismiss_jog_popup()
-        self._runner.start()
 
     def _tick_wcs_live(self, *_args):
         try:
@@ -509,31 +515,34 @@ class CMMWorkbenchPopup(ModalView):
     def _toast_need_probing_option(self) -> None:
         self._toast(tr._("Select a probing option before running."))
 
-    def _idle_ok(self) -> bool:
+    def _machine_state(self) -> str:
         app = App.get_running_app()
-        return app.state == "Idle"
+        if app is None:
+            return NOT_CONNECTED
+        return app.state or NOT_CONNECTED
 
-    def _run_gcode_program(self, program: str):
+    def _is_idle(self) -> bool:
+        return self._machine_state() == "Idle"
+
+    def _execute_line(self, line: str) -> None:
+        self.controller.executeCommand(line + "\n")
+
+    def _run_gcode_program(self, program: ProbeProgram):
         if self.is_probing:
             self._toast(tr._("Probe already in progress."))
             return
-        if not self._idle_ok():
+        if not self._is_idle():
             self._toast(tr._("Machine must be Idle to probe."))
             return
-        lines = split_execute_lines(program)
-        if not lines:
-            self._toast(tr._("No G-code to run."))
-            return
         if self._capture is not None:
-            for ln in lines:
+            for ln in program.tail:
                 meta = extract_probe_start_meta(ln)
                 if meta:
                     op, keys = meta
                     self._capture.prime_upstream(op, keys)
                     break
-        self._start_probing()
-        for ln in lines:
-            self.controller.executeCommand(ln + "\n")
+        self._dismiss_jog_popup()
+        self._runner.start(program)
 
     def _on_probe_values(self, op: str, values: dict[str, float], var_keys: list[str]):
         self._runner.pre_complete()

--- a/carveracontroller/addons/cmm_workbench/ui/probe_runner.py
+++ b/carveracontroller/addons/cmm_workbench/ui/probe_runner.py
@@ -1,19 +1,29 @@
-"""Probe lifecycle management: animation, timeout, and run-token tracking."""
+"""Probe lifecycle management: phased sending, animation, timeout, and run-token tracking."""
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 
 from kivy.clock import Clock
 
 from carveracontroller.translation import tr
 
+from ..core.gcode import ProbeProgram
+
 _PROBE_ANIM_FRAMES = ("◐", "◓", "◑", "◒")
 _PROBE_TIMEOUT_S = 30.0
+_POLL_S = 0.2  # How often to check the machine state.
+_SETUP_SETTLE_S = 1.0  # How long to wait after setup before sending the probe.
+_MOTION_GRACE_S = 3.0  # How long to treat Idle as "probe done" if Run was never seen.
+
+_PHASE_SETUP = "setup"
+_PHASE_PROBE = "probe"
+_PHASE_RESULT = "result"
 
 
 class ProbeRunner:
-    """Manages probe animation, timeout, and run-token lifecycle."""
+    """Runs one probe operation, sending setup, probe motion and result tail in turn."""
 
     def __init__(
         self,
@@ -22,27 +32,44 @@ class ProbeRunner:
         set_status_text: Callable[[str], None],
         on_is_probing_changed: Callable[[], None],
         controller_abort: Callable[[], None],
-        idle_ok: Callable[[], bool],
+        get_state: Callable[[], str],
+        execute_line: Callable[[str], None],
+        on_aborted: Callable[[str], None] | None = None,
     ) -> None:
         self._set_is_probing = set_is_probing
         self._set_status_text = set_status_text
         self._on_is_probing_changed = on_is_probing_changed
         self._controller_abort = controller_abort
-        self._idle_ok = idle_ok
+        self._get_state = get_state
+        self._execute_line = execute_line
+        self._on_aborted = on_aborted
 
         self._gen: int = 0
         self._active_token: int | None = None
         self._anim_event = None
         self._timeout_event = None
+        self._poll_event = None
         self._anim_frame: int = 0
 
-    def start(self) -> int:
+        self._program: ProbeProgram | None = None
+        self._phase: str = _PHASE_SETUP
+        self._phase_started_at: float = 0.0
+        self._saw_busy: bool = False
+
+    def start(self, program: ProbeProgram) -> int:
         """Start a probe run. Returns the run token for deferred validation."""
         self._gen += 1
         self._active_token = self._gen
         self._anim_frame = 0
+        self._program = program
+        self._phase = _PHASE_SETUP
+        self._phase_started_at = time.time()
+        self._saw_busy = False
         self._set_is_probing(True)
         self._tick_status()
+
+        for line in program.setup:
+            self._execute_line(line)
 
         if self._anim_event is not None:
             self._anim_event.cancel()
@@ -55,6 +82,11 @@ class ProbeRunner:
             lambda _dt, t=saved_token: self._on_timeout(_dt, t),
             _PROBE_TIMEOUT_S,
         )
+
+        if self._poll_event is not None:
+            self._poll_event.cancel()
+        self._poll_event = Clock.schedule_interval(self._poll, _POLL_S)
+
         self._on_is_probing_changed()
         return self._active_token
 
@@ -80,11 +112,19 @@ class ProbeRunner:
         """Cancel the current probe run and optionally abort the machine."""
         self._invalidate_token()
         self._clear_events()
-        if abort_machine and not self._idle_ok():
+        if abort_machine and self._get_state() != "Idle":
             self._controller_abort()
         self._set_is_probing(False)
         self._set_status_text("")
         self._on_is_probing_changed()
+
+    def abort(self, reason: str) -> None:
+        """End the run early and report *reason* (timeout, error or bad machine state)."""
+        if self._active_token is None:
+            return
+        self.cancel(abort_machine=True)
+        if self._on_aborted is not None:
+            self._on_aborted(reason)
 
     def shutdown(self) -> None:
         """Silently cancel all events without firing callbacks (use on popup dismiss)."""
@@ -110,7 +150,38 @@ class ProbeRunner:
         if self._timeout_event is not None:
             self._timeout_event.cancel()
             self._timeout_event = None
+        if self._poll_event is not None:
+            self._poll_event.cancel()
+            self._poll_event = None
+        self._program = None
 
+    def _poll(self, _dt=None) -> None:
+        """Watch the machine state and hand it the next phase when it is ready."""
+        if self._active_token is None or self._program is None:
+            return
+
+        # A probe cycle should only ever reports Idle or Run
+        # If we receive anything else, it means the probe stopped early and the run has to be abandoned.
+        state = self._get_state()
+        if state not in ("Idle", "Run"):
+            self.abort(tr._("Probing failed: Unexpected machine state \"%s\".") % state)
+            return
+
+        now = time.time()
+        if self._phase == _PHASE_SETUP:
+            if state == "Idle" and (now - self._phase_started_at) >= _SETUP_SETTLE_S:
+                self._execute_line(self._program.probe)
+                self._phase = _PHASE_PROBE
+                self._phase_started_at = now
+        elif self._phase == _PHASE_PROBE:
+            if state != "Idle":
+                self._saw_busy = True
+            elif self._saw_busy or (now - self._phase_started_at) >= _MOTION_GRACE_S:
+                for line in self._program.tail:
+                    self._execute_line(line)
+                self._phase = _PHASE_RESULT
+        # In _PHASE_RESULT the poll only keeps watching the state
+        # We stop polling when the M118 capture ends the run through pre_complete()/complete().
     def _tick_anim(self, _dt=None) -> None:
         self._anim_frame = (self._anim_frame + 1) % len(_PROBE_ANIM_FRAMES)
         self._tick_status()
@@ -124,13 +195,4 @@ class ProbeRunner:
             return
         if run_token is None or run_token != self._active_token:
             return
-        self.cancel(abort_machine=True)
-        if self._on_timeout_cb is not None:
-            self._on_timeout_cb()
-
-    # Optional timeout notification callback set after construction.
-    _on_timeout_cb: Callable[[], None] | None = None
-
-    def set_on_timeout(self, cb: Callable[[], None]) -> None:
-        """Register a callback invoked when the probe times out."""
-        self._on_timeout_cb = cb
+        self.abort(tr._("Probe timed out."))

--- a/tests/unit/test_cmm_probe_phases.py
+++ b/tests/unit/test_cmm_probe_phases.py
@@ -1,0 +1,227 @@
+"""Phase splitting and ProbeRunner sequencing for CMM Workbench probe runs.
+
+The probe move must stay on its own line so it can be sent apart from the short
+setup and result commands; batching them stops the firmware answering status
+queries long enough for the host to declare the connection lost.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from carveracontroller.addons.cmm_workbench.core.gcode import (
+    ProbeProgram,
+    build_m463,
+    build_m466,
+)
+from carveracontroller.addons.cmm_workbench.ui import probe_runner as probe_runner_mod
+from carveracontroller.addons.cmm_workbench.ui.probe_runner import ProbeRunner
+
+
+def test_probe_program_keeps_the_probe_move_on_its_own():
+    program = build_m466(x="10")
+
+    assert program.setup == ["G21", "G90", "G17", "G94"]
+    assert program.probe.startswith("M466 X10 ")
+    assert program.tail[0].startswith("M118 CMMProbe START M466 ")
+    assert program.tail[-1] == "M118 CMMProbe END"
+    assert "M118" not in program.probe
+    assert "\n" not in program.probe
+
+
+def test_probe_program_echoes_one_variable_per_tail_line():
+    program = build_m463(10, 10)
+
+    echoes = [ln for ln in program.tail if ln.startswith("M118.1")]
+    assert echoes == ["M118.1 P#154", "M118.1 P#155"]
+
+
+class _FakeClockEvent:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+@pytest.fixture
+def runner_harness(monkeypatch):
+    """ProbeRunner with controllable clock, wall-clock, and machine state."""
+    now = {"t": 1000.0}
+    state = {"value": "Idle"}
+    executed: list[str] = []
+    aborted: list[str] = []
+    machine_aborts: list[str] = []
+    is_probing = {"value": False}
+    status_text = {"value": ""}
+    scheduled_once: list[tuple[object, float, _FakeClockEvent]] = []
+
+    def fake_time():
+        return now["t"]
+
+    def schedule_interval(callback, dt):
+        return _FakeClockEvent()
+
+    def schedule_once(callback, dt):
+        event = _FakeClockEvent()
+        scheduled_once.append((callback, dt, event))
+        return event
+
+    monkeypatch.setattr(probe_runner_mod.time, "time", fake_time)
+    monkeypatch.setattr(
+        probe_runner_mod,
+        "Clock",
+        SimpleNamespace(schedule_interval=schedule_interval, schedule_once=schedule_once),
+    )
+
+    program = ProbeProgram(
+        setup=["G21", "G90", "G17", "G94"],
+        probe="M466 X10 F100",
+        tail=[
+            "M118 CMMProbe START M466 X",
+            "M118.1 P#150",
+            "M118 CMMProbe END",
+        ],
+    )
+
+    runner = ProbeRunner(
+        set_is_probing=lambda v: is_probing.__setitem__("value", v),
+        set_status_text=lambda v: status_text.__setitem__("value", v),
+        on_is_probing_changed=lambda: None,
+        controller_abort=lambda: machine_aborts.append("abort"),
+        get_state=lambda: state["value"],
+        execute_line=lambda line: executed.append(line),
+        on_aborted=lambda reason: aborted.append(reason),
+    )
+
+    return SimpleNamespace(
+        runner=runner,
+        program=program,
+        now=now,
+        state=state,
+        executed=executed,
+        aborted=aborted,
+        machine_aborts=machine_aborts,
+        is_probing=is_probing,
+        status_text=status_text,
+        scheduled_once=scheduled_once,
+    )
+
+
+def _advance_past_setup(h):
+    """Send setup, wait out settle, poll until the probe command is sent."""
+    h.runner.start(h.program)
+    assert h.executed == list(h.program.setup)
+    h.now["t"] += probe_runner_mod._SETUP_SETTLE_S
+    h.runner._poll()
+    assert h.executed[-1] == h.program.probe
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+
+def test_setup_is_sent_immediately_and_probe_waits_for_settle(runner_harness):
+    h = runner_harness
+    h.runner.start(h.program)
+
+    assert h.is_probing["value"] is True
+    assert h.executed == list(h.program.setup)
+
+    h.runner._poll()
+    assert h.executed == list(h.program.setup)
+
+    h.now["t"] += probe_runner_mod._SETUP_SETTLE_S - 0.01
+    h.runner._poll()
+    assert h.executed == list(h.program.setup)
+
+    h.now["t"] += 0.01
+    h.runner._poll()
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+
+def test_setup_does_not_advance_while_machine_is_running(runner_harness):
+    h = runner_harness
+    h.runner.start(h.program)
+    h.now["t"] += probe_runner_mod._SETUP_SETTLE_S
+    h.state["value"] = "Run"
+    h.runner._poll()
+
+    assert h.executed == list(h.program.setup)
+
+
+def test_tail_is_sent_after_busy_then_idle(runner_harness):
+    h = runner_harness
+    _advance_past_setup(h)
+
+    h.state["value"] = "Run"
+    h.runner._poll()
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+    h.state["value"] = "Idle"
+    h.runner._poll()
+    assert h.executed == list(h.program.setup) + [h.program.probe] + list(h.program.tail)
+
+
+def test_tail_is_not_sent_while_still_running(runner_harness):
+    h = runner_harness
+    _advance_past_setup(h)
+
+    h.state["value"] = "Run"
+    h.runner._poll()
+    h.runner._poll()
+
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+
+def test_tail_is_sent_after_grace_when_run_was_never_seen(runner_harness):
+    h = runner_harness
+    _advance_past_setup(h)
+
+    h.now["t"] += probe_runner_mod._MOTION_GRACE_S - 0.01
+    h.runner._poll()
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+    h.now["t"] += 0.01
+    h.runner._poll()
+    assert h.executed == list(h.program.setup) + [h.program.probe] + list(h.program.tail)
+
+
+def test_unexpected_state_aborts_the_run(runner_harness):
+    h = runner_harness
+    _advance_past_setup(h)
+
+    h.state["value"] = "Alarm"
+    h.runner._poll()
+
+    assert h.is_probing["value"] is False
+    assert h.runner.get_active_token() is None
+    assert h.machine_aborts == ["abort"]
+    assert len(h.aborted) == 1
+    assert "Alarm" in h.aborted[0]
+    assert h.executed == list(h.program.setup) + [h.program.probe]
+
+
+def test_timeout_aborts_the_run(runner_harness):
+    h = runner_harness
+    token = h.runner.start(h.program)
+    assert len(h.scheduled_once) == 1
+    timeout_cb, timeout_s, _event = h.scheduled_once[0]
+    assert timeout_s == probe_runner_mod._PROBE_TIMEOUT_S
+
+    timeout_cb(0)
+
+    assert h.is_probing["value"] is False
+    assert h.runner.is_token_valid(token) is False
+    assert h.aborted == ["Probe timed out."]
+
+
+def test_stale_timeout_is_ignored_after_complete(runner_harness):
+    h = runner_harness
+    h.runner.start(h.program)
+    timeout_cb, _timeout_s, _event = h.scheduled_once[0]
+
+    h.runner.complete()
+    timeout_cb(0)
+
+    assert h.aborted == []
+    assert h.is_probing["value"] is False


### PR DESCRIPTION
Related to https://github.com/Carvera-Community/Carvera_Controller/issues/710

The current version of the CMM tool sends a lot of commands at the same time (setup + probing command + M118 calls to retrieve the result). It worked fine with the smoothie protocol but the new one only supports one deferred command at a time on Wifi and blocks all incoming packets until that slot is free.

This basically means that if you send a commands that takes some time to process (here a probing command) followed by another one (here a M118), the latter will hold the deferred spot until the first command has been fully processed. It will then block all incoming packets, including the status query requests, and cause the controller to timeout after 5s.

This PR updates the CMM tool in order to send commands in 3 different waves: setup, then probing, then M118 calls (the first two could probably be sent together but I felt it was cleaner this way). This requires to wait for the machine to go back to and idle state before starting the next step.

This method also allows to detect the machine going into unexpected state and directly abort the current operation instead of having to wait 30s for it to timeout.

This is not perfect though:
* if for some reason the controller decides to send another command (other than the query status) while the probing command is being processed it will probably also cause a timeout. But I don't see why it would happen since the controller isn't supposed to send random commands in the background (apart from the status query)
* if assumes the machine will go idle => run => idle => run => idle. I added some grace period so that if it misses a "run" it is able to considers the next "idle" state as being ok, but that could cause false positives if there is a really big lag (> 3s) between the moment a command is sent and the moment the machine goes into its "run" state.