### PR TITLE
Switch update checks to the GitHub releases API

### DIFF
--- a/carveracontroller/Utils.py
+++ b/carveracontroller/Utils.py
@@ -8,6 +8,7 @@ __author__ = "Vasilis Vlachoudis"
 __email__ = "vvlachoudis@gmail.com"
 
 import hashlib
+import json
 import os
 import sys
 
@@ -803,6 +804,37 @@ def fill_local_dir_dropdown(dropdown, common_dirs, recent_dirs):
         )
         btn.bind(on_release=lambda _btn, p=recent_dir: dropdown.select(p))
         dropdown.add_widget(btn)
+
+
+def parse_github_release(payload):
+    """Extract (version, notes) from a GitHub "latest release" API payload.
+
+    Accepts the parsed JSON dict (Kivy's UrlRequest decodes application/json
+    responses) or a raw JSON string/bytes. Returns ("", "") when the payload
+    carries no usable tag, so callers can treat it as "no release found".
+    """
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            return "", ""
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            return "", ""
+    if not isinstance(payload, dict):
+        return "", ""
+    tag = payload.get("tag_name") or payload.get("name") or ""
+    if not isinstance(tag, str):
+        return "", ""
+    version = tag.strip()
+    if version[:1] in ("v", "V"):
+        version = version[1:]
+    notes = payload.get("body")
+    if not isinstance(notes, str):
+        notes = ""
+    return version, notes
 
 
 def digitize_v(version):

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -2980,6 +2980,7 @@ class Makera(RelativeLayout):
     show_update = True
     instantFSoverride = True
     fw_upd_text = ""
+    fw_release_version = ""
     fw_version_new = ""
     fw_version = ""
     fw_version_checking = False
@@ -2995,6 +2996,7 @@ class Makera(RelativeLayout):
     decomptime = 0
 
     ctl_upd_text = ""
+    ctl_release_version = ""
     ctl_version_new = ""
     ctl_version = ""
 
@@ -3502,23 +3504,32 @@ class Makera(RelativeLayout):
             Config.write()
         self.upgrade_popup.dismiss(self)
 
+    # GitHub's API rejects requests without a User-Agent.
+    _GITHUB_API_HEADERS = {
+        "User-Agent": "CarveraControllerCommunity",
+        "Accept": "application/vnd.github+json",
+    }
+
     def check_for_updates(self):
         self.fw_upd_text = ""
+        self.fw_release_version = ""
         self.fw_version_checked = False
         self.ctl_upd_text = ""
-        UrlRequest(FW_UPD_ADDRESS, on_success=self.fw_upd_loaded)
-        UrlRequest(CTL_UPD_ADDRESS, on_success=self.ctl_upd_loaded)
+        self.ctl_release_version = ""
+        UrlRequest(FW_UPD_ADDRESS, on_success=self.fw_upd_loaded, req_headers=self._GITHUB_API_HEADERS)
+        UrlRequest(CTL_UPD_ADDRESS, on_success=self.ctl_upd_loaded, req_headers=self._GITHUB_API_HEADERS)
 
     def fw_upd_loaded(self, req, result):
-        # parse result
-        self.fw_upd_text = result
+        version, notes = Utils.parse_github_release(result)
+        self.fw_release_version = version
+        # Non-empty text marks the download as finished for the idle-time check.
+        self.fw_upd_text = notes or (("v" + version) if version else "")
 
     def check_fw_version(self):
         self.upgrade_popup.fw_upd_text.text = self.fw_upd_text
         self.upgrade_popup.fw_upd_text.cursor = (0, 0)  # Position the cursor at the top of the text
-        versions = re.search(r"\[[0-9]+\.[0-9]+\.[0-9]+\]", self.fw_upd_text)
-        if versions != None:
-            self.fw_version_new = versions[0][1 : len(versions[0]) - 1]
+        if self.fw_release_version:
+            self.fw_version_new = self.fw_release_version
             if self.fw_version != "":
                 app = App.get_running_app()
                 if Utils.digitize_v(self.fw_version_new) > Utils.digitize_v(self.fw_version):
@@ -3532,7 +3543,9 @@ class Makera(RelativeLayout):
         self.fw_version_checked = True
 
     def ctl_upd_loaded(self, req, result):
-        self.ctl_upd_text = result
+        version, notes = Utils.parse_github_release(result)
+        self.ctl_release_version = version
+        self.ctl_upd_text = notes or (("v" + version) if version else "")
         Clock.schedule_once(self.check_ctl_version, 0)
 
     def change_language(self, lang_desc):
@@ -3550,9 +3563,8 @@ class Makera(RelativeLayout):
     def check_ctl_version(self, *args):
         self.upgrade_popup.ctl_upd_text.text = self.ctl_upd_text
         self.upgrade_popup.ctl_upd_text.cursor = (0, 0)  # Position the cursor at the top of the text
-        versions = re.search(r"\[[0-9]+\.[0-9]+\.[0-9]+\]", self.ctl_upd_text)
-        if versions != None:
-            self.ctl_version_new = versions[0][1 : len(versions[0]) - 1]
+        if self.ctl_release_version:
+            self.ctl_version_new = self.ctl_release_version
             app = App.get_running_app()
             if Utils.digitize_v(self.ctl_version_new) > Utils.digitize_v(self.ctl_version):
                 app.ctl_has_update = True
@@ -8140,8 +8152,11 @@ def load_constants():
     global DOWNLOAD_ADDRESS
     global FW_DOWNLOAD_ADDRESS
 
