### PR TITLE
Implement web-based monitoring with time estimate and 3D gcode toolpath on port 8765

### DIFF
--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -322,5 +322,21 @@
         "section": "carvera",
         "key": "show_playbar_tool_change_markers",
         "default": "true"
+    },
+    {
+        "type": "bool",
+        "title": "Enable Job Status Web Server",
+        "desc": "Serves a read-only web page showing job progress (elapsed/remaining time, % complete) on your local network, so another device can watch it. This opens a network port, so it is off by default. Restart the controller after changing this.",
+        "section": "carvera",
+        "key": "status_server_enabled",
+        "default": "false"
+    },
+    {
+        "type": "numeric",
+        "title": "Job Status Web Server Port",
+        "desc": "TCP port the read-only job status web page is served on. Restart the controller after changing this.",
+        "section": "carvera",
+        "key": "status_server_port",
+        "default": "8765"
     }
 ]

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -5924,17 +5924,52 @@ class Makera(RelativeLayout):
         else:
             remaining_sec = 0.0
         elapsed_sec = CNC.vars.get("playedseconds", 0) or 0
+        filename = os.path.basename(app.selected_remote_filename or app.selected_local_filename or "")
+        toolpath_points = len(getattr(self.gcode_viewer, "raw_positions", None) or []) // 3
 
         return {
             "connected": app.state != NOT_CONNECTED,
             "playing": bool(app.playing),
             "state": app.state,
-            "filename": os.path.basename(app.selected_remote_filename or app.selected_local_filename or ""),
+            "filename": filename,
             "percent": float(self.wpb_play.value) if getattr(self, "wpb_play", None) else 0.0,
             "elapsed_sec": elapsed_sec,
             "remaining_sec": remaining_sec,
             "total_sec": elapsed_sec + remaining_sec,
+            "played_line": self.played_lines,
+            "x": CNC.vars.get("wx", 0.0),
+            "y": CNC.vars.get("wy", 0.0),
+            "z": CNC.vars.get("wz", 0.0),
+            # Cheap fingerprint so the browser only re-fetches the (much bigger)
+            # toolpath geometry when the loaded file actually changes.
+            "toolpath_revision": f"{filename}:{toolpath_points}",
         }
