### PR TITLE
Moved Z1 Camera to a collapsible area in the Gcode Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed: Z1 machine config backup option added to settings matching other models
 - Fixed: Switching between different machines no longer reuses the previous machine's settings panels or cached config.txt
 - Changed: added help button to probing screen confirmation/error popup for clarity
+- Changed: Moved Z1 Camera to a collapsible area in the Gcode Viewer. Collapsible splitter is only shown if a supported camera is found.
 
 [2.2.0-RC1]
 - Enhancement: Read tool definitions from post-processor outputs and use them in the G-code viewer

--- a/carveracontroller/addons/camera/CameraControls.kv
+++ b/carveracontroller/addons/camera/CameraControls.kv
@@ -7,7 +7,7 @@
 
 <CameraButtonSlot@AnchorLayout>:
     visible: False
-    anchor_x: 'right'
+    anchor_x: 'left'
     anchor_y: 'top'
     size_hint_y: None
     height: '50dp' if self.visible else 0
@@ -45,18 +45,8 @@
     adjust_open: False
     orientation: 'vertical'
     size_hint: None, None
-    width: '250dp'
+    width: '250dp' if root.adjust_open and app.camera_streaming else '50dp'
     height: self.minimum_height
-    CameraButtonSlot:
-        visible: app.supports_camera
-        TransparentButton:
-            icon: 'data/camera.png'
-            active: app.camera_streaming
-            size_hint: None, None
-            width: '50dp'
-            height: self.parent.height
-            on_release:
-                app.root.toggle_camera_stream()
     CameraButtonSlot:
         visible: app.camera_streaming
         TransparentButton:

--- a/carveracontroller/addons/camera/CameraView.py
+++ b/carveracontroller/addons/camera/CameraView.py
@@ -88,3 +88,18 @@ class CameraView(Widget):
         fitted_width, fitted_height = frame_width * scale, frame_height * scale
         self._rect.size = (fitted_width, fitted_height)
         self._rect.pos = (self.x + (width - fitted_width) / 2.0, self.y + (height - fitted_height) / 2.0)
+
+    def on_touch_down(self, touch):
+        if self.collide_point(*touch.pos):
+            return True
+        return super().on_touch_down(touch)
+
+    def on_touch_move(self, touch):
+        if self.collide_point(*touch.pos):
+            return True
+        return super().on_touch_move(touch)
+
+    def on_touch_up(self, touch):
+        if self.collide_point(*touch.pos):
+            return True
+        return super().on_touch_up(touch)

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -449,12 +449,15 @@ class FloatBox(FloatLayout):
     touch_interval = 0
     color_scheme_panel = ObjectProperty(None)
     camera_controls = ObjectProperty(None)
+    camera_view = ObjectProperty(None)
     tool_bar = ObjectProperty(None)
 
     def _viewer_chrome_hit(self, touch):
         if self.gcode_ctl_bar.collide_point(*touch.pos):
             return True
         if self.tool_bar is not None and self.tool_bar.collide_point(*touch.pos):
+            return True
+        if self.camera_view is not None and self.camera_view.collide_point(*touch.pos):
             return True
         return any(
             panel is not None and panel.collide_point(*touch.pos)
@@ -3179,6 +3182,8 @@ class Makera(RelativeLayout):
             on_streaming=self._set_camera_streaming,
             on_error=partial(self.show_message_popup, btn_disabled=False),
         )
+        self.ids.camera_splitter.bind(collapsed=self._on_camera_splitter_collapsed)
+        self.ids.camera_splitter.collapse()
 
         # init settings
         self.config = ConfigParser()
@@ -7519,9 +7524,24 @@ class Makera(RelativeLayout):
 
     # -----------------------------------------------------------------------
     def toggle_camera_stream(self):
+        splitter = self.ids.get("camera_splitter")
+        if splitter is not None:
+            splitter.toggle_collapsed()
+            return
         if self.camera_stream.is_streaming():
             self.camera_stream.stop()
         elif App.get_running_app().supports_camera:
