### PR TITLE
Fix G-Code files not being properly loaded when they end with comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed: Z1 machine settings tabs now load
 - Fixed: Z1 machine config backup option added to settings matching other models
 - Fixed: Switching between different machines no longer reuses the previous machine's settings panels or cached config.txt
+- Fixed: Fix G-Code files not being properly loaded when they end with comments
 - Changed: added help button to probing screen confirmation/error popup for clarity
 
 [2.2.0-RC1]

--- a/carveracontroller/GcodeViewer.py
+++ b/carveracontroller/GcodeViewer.py
@@ -942,6 +942,13 @@ class GCodeViewer(Widget):
     def set_play_over_callback(self, playovercallback):
         self.play_over_callback = playovercallback
 
+    def begin_new_file_load(self):
+        """Drop leftover path vertices so a new file cannot inherit the previous load."""
+        self.clear_before_new_load = False
+        self.meshmanager.clear()
+        self.total_distance = 0.0
+        self.total_line_count = 0
+
     def clear_loaded_memery(self):
         if self.clear_before_new_load:
             self.clear_before_new_load = False
@@ -1057,7 +1064,7 @@ class GCodeViewer(Widget):
             self.angles_of_vertices = self.meshmanager.angles_of_vertices
 
             self.total_line_count = self.meshmanager.get_pt_count()
-            self.total_distance = self.meshmanager.lengths[-1]
+            self.total_distance = self.meshmanager.lengths[-1] if self.meshmanager.lengths else 0.0
             self.move_scale_by_positon = self.meshmanager.position_scale
 
             self.is_4_axis = self.meshmanager.is_4_axis

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -7614,6 +7614,7 @@ class Makera(RelativeLayout):
         self.gcode_rv.data = []
         self.init_path_visibility()
         self.gcode_viewer.clearDisplay()
+        self.gcode_viewer.begin_new_file_load()
         self.gcode_viewer.set_display_offset(self.content.x, self.content.y)
         self.gcode_viewer.set_move_speed(GCODE_VIEW_SPEED)
         self.gcode_playing = False
@@ -7664,8 +7665,9 @@ class Makera(RelativeLayout):
 
     # ------------------------------------------------------------------------
     def load_gcodes(self, line_no, parsed_list, *args):
-        if len(parsed_list) > 0:
-            self.gcode_viewer.load_array(parsed_list, line_no == self.selected_file_line_count)
+        is_end = line_no == self.selected_file_line_count
+        if parsed_list or is_end:
+            self.gcode_viewer.load_array(parsed_list, is_end)
 
         self.progress_popup.cancel = self.cancel_load_gcodes
         self.progress_popup.btn_cancel.disabled = False


### PR DESCRIPTION
Files generated through Makera Studio can have thousands of commented lines at the end containing the thumbnail of the job, for instance: https://www.makerables.com/project/peak-cabin-laser-image

```
;(thumbnail_image_begin)
;iVBORw0KGgoAAAANSUhEUgAAAyAAAAJYCAYAAACadoJwAAAACXBIWXMAAAsTAAALEwEAmpwYAAAgAElEQVR4nOzdd3QU9fo/8Pds
;S++F3luQSBGQqhCKAl6qCgKKeAEDggLSpV+qgJQIilwBuYA0IQiKFEMRUUA0QgydABGpCelld2d3fn/wm7mTyewm+r2uou/XOZ6w
;uzOzM7PrOZ9nn+f5fITbd++BiIiIiIjIEwx/9AkQEREREdHfBwMQIiIiIiLyGAYgRERERETkMQxAiIiIiIjIYxiAEBERERGRxzAA
;ISIiIiIij2EAQkREREREHsMAhIiIiIiIPIYBCBEREREReQwDECIiIiIi8hgGIERERERE5DEMQIiIiIiIyGMYgBARERERkccwACEi
;IiIiIo9hAEJERERERB7DAISIiIiIiDyGAQgREREREXkMAxAiIiIiIvIYBiBEREREROQxDECIiIiIiMhjGIAQEREREZHHMAAhIiIi
;IiKPYQBCREREREQewwCEiIiIiIg8hgEIERERERF5DAMQIiIiIiLyGAYgRERERETkMQxAiIiIiIjIYxiAEBERERGRxzAAISIiIiIi
(...)
;(thumbnail_image_end)
```

Since the controller loads lines by batches of 10000 and ignore comments, the final `parsed_list` can end up containing no line at all which causes the `self.gcode_viewer.load_array(parsed_list, line_no == self.selected_file_line_count)` line to not be called.

This prevents the paths from actually being displayed but also make them leak to the next file being loaded.

I changed the condition so `self.gcode_viewer.load_array` will always be called on the last line and added an explicit `begin_new_file_load` method to the GcodeViewer to make sure that that loading a new file will drop the previous vertices.