### PR TITLE
Add build-backend to [build-system] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [ "poetry-core>=1.0.0",]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "carvera-controller-community"


### PR DESCRIPTION
Closes #719

## What

Adds the missing `build-backend` declaration to `[build-system]` in `pyproject.toml`:

```toml
[build-system]
requires = [ "poetry-core>=1.0.0",]
build-backend = "poetry.core.masonry.api"
```

## Why

Without an explicit `build-backend`, PEP 517 front-ends (pip, uv, `python -m build`) fall back to `setuptools.build_meta:__legacy__`, which cannot build this Poetry-configured package — `pip install .` fails with `ModuleNotFoundError: No module named 'setuptools'` inside the isolated build env.

## Testing

- `uv build` on a fresh clone: previously failed, now produces both sdist and wheel (`carvera_controller_community-0.0.0-py3-none-any.whl`)
- Poetry workflows are unaffected: Poetry ignores `build-backend` and uses its own machinery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