+            self.camera_stream.start(self.controller.connection_address.split(":")[0])
+
+    # -----------------------------------------------------------------------
+    def _on_camera_splitter_collapsed(self, _splitter, collapsed):
+        if collapsed:
+            if self.camera_stream.is_streaming():
+                self.camera_stream.stop()
+            controls = self.ids.get("camera_controls")
+            if controls is not None:
+                controls.adjust_open = False
+        elif App.get_running_app().supports_camera and not self.camera_stream.is_streaming():
             self.camera_stream.start(self.controller.connection_address.split(":")[0])
 
     # -----------------------------------------------------------------------
@@ -7535,6 +7555,13 @@ class Makera(RelativeLayout):
         if probe != self.camera_probe:
             return
         App.get_running_app().supports_camera = found
+        splitter = self.ids.get("camera_splitter")
+        if splitter is None:
+            return
+        if found and splitter.collapsed:
+            splitter.height = splitter.strip_size
+        elif not found:
+            splitter.collapse()
 
     # -----------------------------------------------------------------------
     def set_camera_resolution(self, label):
@@ -7566,6 +7593,9 @@ class Makera(RelativeLayout):
     # -----------------------------------------------------------------------
     def _set_camera_streaming(self, streaming):
         App.get_running_app().camera_streaming = streaming
+        splitter = self.ids.get("camera_splitter")
+        if splitter is not None and not streaming and not splitter.collapsed:
+            splitter.collapse()
 
     # -----------------------------------------------------------------------
     def clear_selection(self):

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -4421,7 +4421,7 @@
                                 opacity: 1 if app.supports_camera else 0
                                 disabled: not app.supports_camera
                                 tooltip_txt: tr._('Hide camera') if app.camera_streaming else tr._('Show camera')
-                                pos: camera_splitter.center_x - self.width / 2, camera_splitter.top - camera_splitter.strip_size / 2 - self.height / 2
+                                pos: camera_splitter.center_x - self.width / 2, float_layout.y if camera_splitter.collapsed else (camera_splitter.top - camera_splitter.strip_size / 2 - self.height / 2)
                                 canvas.before:
                                     Color:
                                         rgba: 80/255, 80/255, 80/255, 1

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -5,6 +5,7 @@
 #:import _ carveracontroller.ui.LocalFilePicker
 #:import _ carveracontroller.ui.DirectoryView
 #:import _ carveracontroller.ui.DropDownSplitter
+#:import _ carveracontroller.ui.CollapsibleSplitter
 #:import play_progress_bar carveracontroller.ui.PlayProgressBar
 #:import GcodeColorSchemePanel carveracontroller.ui.GcodeColorSchemePanel.GcodeColorSchemePanel
 #:import CameraView carveracontroller.addons.camera.CameraView.CameraView
@@ -4241,25 +4242,52 @@
                             id: float_layout
                             color_scheme_panel: color_scheme_panel
                             camera_controls: camera_controls
+                            camera_view: camera_view
                             tool_bar: tool_bar
                             gcode_ctl_bar: gcode_ctl_bar
                             BoxLayout:
-                                id: gcode_viewer_container
-                                pos: float_layout.pos
                                 orientation: 'vertical'
+                                pos: float_layout.pos
+                                size: float_layout.size
+                                BoxLayout:
+                                    id: gcode_viewer_container
+                                    size_hint_y: 1
+                                    orientation: 'vertical'
+                                CollapsibleSplitter:
+                                    id: camera_splitter
+                                    sizable_from: 'top'
+                                    collapsed: True
+                                    size_hint_y: None
+                                    strip_size: '5dp' if app.supports_camera else 0
+                                    min_size: self.strip_size
+                                    keep_within_parent: True
+                                    opacity: 1 if app.supports_camera else 0
+                                    disabled: not app.supports_camera
+                                    canvas.before:
+                                        Color:
+                                            rgba: 0.6, 0.6, 0.6, 1
+                                        Rectangle:
+                                            pos: self.x, self.y + self.height - self.strip_size
+                                            size: self.width, self.strip_size
+                                    FloatLayout:
+                                        canvas.before:
+                                            Color:
+                                                rgba: 0, 0, 0, 1
+                                            Rectangle:
+                                                pos: self.pos
+                                                size: self.size
+                                        CameraView:
+                                            id: camera_view
+                                            pos: self.parent.pos
+                                            size: self.parent.size
+                                            brightness: app.camera_brightness
+                                            contrast: app.camera_contrast
+                                            gamma: app.camera_gamma
+                                        CameraControls:
+                                            id: camera_controls
+                                            pos_hint: {'x': 0, 'top': 1}
                             GcodeColorSchemePanel:
                                 id: color_scheme_panel
