### PR TITLE
Keep MDI input within the machine command buffer limits

### DIFF
--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -104,6 +104,11 @@ class Controller:
         self.usb_stream = USBStream(log_sent_receive)
         self.wifi_stream = WIFIStream(log_sent_receive)
 
+        # Serializes writes to the active stream. The status poller (streamIO
+        # thread) and command senders (UI thread) share one socket/serial port;
+        # without a lock their writes can interleave mid-command.
+        self._send_lock = threading.RLock()
+
         # Reconnection properties
         self.reconnect_enabled = True
         self.reconnect_wait_time = 10
@@ -242,7 +247,8 @@ class Controller:
                     self._notify_usb_reset_blocked()
                     return
                 payload = line.encode() if isinstance(line, str) else line
-                self.stream.send(self.comms.encode_command(payload))
+                with self._send_lock:
+                    self.stream.send(self.comms.encode_command(payload))
                 if self.execCallback:
                     display = line if isinstance(line, str) else line.decode(errors="ignore")
                     # Strip ".lz" suffix for display
@@ -283,7 +289,8 @@ class Controller:
                 if isinstance(char, (bytes, bytearray)):
                     char = char[0]
                 payload.extend(self.comms.encode_realtime(int(char)))
-            self.stream.send(bytes(payload))
+            with self._send_lock:
+                self.stream.send(bytes(payload))
         except Exception:
             self.log.put((Controller.MSG_ERROR, str(sys.exc_info()[1])))
 
@@ -294,7 +301,8 @@ class Controller:
                 if isinstance(line, str) and not line.endswith("\n"):
                     line += "\n"
                 payload = line.encode() if isinstance(line, str) else line
-                self.stream.send(self.comms.encode_file_command(payload))
+                with self._send_lock:
+                    self.stream.send(self.comms.encode_file_command(payload))
                 if self.execCallback:
                     display = line if isinstance(line, str) else line.decode(errors="ignore")
                     if display.endswith(".lz\n"):

--- a/carveracontroller/WIFIStream.py
+++ b/carveracontroller/WIFIStream.py
@@ -92,7 +92,9 @@ class WIFIStream:
     def send(self, data):
         if self.log_sent_receive:
             logger.debug(f"SENT: {data}")
-        self.socket.send(data)
+        # sendall, not send: a partial socket.send would silently drop the tail
+        # of the command (seen as truncated MDI input on the machine).
+        self.socket.sendall(data)
 
     # ----------------------------------------------------------------------
     def recv(self):

--- a/carveracontroller/machine/mdi.py
+++ b/carveracontroller/machine/mdi.py
@@ -1,0 +1,40 @@
+"""Validation helpers for MDI console input.
+
+The firmware bounds a single command line on every transport, so input that
+exceeds those bounds is truncated or dropped by the machine:
+
+- Smoothie (text) mode: received characters are staged in a
+  ``RingBuffer<char, 256>`` before line assembly, on both USB
+  (``SerialConsole``) and WiFi (``WifiProvider``).
+- Makera (framed) mode over USB: a ``CTRL_MULTI`` payload is copied into a
+  fixed 256-byte queue slot (``MAKERA_CMD_MAX_LEN``) before dispatch, and the
+  whole payload is dispatched as a single console line.
+
+Splitting multi-line input into one write per line and capping each line keeps
+MDI input inside those limits on every transport/protocol combination.
+"""
+
+from __future__ import annotations
+
+# 256-byte firmware limit, minus the line terminator, minus one byte of slack.
+MDI_MAX_LINE_BYTES = 254
+
+
+def prepare_mdi_lines(text: str) -> tuple[list[str], list[str]]:
+    """Split raw MDI input into individual command lines.
+
+    Returns ``(lines, rejected)``: ``lines`` are the non-empty commands, in
+    order, each safe to send as its own write; ``rejected`` are lines whose
+    UTF-8 encoding exceeds ``MDI_MAX_LINE_BYTES`` and must not be sent.
+    """
+    lines: list[str] = []
+    rejected: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if len(line.encode("utf-8")) > MDI_MAX_LINE_BYTES:
+            rejected.append(line)
+        else:
+            lines.append(line)
+    return lines, rejected

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -236,6 +236,7 @@ from .Controller import (
     Controller,
 )
 from .GcodeViewer import GCodeViewer
