### PR TITLE
Stop the remaining-time countdown when the connection is gone

### DIFF
--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5856,8 +5856,10 @@ class Makera(RelativeLayout):
             or (not app.selected_remote_filename and not app.selected_local_filename)
             or not self.selected_file_line_count
             or app.state in self._PROGRESS_TIMER_PAUSED_STATES
+            or app.state in (NOT_CONNECTED, CONNECTED)
         ):
-            # While held/paused, leave the last progress_info unchanged so both timers freeze.
+            # While held/paused (or with no live machine), leave the last
+            # progress_info unchanged so both timers freeze.
             return
         remaining_display = self._current_remaining_sec()
         filename = os.path.basename(app.selected_remote_filename or app.selected_local_filename)
@@ -6245,6 +6247,12 @@ class Makera(RelativeLayout):
                 "2.1.0"
             )  # in community firmware > 2.1.0 the machine state has a is_playing attribute
             machine_not_playing = CNC.vars["is_playing"] == 0 if use_cf_playing_flag else CNC.vars["playedlines"] <= 0
+            # A dead link must read as not playing: after a disconnect,
+            # is_playing/playedlines hold the last values the machine sent
+            # (still "playing" when playback was just aborted), which would
+            # leave the remaining-time countdown running (#712).
+            if CNC.vars["state"] in (NOT_CONNECTED, CONNECTED):
+                machine_not_playing = True
 
             # update progress bar and set selected
             if machine_not_playing:


### PR DESCRIPTION
Fixes #712.

## Root cause

Both disconnect paths (manual `close()` and the heartbeat-loss path) call `updateStatus()` right after closing the link — but the playing check there reads `CNC.vars["is_playing"]` / `CNC.vars["playedlines"]`, which hold the **last values the machine ever sent**. In the abort → disconnect repro, those values still reflect the aborted job, so the check lands in the `app.playing = True` branch and the one-second `_progress_smooth_clock` stays scheduled.

Meanwhile `_update_progress_smooth()` only freezes for `Hold/Pause/Wait/Tool`. During the abort the state passes through one of those (countdown frozen); after disconnecting the state becomes `N/A`, the guard no longer matches, and the countdown **resumes** against wall time — exactly the reported behaviour.

## Changes (surgical, 9 lines in `main.py`)

- `updateStatus()`: when the state shows no live machine (`N/A` or `Connected`), force the not-playing branch. That cancels the smooth progress clock, clears `app.playing`, and resets the progress bars. The interrupted-playback handling still runs first, so the resume-at-line position is recorded before the reset.
- `_update_progress_smooth()`: also freeze when the state shows no live machine — second layer of protection for any path where the clock survives a disconnect.

## Testing

- Unit suite passes (245 tests locally; `hid`-dependent pendant files skipped on Windows for lack of `hidapi.dll`, covered by CI). `ruff` clean.
- App smoke-tested: boots cleanly; file loading and playback simulation unaffected.
- The disconnect paths both funnel through `updateStatus()`, so the fix covers manual disconnect, heartbeat-loss disconnect, and the auto-reconnect flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