-                            CameraView:
-                                id: camera_view
-                                brightness: app.camera_brightness
-                                contrast: app.camera_contrast
-                                gamma: app.camera_gamma
-                                size_hint: None, None
-                                x: float_layout.x
-                                width: float_layout.width
-                                y: gcode_ctl_bar.top
-                                height: (tool_bar.y - gcode_ctl_bar.top) if app.camera_streaming else 0
-                                opacity: 1 if app.camera_streaming else 0
                             BoxLayout:
                                 id: tool_bar
                                 orbit: True
@@ -4335,7 +4363,7 @@
                                 size_hint_y: 0.2 if app.show_gcode_ctl_bar else 0
                                 opacity: 1 if app.show_gcode_ctl_bar else 0
                                 orientation: 'vertical'
-                                pos: float_layout.pos
+                                pos: gcode_viewer_container.pos
                                 canvas.before:
                                     Color:
                                         rgba: 10/255, 10/255, 10/255, 0.2
@@ -4384,9 +4412,23 @@
                                     max: 1000
                                     value: 1000
                                     disabled: app.selected_remote_filename == '' and app.selected_local_filename == ''
-                            CameraControls:
-                                id: camera_controls
-                                pos_hint: {'right': 1, 'top': 1}
+                            TransparentButton:
+                                size_hint: None, None
+                                size: '70dp', '28dp'
+                                icon: 'data/camera.png'
+                                icon_size: 17
+                                active: app.camera_streaming
+                                opacity: 1 if app.supports_camera else 0
+                                disabled: not app.supports_camera
+                                tooltip_txt: tr._('Hide camera') if app.camera_streaming else tr._('Show camera')
+                                pos: camera_splitter.center_x - self.width / 2, camera_splitter.top - camera_splitter.strip_size / 2 - self.height / 2
+                                canvas.before:
+                                    Color:
+                                        rgba: 80/255, 80/255, 80/255, 1
+                                    Rectangle:
+                                        pos: self.pos
+                                        size: self.size
+                                on_release: camera_splitter.toggle_collapsed()
 
             SettingPage:
                 name: 'Setting'

