### PR TITLE
CMM Workbench: Detect unexpected machine states during probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 [2.2.0-RC2]
 - Fixed: Prevent a probing modal crash if E is not provided when using the angle operation
+- Enhancement: Abort CMM workbench operations when an invalid machine state is detected
 
 [2.2.0-RC1]
 - Enhancement: Read tool definitions from post-processor outputs and use them in the G-code viewer

--- a/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
+++ b/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
@@ -237,9 +237,10 @@ class CMMWorkbenchPopup(ModalView):
             set_status_text=lambda v: setattr(self, "probing_status_text", v),
             on_is_probing_changed=self._on_probe_is_probing_changed,
             controller_abort=self.controller.abortCommand,
-            idle_ok=self._idle_ok,
+            get_machine_state=lambda: App.get_running_app().state,
+            on_timeout=self._on_probe_timeout_toast,
+            on_invalid_state=self._on_probe_invalid_state,
         )
-        self._runner.set_on_timeout(self._on_probe_timeout_toast)
 
     def on_kv_post(self, base_widget):
         super().on_kv_post(base_widget)
@@ -447,6 +448,11 @@ class CMMWorkbenchPopup(ModalView):
         if self._capture is not None:
             self._capture.reset()
         self._toast(tr._("Probe timed out."))
+
+    def _on_probe_invalid_state(self, state: str) -> None:
+        if self._capture is not None:
+            self._capture.reset()
+        self._toast(tr._('Probing failed: Unexpected machine state "%s".') % state)
 
     def _cancel_probe_run(self) -> None:
         if self._capture is not None:

--- a/carveracontroller/addons/cmm_workbench/ui/probe_runner.py
+++ b/carveracontroller/addons/cmm_workbench/ui/probe_runner.py
@@ -22,13 +22,17 @@ class ProbeRunner:
         set_status_text: Callable[[str], None],
         on_is_probing_changed: Callable[[], None],
         controller_abort: Callable[[], None],
-        idle_ok: Callable[[], bool],
+        get_machine_state: Callable[[], str],
+        on_timeout: Callable[[], None],
+        on_invalid_state: Callable[[str], None],
     ) -> None:
         self._set_is_probing = set_is_probing
         self._set_status_text = set_status_text
         self._on_is_probing_changed = on_is_probing_changed
         self._controller_abort = controller_abort
-        self._idle_ok = idle_ok
+        self._get_machine_state = get_machine_state
+        self._on_timeout_cb = on_timeout
+        self._on_invalid_state_cb = on_invalid_state
 
         self._gen: int = 0
         self._active_token: int | None = None
@@ -80,7 +84,7 @@ class ProbeRunner:
         """Cancel the current probe run and optionally abort the machine."""
         self._invalidate_token()
         self._clear_events()
-        if abort_machine and not self._idle_ok():
+        if abort_machine and self._get_machine_state() != "Idle":
             self._controller_abort()
         self._set_is_probing(False)
         self._set_status_text("")
@@ -112,6 +116,9 @@ class ProbeRunner:
             self._timeout_event = None
 
     def _tick_anim(self, _dt=None) -> None:
+        self._check_machine_state()
+        if self._active_token is None:
+            return
         self._anim_frame = (self._anim_frame + 1) % len(_PROBE_ANIM_FRAMES)
         self._tick_status()
 
@@ -119,18 +126,19 @@ class ProbeRunner:
         frame = _PROBE_ANIM_FRAMES[self._anim_frame % len(_PROBE_ANIM_FRAMES)]
         self._set_status_text(f"{frame}  {tr._('Probing in progress ...')}")
 
+    def _check_machine_state(self) -> None:
+        if self._active_token is None:
+            return
+        state = self._get_machine_state()
+        if state in ("Idle", "Run"):
+            return
+        self.cancel(abort_machine=False)
+        self._on_invalid_state_cb(state)
+
     def _on_timeout(self, _dt=None, run_token: int | None = None) -> None:
         if self._active_token is None:
             return
         if run_token is None or run_token != self._active_token:
             return
         self.cancel(abort_machine=True)
-        if self._on_timeout_cb is not None:
-            self._on_timeout_cb()
-
-    # Optional timeout notification callback set after construction.
-    _on_timeout_cb: Callable[[], None] | None = None
-
-    def set_on_timeout(self, cb: Callable[[], None]) -> None:
-        """Register a callback invoked when the probe times out."""
-        self._on_timeout_cb = cb
+        self._on_timeout_cb()


### PR DESCRIPTION
This PR adds a small check every time the CMM workbench spinner is refreshed (about 5 times/second when running) so that we can abort the current operation if the machine goes into a state other than "Run" or "Idle". The idea is to prevent users having to wait for the entire duration of the 30s timeout before resuming if an error occurs or if the controller gets disconnected from the machine.

**It should only be merged if we decide to abandon #713 since that one also contains a similar check**