### PR TITLE
Fixes for Probing Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 [2.2.0-RC2]
 - Fixed: Prevent a probing modal crash if E is not provided when using the angle operation
+- Fixed: Default Values on Probing screens caused probing to fail unexpectedly 
+- Changed: added help button to probing screen confirmation/error popup for clarity
+
 
 [2.2.0-RC1]
 - Enhancement: Read tool definitions from post-processor outputs and use them in the G-code viewer

--- a/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
+++ b/carveracontroller/addons/probing/operations/OutsideCorner/OutsideCornerSettings.kv
@@ -32,7 +32,7 @@
                     halign:'right'
                     input_type: 'number'
                     input_filter: 'float'
-                    text: root.get_setting('XAxisDistance') if root.get_setting('XAxisDistance') != '' else '30'
+                    text: root.get_setting('XAxisDistance')
                     on_text: root.setting_changed('XAxisDistance', self.text)
             BoxLayout:
                 ProbeSettingLabel:
@@ -49,7 +49,7 @@
                     halign:'right'
                     input_type: 'number'
                     input_filter: 'float'
-                    text: root.get_setting('YAxisDistance') if root.get_setting('YAxisDistance') != '' else '30'
+                    text: root.get_setting('YAxisDistance')
                     on_text: root.setting_changed('YAxisDistance', self.text)
             BoxLayout:
                 ProbeSettingLabel:

--- a/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
+++ b/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
@@ -59,6 +59,8 @@
                 disabled: (not root.gcode) or (app.state != 'Idle')
                 on_release: root.start_probing()
 #                    root.dismiss()
+            HelpButton:
+                helpPath: "https://carvera-community.gitbook.io/docs/firmware/features/3d-probe-support"
 
 
 


### PR DESCRIPTION
Fixed: Default Values on Probing screens caused probing to fail unexpectedly
Changed: added help button to probing screen confirmation/error popup for clarity