--- a/carveracontroller/ui/CollapsibleSplitter.py
+++ b/carveracontroller/ui/CollapsibleSplitter.py
@@ -1,0 +1,119 @@
+"""Splitter that collapses on click and resizes when the strip is dragged."""
+
+from kivy.factory import Factory
+from kivy.metrics import dp
+from kivy.properties import BooleanProperty, NumericProperty
+from kivy.uix.splitter import Splitter
+
+# Ignore jitter below this so a click is not treated as a tiny resize.
+_DRAG_THRESHOLD = dp(8)
+_MIN_SIBLING_SIZE = dp(120)
+
+
+class CollapsibleSplitter(Splitter):
+    """Vertical splitter whose strip toggles collapse unless the pointer is dragged.
+
+    A press that stays within the drag threshold collapses or restores the pane.
+    Moving past the threshold resizes it like a normal splitter.
+    """
+
+    collapsed = BooleanProperty(False)
+    _restore_height = NumericProperty(0)
+    _did_drag = BooleanProperty(False)
+    _press_pos = (0.0, 0.0)
+
+    def strip_down(self, instance, touch):
+        if not instance.collide_point(*touch.pos):
+            return False
+        # Do not grab or return True: SplitterStrip is a Button, and skipping
+        # ButtonBehavior.on_touch_down leaves touch.ud unset, so on_touch_up
+        # asserts. The Button grabs the strip after this observer runs.
+        self._press_pos = (touch.x, touch.y)
+        self._did_drag = False
+        self.dispatch("on_press")
+
+    def strip_move(self, instance, touch):
+        if not self._is_our_grab(touch, instance):
+            return False
+        if not self._did_drag:
+            if not self._moved_enough(touch):
+                return False
+            self._did_drag = True
+            if self.collapsed:
+                self.collapsed = False
+                self.size_hint_y = None
+        self._resize_from_touch(touch)
+        return True
+
+    def strip_up(self, instance, touch):
+        if not self._is_our_grab(touch, instance):
+            return
+        if not self._did_drag:
+            self.toggle_collapsed()
+        elif self.height <= self.strip_size + 1:
+            self.collapsed = True
+            self._restore_height = self._restore_height or self.height
+        else:
+            self.collapsed = False
+            self._restore_height = self.height
+        self.dispatch("on_release")
+
+    def toggle_collapsed(self):
+        if self.collapsed:
+            self.expand()
+        else:
+            self.collapse()
+
+    def collapse(self):
+        if not self.collapsed:
+            self._restore_height = max(self.height, self.strip_size)
+        self.collapsed = True
+        self.size_hint_y = None
+        self.height = self.strip_size
+
+    def expand(self):
+        self.collapsed = False
+        self.size_hint_y = None
+        restore = self._restore_height
+        if restore <= self.strip_size:
+            restore = 0.3 * (self.parent.height if self.parent else self.height or 200)
+        self.height = max(self.min_size, min(restore, self.max_size))
+
+    def _do_size(self, instance, value):
+        if self.collapsed:
+            return
+        super()._do_size(instance, value)
+
+    def rescale_parent_proportion(self, *args):
+        if self.parent is not None:
+            self.max_size = max(self.min_size, self.parent.height - _MIN_SIBLING_SIZE)
+        if self.collapsed:
+            self.height = self.strip_size
+            return
+        super().rescale_parent_proportion(*args)
+
+    def _moved_enough(self, touch):
+        dx = touch.x - self._press_pos[0]
+        dy = touch.y - self._press_pos[1]
+        return (dx * dx + dy * dy) >= _DRAG_THRESHOLD * _DRAG_THRESHOLD
+
+    def _resize_from_touch(self, touch):
+        diff_y = touch.dy
+        if self.sizable_from[0] == "b":
+            diff_y *= -1
+        if self.size_hint_y:
+            self.size_hint_y = None
+        max_height = self.max_size
+        if self.keep_within_parent and self.parent is not None:
+            max_height = min(max_height, self.parent.top - self.y)
+        self.height = max(self.min_size, min(self.height + diff_y, max_height))
+        if self.parent is not None and self.parent.height:
+            self._parent_proportion = self.height / self.parent.height
+
+    @staticmethod
+    def _is_our_grab(touch, instance):
+        return touch.grab_current is instance
+
+
+if "CollapsibleSplitter" not in Factory.classes:
+    Factory.register("CollapsibleSplitter", cls=CollapsibleSplitter)


### PR DESCRIPTION
Added a new UI element for us to use CollapsibleSplitter. It's like a normal Splitter but when clicked it collapsed/opens, and if dragged it resizes.

I've moved the Z1 CameraView to an area hidden by this CollapsibleSplitter, and tied toggling the CameraStream with the colapsed/open state. The Splitter doesn't show up if there is no supported Camera.

In future I would like to put my #587 into this collapsible area as well. Not sure yet how the toggle between the Camera view and Graph view should look (maybe two buttons? Both open = 50:50 split vertically?), but that's a problem for next release.

Not sure if it's the right stylist choice, but I intentionally had the Camera icon peeking when in the Collapsed state to help signal that it's hidden. @MichaelLevAstro @michael-ring  @Lyrkan Opinions?

Ultimately I'm doing this to resolve #716 

<img width="1797" height="1089" alt="Screenshot 2026-08-19 at 11 22 31 pm" src="https://github.com/user-attachments/assets/b35ce178-235a-48e3-9dff-9c1744d8fb9a" />

<img width="1798" height="1098" alt="Screenshot 2026-08-19 at 11 22 44 pm" src="https://github.com/user-attachments/assets/a9eea496-f166-459f-9005-fbd0f06ef6e3" />