-    FW_UPD_ADDRESS = "https://raw.githubusercontent.com/carvera-community/carvera_community_firmware/master/version.txt"
-    CTL_UPD_ADDRESS = "https://raw.githubusercontent.com/carvera-community/carvera_controller/main/CHANGELOG.md"
+    # /releases/latest returns the newest published, non-prerelease, non-draft
+    # release — so merged-but-unreleased changes and RCs are never offered as
+    # updates (issue #652).
+    FW_UPD_ADDRESS = "https://api.github.com/repos/Carvera-Community/Carvera_Community_Firmware/releases/latest"
+    CTL_UPD_ADDRESS = "https://api.github.com/repos/Carvera-Community/Carvera_Controller/releases/latest"
     DOWNLOAD_ADDRESS = "https://github.com/carvera-community/carvera_controller/releases/latest"
     FW_DOWNLOAD_ADDRESS = "https://github.com/Carvera-Community/Carvera_Community_Firmware/releases/latest"
 

--- a/tests/unit/test_firmware_version_utils.py
+++ b/tests/unit/test_firmware_version_utils.py
@@ -1,6 +1,8 @@
 """Tests for firmware version parsing in Utils.digitize_v."""
 
-from carveracontroller.Utils import digitize_v
+import json
+
+from carveracontroller.Utils import digitize_v, parse_github_release
 
 
 def test_digitize_v_handles_community_rc_versions():
@@ -12,3 +14,32 @@ def test_digitize_v_handles_community_rc_versions():
 
 def test_digitize_v_empty_version():
     assert digitize_v("") == 0
+
+
+class TestParseGithubRelease:
+    def test_parses_dict_payload(self):
+        version, notes = parse_github_release({"tag_name": "v2.1.0", "body": "notes here"})
+        assert version == "2.1.0"
+        assert notes == "notes here"
+
+    def test_parses_json_string_and_bytes(self):
+        payload = json.dumps({"tag_name": "v2.1.0c", "body": "fw notes"})
+        assert parse_github_release(payload) == ("2.1.0c", "fw notes")
+        assert parse_github_release(payload.encode()) == ("2.1.0c", "fw notes")
+
+    def test_tag_without_v_prefix(self):
+        assert parse_github_release({"tag_name": "2.0.0", "body": ""}) == ("2.0.0", "")
+
+    def test_falls_back_to_name_when_tag_missing(self):
+        assert parse_github_release({"name": "v1.2.3", "body": "x"}) == ("1.2.3", "x")
+
+    def test_missing_or_null_body_yields_empty_notes(self):
+        assert parse_github_release({"tag_name": "v1.0.0"}) == ("1.0.0", "")
+        assert parse_github_release({"tag_name": "v1.0.0", "body": None}) == ("1.0.0", "")
+
+    def test_invalid_payloads_yield_empty_result(self):
+        assert parse_github_release("not json") == ("", "")
+        assert parse_github_release(b"\xff\xfe") == ("", "")
+        assert parse_github_release(["list"]) == ("", "")
+        assert parse_github_release({"message": "Not Found"}) == ("", "")
+        assert parse_github_release({"tag_name": 123}) == ("", "")


### PR DESCRIPTION
Fixes #652.

## What

Both update checks (controller and firmware) now use the GitHub releases API instead of scraping files from branch heads:

| Before | After |
|---|---|
| `raw.githubusercontent.com/...carvera_controller/main/CHANGELOG.md` + regex `[x.y.z]` | `api.github.com/repos/Carvera-Community/Carvera_Controller/releases/latest` → `tag_name` |
| `raw.githubusercontent.com/...carvera_community_firmware/master/version.txt` + regex | `api.github.com/repos/Carvera-Community/Carvera_Community_Firmware/releases/latest` → `tag_name` |

`/releases/latest` returns the newest **published, non-prerelease, non-draft** release — so merged-but-unreleased changes and RCs are never announced as updates, which is exactly the pain point in the issue.

## Changes

- `Utils.parse_github_release()`: tolerant `(version, notes)` extraction — accepts the dict that Kivy's `UrlRequest` produces for `application/json` responses as well as raw JSON strings/bytes, strips the `v` prefix from tags (`v2.1.0` → `2.1.0`, `v2.1.0c` → `2.1.0c`), and returns empty values for unusable payloads (404 bodies, missing/non-string tags) so callers treat them as "no release found".
- `check_for_updates()` sends a `User-Agent` header (required by the GitHub API) plus `Accept: application/vnd.github+json`.
- The upgrade popup now shows the **release notes** of the latest release instead of the raw changelog/version.txt dump, and version comparison uses the release tag directly instead of regexing the first `[x.y.z]` out of a markdown file.
- Existing update-flow structure kept intact: `fw_version_new`/`ctl_version_new`, `digitize_v` comparison, the idle-time `check_fw_version()` trigger and the badge properties all work as before.

## Testing

- 6 new unit tests for `parse_github_release` (dict/string/bytes payloads, `v`-prefix stripping, `name` fallback, null body, 404/garbage payloads); full suite passes (251 locally, `hid`-dependent pendant files skipped on Windows).
- Verified end-to-end against the live API: both endpoints fetched with the exact headers the app sends; controller parsed as `2.1.0`, firmware as `2.1.0c`, release notes extracted.
- App smoke-tested: boots cleanly, startup update check runs without errors.

## Notes

- Unauthenticated GitHub API allows 60 requests/hour/IP; the app makes 2 per launch, so rate limiting is not a concern.
- If a rate-limited/404 response ever arrives, the parser returns empty values and the app behaves exactly as it does today on a failed download (no update announced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
