### PR TITLE
Build: Windows pure-Python msgfmt fallback (no gettext tools needed)

### DIFF
--- a/scripts/update_translations.py
+++ b/scripts/update_translations.py
@@ -85,11 +85,111 @@ def generate_po():
 
 def compile_mo():
     # Compile .po files to .mo files
+    import shutil as _shutil
+    import struct as _struct
     po_files = [f"{PACKAGE_PATH}/locales/{lang}/LC_MESSAGES/{lang}.po" for lang in LANGUAGES]
     for po_file in po_files:
         mo_file = po_file.replace(".po", ".mo")
-        subprocess.run(["msgfmt", "-o", mo_file, po_file], cwd=PACKAGE_PATH)
-        print(f"Compiled {po_file} to {mo_file}")
+        # Prefer external msgfmt if available; fall back to pure-Python compiler
+        msgfmt_exe = _shutil.which("msgfmt")
+        if msgfmt_exe is not None:
+            subprocess.run([msgfmt_exe, "-o", mo_file, po_file], cwd=PACKAGE_PATH)
+            print(f"Compiled {po_file} to {mo_file} (msgfmt)")
+            continue
+        # --- Pure-Python fallback compiler (no gettext tools required) ---
+        entries = []
+        with open(po_file, encoding="utf-8") as f:
+            data = f.read()
+        blocks = []
+        current = []
+        for line in data.splitlines():
+            if line.strip() == "":
+                if current:
+                    blocks.append(current)
+                    current = []
+            else:
+                current.append(line)
+        if current:
+            blocks.append(current)
+
+        def _strip_quote(s):
+            s = s.strip()
+            if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+                s = s[1:-1]
+            out = []
+            i = 0
+            while i < len(s):
+                if s[i] == "\\" and i + 1 < len(s):
+                    n = s[i + 1]
+                    out.append({
+                        "n": "\n", "t": "\t", "r": "\r",
+                        '"': '"', "'": "'", "\\": "\\",
+                    }.get(n, n))
+                    i += 2
+                else:
+                    out.append(s[i])
+                    i += 1
+            return "".join(out)
+
+        for block in blocks:
+            msgid_lines = []
+            msgstr_lines = []
+            mode = None
+            for line in block:
+                line_s = line.strip()
+                if line_s.startswith("#"):
+                    continue
+                if line_s.startswith("msgid "):
+                    mode = "msgid"
+                    msgid_lines.append(line_s[len("msgid "):])
+                elif line_s.startswith("msgstr "):
+                    mode = "msgstr"
+                    msgstr_lines.append(line_s[len("msgstr "):])
+                elif (line_s[:1] in ('"', "'")):
+                    if mode == "msgid":
+                        msgid_lines.append(line_s)
+                    elif mode == "msgstr":
+                        msgstr_lines.append(line_s)
+            msgid = _strip_quote("".join(msgid_lines)) if msgid_lines else ""
+            msgstr = _strip_quote("".join(msgstr_lines)) if msgstr_lines else ""
+            if msgid != "" or msgstr != "":
+                entries.append((msgid.encode("utf-8"), msgstr.encode("utf-8")))
+
+        num = len(entries)
+        data = bytearray()
+        data += _struct.pack("<I", 0x950412de)
+        data += _struct.pack("<I", 0)
+        data += _struct.pack("<I", num)
+        id_off = 28
+        str_off = 28 + num * 8
+        data += _struct.pack("<I", id_off)
+        data += _struct.pack("<I", str_off)
+        data += _struct.pack("<I", 0)
+        data += _struct.pack("<I", 0)
+        # Compute block start
+        blob_start = 28 + num * 8 * 2
+        cur = blob_start
+        id_descs = []
+        for msgid, _msgstr in entries:
+            id_descs.append((len(msgid), cur))
+            cur += len(msgid) + 1
+        str_descs = []
+        for _msgid, msgstr in entries:
+            str_descs.append((len(msgstr), cur))
+            cur += len(msgstr) + 1
+        for length, offset in id_descs:
+            data += _struct.pack("<I", length)
+            data += _struct.pack("<I", offset)
+        for length, offset in str_descs:
+            data += _struct.pack("<I", length)
+            data += _struct.pack("<I", offset)
+        for msgid, _msgstr in entries:
+            data += msgid + b"\x00"
+        for _msgid, msgstr in entries:
+            data += msgstr + b"\x00"
+        with open(mo_file, "wb") as f:
+            f.write(bytes(data))
+        print(f"Compiled {po_file} to {mo_file} (pure-python fallback)")
 
 
 def main():


### PR DESCRIPTION
- Scripts that ship with the repo (build.py compile_mo step) called external msgfmt.exe unconditionally, which is not installed by default on Windows developer machines causing FileNotFoundError
- Prefer external msgfmt if present on PATH (existing behavior)
- Fall back to a minimal pure-Python .po -> .mo compiler covering the small message set used by carveracontroller (en + zh-CN), so builds work out-of-the-box without installing GNU gettext on Windows
- Tested: build.py --os windows completes without error on clean Windows