+
+    def get_toolpath_snapshot(self):
+        """Read-only toolpath geometry for the local status web server's 3D view.
+
+        Reuses the already-parsed vertex data GCodeViewer built for its own
+        OpenGL render, so nothing gets re-parsed. May be called from the
+        status server's request-handling thread; only reads plain lists.
+        """
+        gv = getattr(self, "gcode_viewer", None)
+        positions = list(getattr(gv, "raw_positions", None) or [])
+        feeds = list(getattr(gv, "raw_feed_rates", None) or [])
+        lines = list(getattr(gv, "raw_linenumbers", None) or [])
+
+        # Guard against reading mid-load, when these lists (built incrementally
+        # as the file streams in) may briefly have mismatched lengths.
+        count = min(len(positions) // 3, len(feeds), len(lines))
+        positions = positions[: count * 3]
+        feeds = feeds[:count]
+        lines = lines[:count]
+
+        bounds = None
+        if count:
+            xs, ys, zs = positions[0::3], positions[1::3], positions[2::3]
+            bounds = {"min": [min(xs), min(ys), min(zs)], "max": [max(xs), max(ys), max(zs)]}
+
+        return {"points": positions, "feed": feeds, "line": lines, "bounds": bounds}
 
     def _update_progress_smooth(self, dt):
         """Refresh elapsed/remaining display every second while playing."""
@@ -8238,7 +8273,9 @@ class MakeraApp(App):
     def on_start(self):
         if Config.getboolean("carvera", "status_server_enabled", fallback=False):
             port = Config.getint("carvera", "status_server_port", fallback=8765)
-            self.status_server = StatusServer(self.root.get_status_snapshot, port=port)
+            self.status_server = StatusServer(
+                self.root.get_status_snapshot, toolpath_provider=self.root.get_toolpath_snapshot, port=port
+            )
             self.status_server.start()
 
         # Workaround for Android blank screen issue

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -250,6 +250,7 @@ from .GcodeViewer import (
     VISIBILITY_MAX_TOOLS,
     GCodeViewer,
 )
+from .status_server import StatusServer
 from .ui import widget_helpers
 from .ui.PlayProgressBar import play_percent_from_line, tool_change_markers_to_percents
 from .ui.popups.adv_calibrate import AdvCalibratePopup
@@ -5904,6 +5905,37 @@ class Makera(RelativeLayout):
     def _current_remaining_sec(self):
         return max(0.0, self._remaining_anchor_sec - (time.time() - self._remaining_anchor_time))
 
+    def get_status_snapshot(self):
+        """Read-only job-progress snapshot for the local status web server.
+
+        May be called from the status server's request-handling thread, so
+        this must only read simple attributes/properties, never mutate
+        widget state.
+        """
+        app = App.get_running_app()
+        if app is None:
+            return {"connected": False}
+
+        if app.playing and app.state not in self._PROGRESS_TIMER_PAUSED_STATES:
+            remaining_sec = self._current_remaining_sec()
+        elif app.playing:
+            # Frozen while held/paused, same as the main progress display.
+            remaining_sec = self._remaining_anchor_sec
+        else:
+            remaining_sec = 0.0
+        elapsed_sec = CNC.vars.get("playedseconds", 0) or 0
+
+        return {
+            "connected": app.state != NOT_CONNECTED,
+            "playing": bool(app.playing),
+            "state": app.state,
+            "filename": os.path.basename(app.selected_remote_filename or app.selected_local_filename or ""),
+            "percent": float(self.wpb_play.value) if getattr(self, "wpb_play", None) else 0.0,
+            "elapsed_sec": elapsed_sec,
+            "remaining_sec": remaining_sec,
+            "total_sec": elapsed_sec + remaining_sec,
+        }
+
     def _update_progress_smooth(self, dt):
         """Refresh elapsed/remaining display every second while playing."""
         app = App.get_running_app()
@@ -8188,6 +8220,9 @@ class MakeraApp(App):
             Clock.unschedule(self.root.switch_status)
         if hasattr(self.root, "check_model_metadata"):
             Clock.unschedule(self.root.check_model_metadata)
+        if self.status_server is not None:
+            self.status_server.stop()
+            self.status_server = None
         # Stop the main run loop
         self.root.stop_run()
 
@@ -8196,10 +8231,16 @@ class MakeraApp(App):
         self.use_kivy_settings = True
         self.title = tr._("Carvera Controller Community") + " v" + __version__
         self.icon = os.path.join(os.path.dirname(__file__), "icon.png")
+        self.status_server = None
 
         return Makera(ctl_version=__version__)
 
     def on_start(self):
+        if Config.getboolean("carvera", "status_server_enabled", fallback=False):
+            port = Config.getint("carvera", "status_server_port", fallback=8765)
+            self.status_server = StatusServer(self.root.get_status_snapshot, port=port)
+            self.status_server.start()
+
         # Workaround for Android blank screen issue
         # https://github.com/kivy/python-for-android/issues/2720
         viewport_update_count = 0

--- a/carveracontroller/status_server.py
+++ b/carveracontroller/status_server.py
@@ -134,9 +134,68 @@ _PAGE = """<!doctype html>
     color: var(--muted);
     font-variant-numeric: tabular-nums;
   }
+  .wrap {
+    width: 100%;
+    max-width: 900px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+  }
+  .wrap .card { max-width: 480px; }
+  .viewer-card {
+    max-width: 100%;
+    width: 100%;
+    padding: 0;
+    overflow: hidden;
+  }
+  .viewer-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .viewer-header .title { font-weight: 600; font-size: 0.95rem; }
+  .viewer-header .hint { font-size: 0.75rem; color: var(--muted); }
+  .viewer-body { position: relative; }
+  #glcanvas {
+    display: block;
+    width: 100%;
+    height: min(60vh, 520px);
+    background: var(--bg);
+    touch-action: none;
+  }
+  .legend {
+    position: absolute;
+    left: 12px;
+    bottom: 10px;
+    display: flex;
+    gap: 14px;
+    font-size: 0.72rem;
+    color: var(--muted);
+    background: color-mix(in srgb, var(--card) 80%, transparent);
+    padding: 4px 8px;
+    border-radius: 8px;
+  }
+  .legend span { display: inline-flex; align-items: center; gap: 5px; }
+  .legend i { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
+  .viewer-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-align: center;
+    padding: 0 20px;
+    pointer-events: none;
+  }
 </style>
 </head>
 <body>
+<div class="wrap">
   <div class="card">
     <div class="filename" id="filename">&nbsp;</div>
     <div class="state" id="state">Loading&hellip;</div>
@@ -150,6 +209,23 @@ _PAGE = """<!doctype html>
     <div class="banner" id="banner">Lost contact with the Controller app</div>
     <div class="updated" id="updated">Waiting for first update&hellip;</div>
   </div>
+  <div class="card viewer-card">
+    <div class="viewer-header">
+      <span class="title">3D View</span>
+      <span class="hint" id="viewerHint">drag to orbit &middot; scroll/pinch to zoom</span>
+    </div>
+    <div class="viewer-body">
+      <canvas id="glcanvas"></canvas>
+      <div class="legend">
+        <span><i style="background:#3fb950"></i>cut &mdash; ahead</span>
+        <span><i style="background:#e3b341"></i>rapid &mdash; ahead</span>
+        <span><i style="background:#4da3ff"></i>done</span>
+        <span><i style="background:#ff4d4f;border-radius:50%"></i>tool</span>
+      </div>
+      <div class="viewer-empty" id="viewerEmpty">No toolpath loaded yet</div>
+    </div>
+  </div>
+</div>
 <script>
 function fmt(sec) {
   sec = Math.max(0, Math.round(sec || 0));
@@ -158,6 +234,292 @@ function fmt(sec) {
   var s = sec % 60;
   function pad(n) { return n < 10 ? "0" + n : "" + n; }
   return h + ":" + pad(m) + ":" + pad(s);
+}
+
+// ---------------------------------------------------------------------
+// Minimal WebGL 3D toolpath viewer. No external libraries (three.js etc.)
+// so this keeps working on a machine-shop network with no internet access.
+// ---------------------------------------------------------------------
+var Viewer = (function () {
+  var canvas = document.getElementById("glcanvas");
+  var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+  var emptyEl = document.getElementById("viewerEmpty");
+  if (!gl) {
+    emptyEl.textContent = "WebGL is not available in this browser";
+    return { setBounds: function () {}, setPath: function () {}, setPlayedLine: function () {}, setMarker: function () {} };
+  }
+
+  // -- tiny column-major mat4 helpers (glMatrix-style, hand-rolled to avoid a dependency) --
+  function perspective(fovy, aspect, near, far) {
+    var f = 1.0 / Math.tan(fovy / 2);
+    var nf = 1 / (near - far);
+    return new Float32Array([
+      f / aspect, 0, 0, 0,
+      0, f, 0, 0,
+      0, 0, (far + near) * nf, -1,
+      0, 0, 2 * far * near * nf, 0,
+    ]);
+  }
+  function lookAt(eye, center, up) {
+    var z0 = eye[0] - center[0], z1 = eye[1] - center[1], z2 = eye[2] - center[2];
+    var len = Math.hypot(z0, z1, z2) || 1;
+    z0 /= len; z1 /= len; z2 /= len;
+    var x0 = up[1] * z2 - up[2] * z1, x1 = up[2] * z0 - up[0] * z2, x2 = up[0] * z1 - up[1] * z0;
+    len = Math.hypot(x0, x1, x2) || 1;
+    x0 /= len; x1 /= len; x2 /= len;
+    var y0 = z1 * x2 - z2 * x1, y1 = z2 * x0 - z0 * x2, y2 = z0 * x1 - z1 * x0;
+    return new Float32Array([
+      x0, y0, z0, 0,
+      x1, y1, z1, 0,
+      x2, y2, z2, 0,
+      -(x0 * eye[0] + x1 * eye[1] + x2 * eye[2]),
+      -(y0 * eye[0] + y1 * eye[1] + y2 * eye[2]),
+      -(z0 * eye[0] + z1 * eye[1] + z2 * eye[2]),
+      1,
+    ]);
+  }
+  function multiply(a, b) {
+    var out = new Float32Array(16);
+    for (var i = 0; i < 4; i++) {
+      for (var j = 0; j < 4; j++) {
+        var sum = 0;
+        for (var k = 0; k < 4; k++) sum += a[k * 4 + j] * b[i * 4 + k];
+        out[i * 4 + j] = sum;
+      }
+    }
+    return out;
+  }
+
+  function compile(type, src) {
+    var sh = gl.createShader(type);
+    gl.shaderSource(sh, src);
+    gl.compileShader(sh);
+    if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+      console.error(gl.getShaderInfoLog(sh));
+    }
+    return sh;
+  }
+  function program(vsSrc, fsSrc) {
+    var p = gl.createProgram();
+    gl.attachShader(p, compile(gl.VERTEX_SHADER, vsSrc));
+    gl.attachShader(p, compile(gl.FRAGMENT_SHADER, fsSrc));
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+      console.error(gl.getProgramInfoLog(p));
+    }
+    return p;
+  }
+
+  var pathProgram = program(
+    "attribute vec3 aPos; attribute float aLine; attribute float aFeed;" +
+      "uniform mat4 uMVP; uniform float uPlayedLine;" +
+      "uniform vec3 uCutColor; uniform vec3 uRapidColor; uniform vec3 uDoneColor;" +
+      "varying vec3 vColor;" +
+      "void main() {" +
+      "  vec3 base = aFeed > 0.5 ? uCutColor : uRapidColor;" +
+      "  float done = step(aLine, uPlayedLine);" +
+      "  vColor = mix(base, uDoneColor, done);" +
+      "  gl_Position = uMVP * vec4(aPos, 1.0);" +
+      "}",
+    "precision mediump float; varying vec3 vColor;" +
+      "void main() { gl_FragColor = vec4(vColor, 1.0); }"
+  );
+  var markerProgram = program(
+    "attribute vec3 aPos; uniform mat4 uMVP;" +
+      "void main() { gl_Position = uMVP * vec4(aPos, 1.0); gl_PointSize = 14.0; }",
+    "precision mediump float; uniform vec3 uColor;" +
+      "void main() {" +
+      "  vec2 c = gl_PointCoord - vec2(0.5);" +
+      "  if (dot(c, c) > 0.25) discard;" +
+      "  gl_FragColor = vec4(uColor, 1.0);" +
+      "}"
+  );
+
+  var pathBuf = gl.createBuffer();
+  var markerBuf = gl.createBuffer();
+  var vertexCount = 0;
+  var bounds = null;
+  var center = [0, 0, 0];
+  var radius = 100;
+  var playedLine = -1;
+  var marker = null;
+
+  var yaw = Math.PI * 0.25;
+  var pitch = Math.PI * 0.22;
+  var distance = 300;
+  var minDistance = 5;
+
+  function frame() {
+    if (!bounds) return;
+    center = [
+      (bounds.min[0] + bounds.max[0]) / 2,
+      (bounds.min[1] + bounds.max[1]) / 2,
+      (bounds.min[2] + bounds.max[2]) / 2,
+    ];
+    var dx = bounds.max[0] - bounds.min[0];
+    var dy = bounds.max[1] - bounds.min[1];
+    var dz = bounds.max[2] - bounds.min[2];
+    radius = Math.max(1, Math.hypot(dx, dy, dz) / 2);
+    distance = radius * 2.2;
+    minDistance = radius * 0.05;
+  }
+
+  function setBounds(b) {
+    bounds = b;
+    frame();
+  }
+
+  function setPath(points, line, feed) {
+    vertexCount = line.length;
+    if (!vertexCount) return;
+    var interleaved = new Float32Array(vertexCount * 5);
+    for (var i = 0; i < vertexCount; i++) {
+      interleaved[i * 5 + 0] = points[i * 3 + 0];
+      interleaved[i * 5 + 1] = points[i * 3 + 1];
+      interleaved[i * 5 + 2] = points[i * 3 + 2];
+      interleaved[i * 5 + 3] = line[i];
+      interleaved[i * 5 + 4] = feed[i];
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, pathBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, interleaved, gl.STATIC_DRAW);
+    emptyEl.style.display = "none";
+  }
+
+  function setPlayedLine(n) {
+    playedLine = typeof n === "number" ? n : -1;
+  }
+
+  function setMarker(x, y, z) {
+    marker = [x, y, z];
+  }
+
+  function resize() {
+    var rect = canvas.getBoundingClientRect();
+    var dpr = window.devicePixelRatio || 1;
+    var w = Math.max(1, Math.round(rect.width * dpr));
+    var h = Math.max(1, Math.round(rect.height * dpr));
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    gl.viewport(0, 0, canvas.width, canvas.height);
+  }
+
+  function draw() {
+    resize();
+    gl.clearColor(0, 0, 0, 0);
+    gl.enable(gl.DEPTH_TEST);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    if (!vertexCount) {
+      requestAnimationFrame(draw);
+      return;
+    }
+
+    var aspect = canvas.width / Math.max(1, canvas.height);
+    var proj = perspective((45 * Math.PI) / 180, aspect, Math.max(0.1, radius * 0.01), radius * 20 + distance);
+    var cp = Math.cos(pitch), sp = Math.sin(pitch);
+    var cy = Math.cos(yaw), sy = Math.sin(yaw);
+    var eye = [
+      center[0] + distance * cp * cy,
+      center[1] + distance * cp * sy,
+      center[2] + distance * sp,
+    ];
+    var view = lookAt(eye, center, [0, 0, 1]); // Z is the vertical (spindle) axis in machine coordinates
+    var mvp = multiply(proj, view);
+
+    gl.useProgram(pathProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, pathBuf);
+    var stride = 5 * 4;
+    var aPos = gl.getAttribLocation(pathProgram, "aPos");
+    var aLine = gl.getAttribLocation(pathProgram, "aLine");
+    var aFeed = gl.getAttribLocation(pathProgram, "aFeed");
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(aLine);
+    gl.vertexAttribPointer(aLine, 1, gl.FLOAT, false, stride, 12);
+    gl.enableVertexAttribArray(aFeed);
+    gl.vertexAttribPointer(aFeed, 1, gl.FLOAT, false, stride, 16);
+    gl.uniformMatrix4fv(gl.getUniformLocation(pathProgram, "uMVP"), false, mvp);
+    gl.uniform1f(gl.getUniformLocation(pathProgram, "uPlayedLine"), playedLine);
+    gl.uniform3f(gl.getUniformLocation(pathProgram, "uCutColor"), 0.247, 0.725, 0.314);
+    gl.uniform3f(gl.getUniformLocation(pathProgram, "uRapidColor"), 0.89, 0.702, 0.255);
+    gl.uniform3f(gl.getUniformLocation(pathProgram, "uDoneColor"), 0.302, 0.639, 1.0);
+    gl.drawArrays(gl.LINE_STRIP, 0, vertexCount);
+
+    if (marker) {
+      gl.useProgram(markerProgram);
+      gl.bindBuffer(gl.ARRAY_BUFFER, markerBuf);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(marker), gl.DYNAMIC_DRAW);
+      var mPos = gl.getAttribLocation(markerProgram, "aPos");
+      gl.enableVertexAttribArray(mPos);
+      gl.vertexAttribPointer(mPos, 3, gl.FLOAT, false, 0, 0);
+      gl.uniformMatrix4fv(gl.getUniformLocation(markerProgram, "uMVP"), false, mvp);
+      gl.uniform3f(gl.getUniformLocation(markerProgram, "uColor"), 1.0, 0.302, 0.302);
+      gl.drawArrays(gl.POINTS, 0, 1);
+    }
+
+    requestAnimationFrame(draw);
+  }
+  requestAnimationFrame(draw);
+
+  // -- orbit (drag to rotate, wheel/pinch to zoom) --
+  var pointers = new Map();
+  canvas.addEventListener("pointerdown", function (e) {
+    canvas.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  });
+  canvas.addEventListener("pointerup", function (e) { pointers.delete(e.pointerId); });
+  canvas.addEventListener("pointercancel", function (e) { pointers.delete(e.pointerId); });
+  canvas.addEventListener("pointermove", function (e) {
+    if (!pointers.has(e.pointerId)) return;
+    var prev = pointers.get(e.pointerId);
+    var curr = { x: e.clientX, y: e.clientY };
+    if (pointers.size === 1) {
+      yaw += (curr.x - prev.x) * 0.008;
+      pitch += (curr.y - prev.y) * 0.008;
+      pitch = Math.max(-1.5, Math.min(1.5, pitch));
+    } else if (pointers.size === 2) {
+      var others = [];
+      pointers.forEach(function (v, k) { others.push(k === e.pointerId ? curr : v); });
+      var before = 0, after = 0;
+      var ids = Array.from(pointers.keys());
+      var a = ids[0] === e.pointerId ? curr : pointers.get(ids[0]);
+      var b = ids[1] === e.pointerId ? curr : pointers.get(ids[1]);
+      var aP = ids[0] === e.pointerId ? prev : pointers.get(ids[0]);
+      var bP = ids[1] === e.pointerId ? prev : pointers.get(ids[1]);
+      before = Math.hypot(aP.x - bP.x, aP.y - bP.y);
+      after = Math.hypot(a.x - b.x, a.y - b.y);
+      if (before > 0) distance *= before / after;
+      distance = Math.max(minDistance, Math.min(radius * 20, distance));
+    }
+    pointers.set(e.pointerId, curr);
+  });
+  canvas.addEventListener(
+    "wheel",
+    function (e) {
+      e.preventDefault();
+      distance *= e.deltaY > 0 ? 1.1 : 0.9;
+      distance = Math.max(minDistance, Math.min(radius * 20, distance));
+    },
+    { passive: false }
+  );
+
+  return { setBounds: setBounds, setPath: setPath, setPlayedLine: setPlayedLine, setMarker: setMarker };
+})();
+
+var lastToolpathRevision = null;
+function maybeLoadToolpath(revision) {
+  if (!revision || revision === lastToolpathRevision) return;
+  lastToolpathRevision = revision;
+  fetch("toolpath.json", { cache: "no-store" })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (!data.bounds || !data.points || !data.points.length) return;
+      Viewer.setBounds(data.bounds);
+      Viewer.setPath(data.points, data.line, data.feed);
+    })
+    .catch(function () {});
 }
 
 function render(data) {
@@ -182,6 +544,12 @@ function render(data) {
   var now = new Date();
   var timeStr = now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
   document.getElementById("updated").textContent = "Updated " + timeStr;
+
+  maybeLoadToolpath(data.toolpath_revision);
+  Viewer.setPlayedLine(typeof data.played_line === "number" ? data.played_line : -1);
+  if (data.connected && (data.x || data.y || data.z)) {
+    Viewer.setMarker(data.x || 0, data.y || 0, data.z || 0);
+  }
 }
 
 function poll() {
@@ -194,7 +562,7 @@ function poll() {
 }
 
 poll();
-setInterval(poll, 3000);
+setInterval(poll, 1000);
 </script>
 </body>
 </html>
@@ -204,6 +572,7 @@ setInterval(poll, 3000);
 class _Handler(BaseHTTPRequestHandler):
     # Set per-server via a subclass in StatusServer.start().
     status_provider: Callable[[], dict] = None
+    toolpath_provider: Callable[[], dict] | None = None
 
     def log_message(self, fmt, *args):  # noqa: A003 - stdlib signature
         logger.debug("%s - %s", self.address_string(), fmt % args)
@@ -228,14 +597,29 @@ class _Handler(BaseHTTPRequestHandler):
                 payload = {"error": "unavailable"}
             self._write(200, json.dumps(payload).encode("utf-8"), "application/json")
             return
+        if self.path in ("/toolpath.json", "/toolpath"):
+            try:
+                payload = self.toolpath_provider() if self.toolpath_provider else {}
+            except Exception:
+                logger.exception("Toolpath provider failed")
+                payload = {"error": "unavailable"}
+            self._write(200, json.dumps(payload).encode("utf-8"), "application/json")
+            return
         self._write(404, b"Not found", "text/plain; charset=utf-8")
 
 
 class StatusServer:
     """Serves a read-only job-progress page/JSON on the local network."""
 
-    def __init__(self, status_provider: Callable[[], dict], host: str = "0.0.0.0", port: int = 8765):
+    def __init__(
+        self,
+        status_provider: Callable[[], dict],
+        toolpath_provider: Callable[[], dict] | None = None,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+    ):
         self._status_provider = status_provider
+        self._toolpath_provider = toolpath_provider
         self._host = host
         self._port = port
         self._httpd: ThreadingHTTPServer | None = None
@@ -252,7 +636,14 @@ class StatusServer:
     def start(self):
         if self._httpd is not None:
             return
-        handler = type("_BoundHandler", (_Handler,), {"status_provider": staticmethod(self._status_provider)})
+        handler = type(
+            "_BoundHandler",
+            (_Handler,),
+            {
+                "status_provider": staticmethod(self._status_provider),
+                "toolpath_provider": staticmethod(self._toolpath_provider) if self._toolpath_provider else None,
+            },
+        )
         try:
             self._httpd = ThreadingHTTPServer((self._host, self._port), handler)
         except OSError as e:

--- a/carveracontroller/status_server.py
+++ b/carveracontroller/status_server.py
@@ -1,0 +1,272 @@
+"""Small read-only HTTP server exposing current job progress.
+
+Lets a second device (phone, tablet, another PC) watch time-remaining/elapsed
+for the job this Controller instance is running, without needing its own
+connection to the machine (the machine's firmware only accepts one TCP
+client on port 2222 at a time, so a second *Controller* can't connect
+directly).
+
+The server just serves a small self-contained status page plus the JSON it
+polls. It has no write/control endpoints - it cannot jog, send gcode, or
+otherwise touch the machine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Carvera Job Status</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f4f5f7;
+    --card: #ffffff;
+    --text: #1b1d21;
+    --muted: #6b7280;
+    --track: #e5e7eb;
+    --bar: #2f8cff;
+    --border: #e5e7eb;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #16181d;
+      --card: #1f2229;
+      --text: #f2f3f5;
+      --muted: #9aa1ac;
+      --track: #2b2f38;
+      --bar: #4da3ff;
+      --border: #2b2f38;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+  .card {
+    width: 100%;
+    max-width: 480px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 24px;
+  }
+  .filename {
+    font-size: 1.05rem;
+    font-weight: 600;
+    word-break: break-word;
+    margin-bottom: 2px;
+  }
+  .state {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-bottom: 20px;
+  }
+  .state.playing { color: var(--bar); }
+  .bar-track {
+    width: 100%;
+    height: 14px;
+    border-radius: 7px;
+    background: var(--track);
+    overflow: hidden;
+    margin-bottom: 10px;
+  }
+  .bar-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--bar);
+    transition: width 0.6s ease;
+  }
+  .percent {
+    text-align: right;
+    font-size: 0.9rem;
+    color: var(--muted);
+    margin-bottom: 20px;
+  }
+  .times {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 8px;
+    text-align: center;
+  }
+  .times div { display: flex; flex-direction: column; gap: 4px; }
+  .times .label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+  }
+  .times .value { font-size: 1.15rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .banner {
+    display: none;
+    margin-top: 18px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: #7a1f1f;
+    color: #fff;
+    font-size: 0.85rem;
+    text-align: center;
+  }
+  .banner.show { display: block; }
+  .updated {
+    margin-top: 16px;
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="filename" id="filename">&nbsp;</div>
+    <div class="state" id="state">Loading&hellip;</div>
+    <div class="bar-track"><div class="bar-fill" id="bar"></div></div>
+    <div class="percent" id="percent">0%</div>
+    <div class="times">
+      <div><span class="label">Elapsed</span><span class="value" id="elapsed">--:--:--</span></div>
+      <div><span class="label">Remaining</span><span class="value" id="remaining">--:--:--</span></div>
+      <div><span class="label">Total (est.)</span><span class="value" id="total">--:--:--</span></div>
+    </div>
+    <div class="banner" id="banner">Lost contact with the Controller app</div>
+    <div class="updated" id="updated">Waiting for first update&hellip;</div>
+  </div>
+<script>
+function fmt(sec) {
+  sec = Math.max(0, Math.round(sec || 0));
+  var h = Math.floor(sec / 3600);
+  var m = Math.floor((sec % 3600) / 60);
+  var s = sec % 60;
+  function pad(n) { return n < 10 ? "0" + n : "" + n; }
+  return h + ":" + pad(m) + ":" + pad(s);
+}
+
+function render(data) {
+  document.getElementById("banner").classList.remove("show");
+  var name = data.filename || (data.connected ? "No file selected" : "Not connected");
+  document.getElementById("filename").textContent = name;
+
+  var stateEl = document.getElementById("state");
+  stateEl.textContent = data.connected ? data.state : "Machine not connected";
+  stateEl.classList.toggle("playing", !!data.playing);
+
+  var pct = Math.max(0, Math.min(100, data.percent || 0));
+  document.getElementById("bar").style.width = pct + "%";
+  document.getElementById("percent").textContent = Math.round(pct) + "%";
+
+  document.getElementById("elapsed").textContent = fmt(data.elapsed_sec);
+  document.getElementById("remaining").textContent = fmt(data.remaining_sec);
+  document.getElementById("total").textContent = fmt(data.total_sec);
+
+  // Local-time stamp of this successful poll, so a stalled page is obvious
+  // (this stops advancing) rather than silently showing stale numbers.
+  var now = new Date();
+  var timeStr = now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  document.getElementById("updated").textContent = "Updated " + timeStr;
+}
+
+function poll() {
+  fetch("status.json", { cache: "no-store" })
+    .then(function (r) { return r.json(); })
+    .then(render)
+    .catch(function () {
+      document.getElementById("banner").classList.add("show");
+    });
+}
+
+poll();
+setInterval(poll, 3000);
+</script>
+</body>
+</html>
+"""
+
+
+class _Handler(BaseHTTPRequestHandler):
+    # Set per-server via a subclass in StatusServer.start().
+    status_provider: Callable[[], dict] = None
+
+    def log_message(self, fmt, *args):  # noqa: A003 - stdlib signature
+        logger.debug("%s - %s", self.address_string(), fmt % args)
+
+    def _write(self, status: int, body: bytes, content_type: str):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/", "/index.html"):
+            self._write(200, _PAGE.encode("utf-8"), "text/html; charset=utf-8")
+            return
+        if self.path in ("/status.json", "/status"):
+            try:
+                payload = self.status_provider()
+            except Exception:
+                logger.exception("Status provider failed")
+                payload = {"error": "unavailable"}
+            self._write(200, json.dumps(payload).encode("utf-8"), "application/json")
+            return
+        self._write(404, b"Not found", "text/plain; charset=utf-8")
+
+
+class StatusServer:
+    """Serves a read-only job-progress page/JSON on the local network."""
+
+    def __init__(self, status_provider: Callable[[], dict], host: str = "0.0.0.0", port: int = 8765):
+        self._status_provider = status_provider
+        self._host = host
+        self._port = port
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._httpd is not None
+
+    @property
+    def port(self) -> int:
+        return self._httpd.server_address[1] if self._httpd else self._port
+
+    def start(self):
+        if self._httpd is not None:
+            return
+        handler = type("_BoundHandler", (_Handler,), {"status_provider": staticmethod(self._status_provider)})
+        try:
+            self._httpd = ThreadingHTTPServer((self._host, self._port), handler)
+        except OSError as e:
+            logger.error(f"Could not start status server on {self._host}:{self._port}: {e}")
+            self._httpd = None
+            return
+        self._thread = threading.Thread(target=self._httpd.serve_forever, name="StatusServer", daemon=True)
+        self._thread.start()
+        logger.info(f"Job status server listening on port {self.port}")
+
+    def stop(self):
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._httpd = None
+        self._thread = None


### PR DESCRIPTION
I have a laptop with pendant attached to the Carvera Air that I use to do probing and then start the job. But then I want to track the progress from my phone or my work laptop to see when the job will be finished. This change adds a web server to the controller on port 8765 that you can connect to via a web browser on the same network. It shows a live time estimate, 3D rendering of the gcode toolpath, and the position of the tool. I put this prototype together with Claude Code to see what could be possible and I was happy with the result. The alternative would be to have a read-only controller that somehow connects to the existing controller and proxy the connection through, but that seemed too difficult.