+from .machine.mdi import MDI_MAX_LINE_BYTES, prepare_mdi_lines
 from .ui import widget_helpers
 from .ui.PlayProgressBar import play_percent_from_line, tool_change_markers_to_percents
 from .ui.popups.adv_calibrate import AdvCalibratePopup
@@ -7840,15 +7841,29 @@ class Makera(RelativeLayout):
             if to_send.lower() == "clear":
                 self.manual_rv.data = []
             else:
-                sanitized_to_send = "\n".join([line for line in to_send.split("\n") if line.strip().lower() != "clear"])
-                if sanitized_to_send != to_send:
+                lines, rejected = prepare_mdi_lines(to_send)
+                if any(line.lower() == "clear" for line in lines):
+                    lines = [line for line in lines if line.lower() != "clear"]
                     self.manual_rv.data.append(
                         {
                             "text": "clear command can't be used together with other commands",
                             "color": (250 / 255, 105 / 255, 102 / 255, 1),
                         }
                     )
-                self.controller.executeCommand(sanitized_to_send)
+                for line in rejected:
+                    self.manual_rv.data.append(
+                        {
+                            "text": tr._("Line exceeds the machine's %d byte command buffer, not sent:")
+                            % MDI_MAX_LINE_BYTES
+                            + " %s" % (line if len(line) <= 60 else line[:57] + "..."),
+                            "color": (250 / 255, 105 / 255, 102 / 255, 1),
+                        }
+                    )
+                # One write per line: the firmware assembles/queues commands
+                # line-by-line, and a framed CTRL_MULTI payload is dispatched
+                # as a single console line no matter how many newlines it has.
+                for line in lines:
+                    self.controller.executeCommand(line)
         self.manual_cmd.text = ""
         Clock.schedule_once(self.refocus_cmd)
 

--- a/tests/unit/test_mdi.py
+++ b/tests/unit/test_mdi.py
@@ -1,0 +1,57 @@
+"""Tests for MDI input validation against machine buffer limits."""
+
+from carveracontroller.machine.mdi import MDI_MAX_LINE_BYTES, prepare_mdi_lines
+
+
+class TestPrepareMdiLines:
+    def test_single_line_passes_through(self):
+        assert prepare_mdi_lines("G0 X10") == (["G0 X10"], [])
+
+    def test_multiline_input_splits_into_individual_lines(self):
+        lines, rejected = prepare_mdi_lines("G21\nG90\nG0 X10 Y10")
+        assert lines == ["G21", "G90", "G0 X10 Y10"]
+        assert rejected == []
+
+    def test_blank_and_whitespace_lines_are_dropped(self):
+        lines, rejected = prepare_mdi_lines("G21\n\n   \nG90\n")
+        assert lines == ["G21", "G90"]
+        assert rejected == []
+
+    def test_crlf_input_splits_without_stray_carriage_returns(self):
+        lines, _ = prepare_mdi_lines("G21\r\nG90\r\n")
+        assert lines == ["G21", "G90"]
+
+    def test_lines_are_stripped(self):
+        lines, _ = prepare_mdi_lines("  G0 X1  \n\tG0 Y1\t")
+        assert lines == ["G0 X1", "G0 Y1"]
+
+    def test_line_at_limit_is_accepted(self):
+        line = "M117 " + "a" * (MDI_MAX_LINE_BYTES - 5)
+        assert len(line.encode("utf-8")) == MDI_MAX_LINE_BYTES
+        lines, rejected = prepare_mdi_lines(line)
+        assert lines == [line]
+        assert rejected == []
+
+    def test_line_over_limit_is_rejected(self):
+        line = "M117 " + "a" * MDI_MAX_LINE_BYTES
+        lines, rejected = prepare_mdi_lines(line)
+        assert lines == []
+        assert rejected == [line]
+
+    def test_limit_is_measured_in_utf8_bytes_not_characters(self):
+        # ç encodes to two UTF-8 bytes: 200 chars -> 400 bytes, over the limit
+        line = "ç" * 200
+        assert len(line) < MDI_MAX_LINE_BYTES
+        lines, rejected = prepare_mdi_lines(line)
+        assert lines == []
+        assert rejected == [line]
+
+    def test_rejection_keeps_valid_lines(self):
+        long_line = "b" * (MDI_MAX_LINE_BYTES + 1)
+        lines, rejected = prepare_mdi_lines(f"G21\n{long_line}\nG90")
+        assert lines == ["G21", "G90"]
+        assert rejected == [long_line]
+
+    def test_empty_input_returns_nothing(self):
+        assert prepare_mdi_lines("") == ([], [])
+        assert prepare_mdi_lines("   \n  ") == ([], [])


