### PR TITLE
Add "Allow jogging when spindle or laser is on" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 [2.2.0-RC2]
+- Enhancement: Adds "Allow Jogging When Spindle Is On" option (disabled by default). "Allow Jogging When Machine Running" will now be enabled by default. Existing configs that already allowed jogging while the machine is running also enable the new spindle option.
 - Fixed: Prevent a probing modal crash if E is not provided when using the angle operation
 
 [2.2.0-RC1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 [2.2.0-RC2]
-- Enhancement: Adds "Allow Jogging When Spindle Is On" option (disabled by default). "Allow Jogging When Machine Running" will now be enabled by default. Existing configs that already allowed jogging while the machine is running also enable the new spindle option.
+- Enhancement: Adds "Allow Jogging When Spindle or Laser Is On" option (disabled by default). "Allow Jogging When Machine Running" will now be enabled by default. Existing configs that already allowed jogging while the machine is running also enable the new spindle/laser option.
 - Fixed: Prevent a probing modal crash if E is not provided when using the angle operation
 
 [2.2.0-RC1]

--- a/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.kv
+++ b/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.kv
@@ -1103,7 +1103,7 @@
                             size: self.size
                             radius: [self.height / 2, self.height / 2]
                     BoxLayout:
-                        disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                        disabled: not app.jog_controls_enabled
                         padding: dp(0)
                         canvas.before:
                             Color:
@@ -1153,7 +1153,7 @@
                                     on_release: app.root.controller.stopContinuousJog()
                             GridBoxLayout:
                 BoxLayout:
-                    disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                    disabled: not app.jog_controls_enabled
                     padding: dp(0)
                     orientation: 'horizontal'
                     size_hint_x: 1

--- a/carveracontroller/addons/probing/ProbingPopup.kv
+++ b/carveracontroller/addons/probing/ProbingPopup.kv
@@ -489,7 +489,7 @@
                             size: self.size
                             radius: [self.height / 2,self.height / 2]
                     BoxLayout:
-                        disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                        disabled: not app.jog_controls_enabled
                         padding: '0dp'
                         canvas.before:
                             Color:
@@ -536,12 +536,12 @@
                             GridBoxLayout:
                 BoxLayout:
                     size_hint_x: 0.1
-                    disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                    disabled: not app.jog_controls_enabled
                     padding: '0dp'
                     orientation: 'horizontal'
                 #A and Z controls
                 BoxLayout:
-                    disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                    disabled: not app.jog_controls_enabled
                     padding: '0dp'
                     orientation: 'horizontal'
                     canvas.before:
@@ -601,7 +601,7 @@
                                 on_release: app.root.controller.stopContinuousJog()
                 BoxLayout:
                     size_hint_x: 0.1
-                    disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and app.root.allow_jogging_while_machine_running == '0')
+                    disabled: not app.jog_controls_enabled
                     padding: '0dp'
                     orientation: 'horizontal'
                 BoxLayout:

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -121,8 +121,8 @@
     },
     {
         "type": "bool",
-        "title": "Allow Jogging When Spindle Is On",
-        "desc": "Allow jogging while the spindle is enabled. Use this functionality with caution.",
+        "title": "Allow Jogging When Spindle or Laser Is On",
+        "desc": "Allow jogging while the spindle is spinning or the laser is firing. Use this functionality with caution.",
         "section": "carvera",
         "key": "allow_jogging_while_spindle_on",
         "default": "false"

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -114,9 +114,17 @@
     {
         "type": "bool",
         "title": "Allow Jogging When Machine Running",
-        "desc": "This option allows for manual movement while spindle is running. Use this functionality with caution.",
+        "desc": "Allow jogging while the machine is in the Run state. Use this functionality with caution.",
         "section": "carvera",
         "key": "allow_jogging_while_machine_running",
+        "default": "true"
+    },
+    {
+        "type": "bool",
+        "title": "Allow Jogging When Spindle Is On",
+        "desc": "Allow jogging while the spindle is enabled. Use this functionality with caution.",
+        "section": "carvera",
+        "key": "allow_jogging_while_spindle_on",
         "default": "false"
     },
     {

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6109,10 +6109,9 @@ class Makera(RelativeLayout):
                 else:
                     v.minr_text = "Vac: {}".format("On" if CNC.vars["vacuummode"] else "Off")
 
-            app.spindle_on = (
-                app.state not in (NOT_CONNECTED, CONNECTED)
-                and not CNC.vars["lasermode"]
-                and CNC.vars["curspindle"] > 0.0
+            app.spindle_or_laser_is_on = app.state not in (NOT_CONNECTED, CONNECTED) and (
+                (not CNC.vars["lasermode"] and CNC.vars["curspindle"] > 0.0)
+                or (CNC.vars["lasermode"] and CNC.vars["laserpower"] > 0.0)
             )
 
             elapsed = now - self.control_list["vacuum_mode"][0]
@@ -6809,7 +6808,7 @@ class Makera(RelativeLayout):
             app.bind(
                 state=self.update_jog_controls_enabled,
                 playing=self.update_jog_controls_enabled,
-                spindle_on=self.update_jog_controls_enabled,
+                spindle_or_laser_is_on=self.update_jog_controls_enabled,
             )
         self.update_jog_controls_enabled()
 
@@ -6827,7 +6826,7 @@ class Makera(RelativeLayout):
                 app.state in ["Idle", "Pause"]
                 or (app.state == "Run" and self.allow_jogging_while_machine_running == "1")
             )
-            and (not app.spindle_on or self.allow_jogging_while_spindle_on == "1")
+            and (not app.spindle_or_laser_is_on or self.allow_jogging_while_spindle_on == "1")
         )
 
     def is_jogging_enabled(self):
@@ -7904,7 +7903,7 @@ class Makera(RelativeLayout):
 class MakeraApp(App):
     state = StringProperty(NOT_CONNECTED)
     playing = BooleanProperty(False)
-    spindle_on = BooleanProperty(False)
+    spindle_or_laser_is_on = BooleanProperty(False)
     jog_controls_enabled = BooleanProperty(False)
     has_4axis = BooleanProperty(False)
     has_atc = BooleanProperty(False)

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3031,7 +3031,8 @@ class Makera(RelativeLayout):
     status_index = 0
     past_machine_addr = None
     allow_mdi_while_machine_running = "0"
-    allow_jogging_while_machine_running = "0"
+    allow_jogging_while_machine_running = "1"
+    allow_jogging_while_spindle_on = "0"
     _selected_file_machine_key = None
     _last_loaded_file_key = None  # used to track if a different file is selected
 
@@ -3200,6 +3201,11 @@ class Makera(RelativeLayout):
 
         if Config.has_option("carvera", "allow_jogging_while_machine_running"):
             self.allow_jogging_while_machine_running = Config.get("carvera", "allow_jogging_while_machine_running")
+
+        if Config.has_option("carvera", "allow_jogging_while_spindle_on"):
+            self.allow_jogging_while_spindle_on = Config.get("carvera", "allow_jogging_while_spindle_on")
+
+        self._bind_jog_control_deps()
 
         # Setup pendant
         self.refresh_pendant_settings()
@@ -6103,6 +6109,12 @@ class Makera(RelativeLayout):
                 else:
                     v.minr_text = "Vac: {}".format("On" if CNC.vars["vacuummode"] else "Off")
 
+            app.spindle_on = (
+                app.state not in (NOT_CONNECTED, CONNECTED)
+                and not CNC.vars["lasermode"]
+                and CNC.vars["curspindle"] > 0.0
+            )
+
             elapsed = now - self.control_list["vacuum_mode"][0]
             if elapsed < 2:
                 if elapsed > 0.5:
@@ -6791,21 +6803,37 @@ class Makera(RelativeLayout):
             modals.append(self.cmm_workbench_popup)
         return self._is_popup_open() and not any(m.allows_external_jog() for m in modals)
 
-    def is_jogging_enabled(self):
+    def _bind_jog_control_deps(self):
         app = App.get_running_app()
+        if app is not None:
+            app.bind(
+                state=self.update_jog_controls_enabled,
+                playing=self.update_jog_controls_enabled,
+                spindle_on=self.update_jog_controls_enabled,
+            )
+        self.update_jog_controls_enabled()
 
-        # Keyboard/pendant jogging is normally blocked whenever a modal popup is open,
-        # except for probing and the probe-scan jog overlay (see allows_external_jog).
-        popup_prevents_jogging = self._popup_prevents_jogging()
+    def update_jog_controls_enabled(self, *args):
+        app = App.get_running_app()
+        if app is None:
+            return
+        app.jog_controls_enabled = self._machine_allows_jogging()
 
+    def _machine_allows_jogging(self):
+        app = App.get_running_app()
         return (
             (not app.playing or app.state == "Pause")
             and (
                 app.state in ["Idle", "Pause"]
                 or (app.state == "Run" and self.allow_jogging_while_machine_running == "1")
             )
-            and not popup_prevents_jogging
+            and (not app.spindle_on or self.allow_jogging_while_spindle_on == "1")
         )
+
+    def is_jogging_enabled(self):
+        # Keyboard/pendant jogging is normally blocked whenever a modal popup is open,
+        # except for probing and the probe-scan jog overlay (see allows_external_jog).
+        return self._machine_allows_jogging() and not self._popup_prevents_jogging()
 
     def is_pendant_jogging_enabled(self):
         # If the user disabled pendant, respect it.
@@ -7092,13 +7120,19 @@ class Makera(RelativeLayout):
                 "allow_mdi_while_machine_running"
             )
 
