### PR TITLE
Show the WCS rotation angle on the coordinate-system button

### DIFF
--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1488,11 +1488,11 @@ class WCSSettingsPopup(ModalView):
         """Populate the WCS fields with parsed data from machine"""
 
         def update_ui(dt):
-            # wcs_data format: {'G54': [x, y, z, a, rotation], 'G55': [...], ...}
+            # wcs_data format: {'G54': [x, y, z, a, b, rotation], 'G55': [...], ...}
 
             for wcs, values in wcs_data.items():
-                if len(values) >= 5:  # Ensure we have X, Y, Z, A, rotation
-                    x, y, z, a, b, rotation = values
+                if len(values) >= 6:  # Ensure we have X, Y, Z, A, B, rotation
+                    x, y, z, a, b, rotation = values[:6]
 
                     # Store original values for comparison
                     self.original_values[wcs] = {"X": x, "Y": y, "Z": z, "A": a, "B": b, "R": rotation}
@@ -6201,8 +6201,15 @@ class Makera(RelativeLayout):
                 self.coord_system_data_view.main_text = wcs_description
             else:
                 self.coord_system_data_view.main_text = coord_system_name
-            self.coord_system_data_view.minr_text = coord_system_name
-            self.coord_system_data_view.scale = 80.0 if abs(rotation_angle) > 0.01 else 100.0
+            # Take turns between the WCS name and the rotation angle (same
+            # pattern as the feed/spindle/tool buttons), so a rotated WCS
+            # shows its angle without ever hiding the WCS name (#637).
+            has_rotation = abs(rotation_angle) > 0.001
+            if has_rotation and self.status_index % 2 == 1:
+                self.coord_system_data_view.minr_text = f"R: {rotation_angle:.3f}°"
+            else:
+                self.coord_system_data_view.minr_text = coord_system_name
+            self.coord_system_data_view.scale = 80.0 if has_rotation else 100.0
 
             # Update WCS Settings popup if it's open
             if hasattr(self, "wcs_settings_popup") and self.wcs_settings_popup.parent:


### PR DESCRIPTION
Fixes #637, implementing the approach agreed in the issue discussion.

## What

When the active WCS has a rotation set, the coordinate-system button's minor text now **takes turns** between the WCS name and the rotation angle (`R: x.xxx°`), using the same `status_index` alternation as the feed, spindle and tool buttons. With no rotation, it shows the WCS name full-time, as before.

This addresses both sides of the discussion:

- the rotation angle is visible on the main screen again (the original report), and
- the WCS name is never hidden (the concern that led to #638 being closed — with a description set, replacing the minor text outright would have removed the name entirely).

The existing shrink-to-80% hint for a rotated WCS is kept, now driven by the same `has_rotation` condition.

## Also fixed

The guard flagged at the end of the issue: `populate_wcs_values()` checked `len(values) >= 5` but then unpacked **six** values, so a five-element entry would raise `ValueError` instead of being skipped. The guard now requires six values and unpacks `values[:6]` (B stays unused, per the discussion — the controller doesn't support 5-axis).

## Testing

- Full unit suite passes (245 locally; `hid`-dependent pendant files skipped on Windows), `ruff` clean.
- App smoke-tested: boots cleanly; coordinate-system button renders and alternates on the `switch_status` cadence.
- Not tested against a machine with a rotated WCS (no hardware here) — the alternation logic mirrors the surrounding feed/spindle/tool button code paths, which run on every status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