### PR DESCRIPTION
Fixes #718 (controller side).

## Firmware limits this enforces

Digging through `Carvera_Community_Firmware` for the actual bounds:

| Transport / protocol | Limit | Failure mode today |
|---|---|---|
| USB + WiFi, smoothie text mode | `RingBuffer<char, 256>` receive buffer (`SerialConsole.h`, `WifiProvider.h`) | chars beyond capacity are lost → truncated command |
| USB, makera framed mode | `MAKERA_CMD_MAX_LEN = 256` per queued `CTRL_MULTI` payload, queue depth 4 (`SerialConsole.cpp`) | oversized payload is rejected by `makera_cmd_queue_push` → command silently dropped |
| any, makera framed mode | whole `CTRL_MULTI` payload dispatched as **one** `SerialMessage` regardless of embedded newlines (`SerialConsole::on_main_loop`, `WifiProvider::on_main_loop`) | multi-line MDI text lumped into a single console line |

On the controller side there were two additional mangling vectors:

- `WIFIStream.send()` used `socket.send()` and ignored the return value — a partial send silently dropped the tail of the command.
- The 200 ms status poll (`streamIO` thread) and command writes (UI thread) share one socket/serial port with no synchronization, so writes could interleave.

## Changes

- **`carveracontroller/machine/mdi.py`** (new, Kivy-free, `mypy --strict` clean): `prepare_mdi_lines()` splits MDI input into individual command lines and rejects lines whose UTF-8 encoding exceeds `MDI_MAX_LINE_BYTES = 254` (256 minus line terminator minus one byte of slack).
- **`main.py send_cmd()`**: sends one write per line instead of the whole multi-line text in a single write; lines over the limit surface a red error row in the MDI console instead of being silently truncated by the machine. Existing `clear` semantics preserved.
- **`Controller`**: all `stream.send()` call sites (commands, realtime bytes, file commands) now serialize behind an `RLock`, so the status poll can no longer interleave with command writes.
- **`WIFIStream.send()`**: `socket.sendall()` instead of `socket.send()`.

## Testing

- `tests/unit/test_mdi.py`: 10 new tests — line splitting, CRLF, blank-line removal, exact-limit acceptance, UTF-8 byte-length measurement (multi-byte chars), mixed valid/rejected input.
- Full unit suite passes (255 tests; the two `hid`-dependent pendant test files were skipped locally on Windows because `hidapi.dll` is unavailable — unrelated to this change and covered by CI).
- `ruff check` / `ruff format` clean; `mypy --strict carveracontroller/machine/` clean; both import-linter contracts kept.
- App smoke-tested: boots cleanly with the changes.

## Out of scope

Pacing of rapid command bursts against the depth-4 makera command queue (and the resulting disconnects) is #710 territory — this PR only guarantees each MDI line arrives whole and individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