-        if (
-            self.controller_setting_change_list.get("allow_jogging_while_machine_running")
-            != self.allow_jogging_while_machine_running
-        ):
-            self.allow_jogging_while_machine_running = self.controller_setting_change_list.get(
+        if "allow_jogging_while_machine_running" in self.controller_setting_change_list:
+            self.allow_jogging_while_machine_running = self.controller_setting_change_list[
                 "allow_jogging_while_machine_running"
-            )
+            ]
+
+        if "allow_jogging_while_spindle_on" in self.controller_setting_change_list:
+            self.allow_jogging_while_spindle_on = self.controller_setting_change_list["allow_jogging_while_spindle_on"]
+
+        if (
+            "allow_jogging_while_machine_running" in self.controller_setting_change_list
+            or "allow_jogging_while_spindle_on" in self.controller_setting_change_list
+        ):
+            self.update_jog_controls_enabled()
 
         if self.controller_setting_change_list.get("invert_y_axis_jogging"):
             App.get_running_app().invert_y_axis_jogging = (
@@ -7870,6 +7904,8 @@ class Makera(RelativeLayout):
 class MakeraApp(App):
     state = StringProperty(NOT_CONNECTED)
     playing = BooleanProperty(False)
+    spindle_on = BooleanProperty(False)
+    jog_controls_enabled = BooleanProperty(False)
     has_4axis = BooleanProperty(False)
     has_atc = BooleanProperty(False)
     lasering = BooleanProperty(False)
@@ -8048,6 +8084,14 @@ def set_config_defaults(default_lang):
         Config.set("carvera", "custom_bkg_img_dir", "")
     if not Config.has_option("carvera", "invert_y_axis_jogging"):
         Config.set("carvera", "invert_y_axis_jogging", "0")
+    had_jogging_while_running = Config.has_option("carvera", "allow_jogging_while_machine_running")
+    if not had_jogging_while_running:
+        Config.set("carvera", "allow_jogging_while_machine_running", "1")
+    if not Config.has_option("carvera", "allow_jogging_while_spindle_on"):
+        migrate_spindle_on = had_jogging_while_running and Config.getboolean(
+            "carvera", "allow_jogging_while_machine_running", fallback=False
+        )
+        Config.set("carvera", "allow_jogging_while_spindle_on", "1" if migrate_spindle_on else "0")
     if not Config.has_option("carvera", "allow_manual_usb_device"):
         Config.set("carvera", "allow_manual_usb_device", "0")
     if not Config.has_option("carvera", "manual_usb_device"):

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3757,7 +3757,7 @@
                                 size: self.size
                                 radius: [self.height / 2,]
                         BoxLayout:
-                            disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
+                            disabled: not app.jog_controls_enabled
                             padding: '25dp'
                             canvas.before:
                                 Color:
@@ -3825,7 +3825,7 @@
                             Widget:
                                 size_hint_y: 0.15
                             BoxLayout:
-                                disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
+                                disabled: not app.jog_controls_enabled
                                 orientation: 'vertical'
                                 padding: '3dp'
                                 size_hint_y: 0.3
@@ -3986,7 +3986,7 @@
                             Widget:
                                 size_hint_y: 0.1
                             BoxLayout:
-                                disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
+                                disabled: not app.jog_controls_enabled
                                 orientation: 'vertical'
                                 padding: '3dp'
                                 size_hint_y: 0.5
@@ -4035,7 +4035,7 @@
                                                 on_release: app.root.toggle_pendant_jog_control()
 
                         BoxLayout:
-                            disabled: not (app.state == 'Idle' or app.state == 'Run' or app.state == 'Pause') or (app.playing and app.state != 'Pause') or (app.state == 'Run' and root.allow_jogging_while_machine_running == '0')
+                            disabled: not app.jog_controls_enabled
                             padding: '25dp'
                             orientation: 'horizontal'
                             canvas.before:


### PR DESCRIPTION
Related to https://github.com/Carvera-Community/Carvera_Controller/issues/730#issuecomment-5250466360

This adds a new "Allow jogging when spindle or laser is on" setting after the existing "Allow jogging when machine running":

<img width="1365" height="287" alt="image" src="https://github.com/user-attachments/assets/aabae3c3-df5f-4153-b7bb-2efa181cf333" />

By default the option is disabled on a new install, but takes the value of "Allow jogging when machine running" if it was already set (so same behaviors for existing users).

I did a bit of refactoring so that the current state can be accessed through `app.jog_controls_enabled` so we don't have to copy paste the same checks everywhere anymore (see `makera.kv` changes).

The current state of the spindle (**Edit:** and laser) is also now available in `app.spindle_or_laser_is_on`. It is considered enabled if:
* The current state is different from `NOT_CONNECTED` (for obvious reasons) and `CONNECTED` (which is in reality "Wait")
* And one of those two conditions is true:
  * The laser mode is disabled and `curspindle` is > 0 
  * The laser mode is enabled and `laserpower` is > 0


**EDIT:** I initially made it so that it only checked the spindle state (see first commit) and purposefully excluded the laser, but after thinking about it it doesn't make sense to allow jogging if the laser is on either, so I updated it in the second commit. Feel free to revert that one if you prefer to only check if the spindle is spinning.