### PR TITLE
Z1 config n run additions for Auto blow, bed-clean, and ionizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Enhancement: Intellisense-like popups explaining commands in lines selected in the gcode viewer and MDI terminal
 - Enhancement: Support for connect to the Makera Z1 over USB
 - Enhancement: The step size is now synchronized between the main screen and the Probing screen
+- Enhancement: Add Auto Blow, Auto Bed Clean, and Ionizer toggles to the Config and Run screen on Z1
+- Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1
 - Fixed: Y+/Y- jogging buttons on the Probing screen respect the configured Y axis inversion setting
 
 [2.2.0-RC2]

--- a/carveracontroller/CNC.py
+++ b/carveracontroller/CNC.py
@@ -260,6 +260,9 @@ class CNC:
         "OvSpindle": 100,
         "vacuummode": 0,
         "extoutmode": 0,
+        "autoblowmode": 0,
+        "autobedcleanmode": 0,
+        "ionizermode": 0,
         "_OvChanged": False,
         "_OvFeed": 100,  # Override target values
         "_OvRapid": 100,

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -561,6 +561,27 @@ class Controller:
         else:
             self.executeCommand("M332.3\n")
 
+    def setAutoBlowMode(self, mode):
+        CNC.vars["autoblowmode"] = 1 if mode else 0
+        if mode:
+            self.executeCommand("M331.1\n")
+        else:
+            self.executeCommand("M332.1\n")
+
+    def setAutoBedCleanMode(self, mode):
+        CNC.vars["autobedcleanmode"] = 1 if mode else 0
+        if mode:
+            self.executeCommand("M331.2\n")
+        else:
+            self.executeCommand("M332.2\n")
+
+    def setIonizerMode(self, mode):
+        CNC.vars["ionizermode"] = 1 if mode else 0
+        if mode:
+            self.executeCommand("M331.4\n")
+        else:
+            self.executeCommand("M332.4\n")
+
     def setLaserMode(self, mode):
         if mode:
             self.executeCommand("M321\n")

--- a/carveracontroller/addons/intellisense/commands.json
+++ b/carveracontroller/addons/intellisense/commands.json
@@ -6,7 +6,6 @@
     "parameters.<name>.required is true or false.",
     "parameters.<name>.default is a number, string, or null when there is no fixed default.",
     "default_source names a config key when the default comes from configuration.",
-    "C1 uses src/config.default; CA1 uses src/config2.default; the SD overlay can override both.",
     "3D-printer leftovers are listed because the firmware still parses them; they are not used on Carvera."
   ],
   "commands": {
@@ -1181,12 +1180,50 @@
     },
     "M331": {
       "type": "mcode",
-      "description": "Enable auto vacuum mode on the Carvera C1 so the vacuum follows the spindle.",
+      "description": "Enable auto chip clearing following the spindle on/off state. On C1 this is the vacuum; on CA1 and Z1 it is the external output.",
+      "parameters": {}
+    },
+    "M331.1": {
+      "type": "mcode",
+      "description": "Enable auto blow on Z1. The spindle fan will always run with this minimum power while the spindle is on.",
+      "parameters": {
+        "S": {
+          "required": false,
+          "description": "Fan power while blowing.",
+          "default": 30,
+          "unit": "%",
+          "default_source": "accessory.auto_blowing_power"
+        }
+      }
+    },
+    "M331.2": {
+      "type": "mcode",
+      "description": "Runs a cleaning cycle when gcode playback finishes.",
+      "parameters": {}
+    },
+    "M331.4": {
+      "type": "mcode",
+      "description": "Turn on the ionizer on Z1.",
       "parameters": {}
     },
     "M332": {
       "type": "mcode",
-      "description": "Disable auto vacuum mode.",
+      "description": "Disable auto chip clearing (C1: vacuum, CA1/Z1: External Output pin).",
+      "parameters": {}
+    },
+    "M332.1": {
+      "type": "mcode",
+      "description": "Disable auto blow.",
+      "parameters": {}
+    },
+    "M332.2": {
+      "type": "mcode",
+      "description": "Disable automatic bed cleaning after jobs.",
+      "parameters": {}
+    },
+    "M332.4": {
+      "type": "mcode",
+      "description": "Turn off the ionizer.",
       "parameters": {}
     },
     "M333": {
@@ -2559,6 +2596,25 @@
       "type": "mcode",
       "description": "Switch communication protocol to Makera.",
       "parameters": {}
+    },
+    "M486.1": {
+      "type": "mcode",
+      "description": "Run a bed-cleaning cycle on Z1.",
+      "parameters": {
+        "N": {
+          "required": false,
+          "description": "Number of sweep cycles (1–10).",
+          "default": 1,
+          "default_source": "bed_cleaning.cycles"
+        },
+        "T": {
+          "required": false,
+          "description": "Distance between successive sweep rows.",
+          "default": 40,
+          "unit": "mm",
+          "default_source": "bed_cleaning.spacing"
+        }
+      }
     },
     "M489": {
       "type": "mcode",

--- a/carveracontroller/config_z1.json
+++ b/carveracontroller/config_z1.json
@@ -21,6 +21,64 @@
         "default": "0.0"
     },
     {
+        "type": "numeric",
+        "title": "LED brightness",
+        "desc": "Status light brightness (0 - 255)",
+        "section": "Basic",
+        "key": "light.ledBrightness",
+        "default": "15"
+    },
+    {
+        "type": "title",
+        "title": "Accessories",
+        "section": "Basic"
+    },
+    {
+        "type": "numeric",
+        "title": "Chip clear power",
+        "desc": "External output power when auto chip clearing is on (0 - 100)",
+        "section": "Basic",
+        "key": "accessory.chip_clear_power",
+        "default": "80"
+    },
+    {
+        "type": "numeric",
+        "title": "Auto blow power",
+        "desc": "Spindle fan power used by auto blow (0 - 100)",
+        "section": "Basic",
+        "key": "accessory.auto_blowing_power",
+        "default": "30"
+    },
+    {
+        "type": "title",
+        "title": "Bed cleaning",
+        "section": "Basic"
+    },
+    {
+        "type": "numeric",
+        "title": "Cleaning cycles",
+        "desc": "Number of sweep cycles (1 - 10)",
+        "section": "Basic",
+        "key": "bed_cleaning.cycles",
+        "default": "1"
+    },
+    {
+        "type": "numeric",
+        "title": "Sweep spacing",
+        "desc": "Distance between successive sweep rows (mm)",
+        "section": "Basic",
+        "key": "bed_cleaning.spacing",
+        "default": "40"
+    },
+    {
+        "type": "numeric",
+        "title": "Cleaning fan power",
+        "desc": "Spindle fan power during bed cleaning (0 - 100)",
+        "section": "Basic",
+        "key": "accessory.bed_cleaning_fan_power",
+        "default": "100"
+    },
+    {
         "type": "title",
         "title": "Safety",
         "section": "Basic"
@@ -190,6 +248,54 @@
         "default": "-3.0"
     },
     {
+        "type": "numeric",
+        "title": "Bed cleaning X min",
+        "desc": "Rear-left X of the bed cleaning sweep (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.x_min",
+        "default": "-192.4"
+    },
+    {
+        "type": "numeric",
+        "title": "Bed cleaning X max",
+        "desc": "Front-right X of the bed cleaning sweep (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.x_max",
+        "default": "-11.6"
+    },
+    {
+        "type": "numeric",
+        "title": "Bed cleaning Y min",
+        "desc": "Rear Y of the bed cleaning sweep (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.y_min",
+        "default": "-194.3"
+    },
+    {
+        "type": "numeric",
+        "title": "Bed cleaning Y max",
+        "desc": "Front Y of the bed cleaning sweep (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.y_max",
+        "default": "-1.0"
+    },
+    {
+        "type": "numeric",
+        "title": "Bed cleaning park Y",
+        "desc": "Y parking position after a cleaning cycle (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.park_y",
+        "default": "-14.6"
+    },
+    {
+        "type": "numeric",
+        "title": "Bed cleaning front X",
+        "desc": "Front-edge X used to dump chips off the bed (mm)",
+        "section": "Advanced",
+        "key": "bed_cleaning.front_x",
+        "default": "-2.0"
+    },
+    {
         "type": "bool",
         "title": "Soft Limits",
         "desc": "Enabled to precheck if gCode commands will exceed the travel limits",
@@ -212,6 +318,14 @@
         "section": "Advanced",
         "key": "soft_endstop.y_min",
         "default": "-206.0"
+    },
+    {
+        "type": "numeric",
+        "title": "Rotary Y Min Coordinate",
+        "desc": "Minimum Y axis coordinate with the rotary module installed",
+        "section": "Advanced",
+        "key": "soft_endstop.rotary_y_min",
+        "default": "-160.0"
     },
     {
         "type": "numeric",

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1143,6 +1143,9 @@ class CoordPopup(ModalView):
     mode = StringProperty()
     vacuummode = ObjectProperty()
     extoutmode = ObjectProperty()
+    autoblowmode = ObjectProperty()
+    autobedcleanmode = ObjectProperty()
+    ionizermode = ObjectProperty()
     origin_popup = ObjectProperty()
     zprobe_popup = ObjectProperty()
     auto_level_popup = ObjectProperty()
@@ -1270,6 +1273,21 @@ class CoordPopup(ModalView):
             self.extoutmode = True
         else:
             self.extoutmode = False
+
+        if CNC.vars["autoblowmode"] == 1:
+            self.autoblowmode = True
+        else:
+            self.autoblowmode = False
+
+        if CNC.vars["autobedcleanmode"] == 1:
+            self.autobedcleanmode = True
+        else:
+            self.autobedcleanmode = False
+
+        if CNC.vars["ionizermode"] == 1:
+            self.ionizermode = True
+        else:
+            self.ionizermode = False
 
         # init margin widgets
         self.cbx_margin.active = self.config["margin"]["active"]
@@ -3091,6 +3109,9 @@ class Makera(RelativeLayout):
         "spindle_scale": [0.0, 100],
         "vacuum_mode": [0.0, 0],
         "extout_mode": [0.0, 0],
+        "autoblow_mode": [0.0, 0],
+        "autobedclean_mode": [0.0, 0],
+        "ionizer_mode": [0.0, 0],
         "laser_mode": [0.0, 0],
         "laser_scale": [0.0, 100],
         "laser_test": [0.0, 0],
@@ -6270,6 +6291,27 @@ class Makera(RelativeLayout):
                     if extout_switch_play.active != CNC.vars["extoutmode"]:
                         extout_switch_play.set_flag = True
                         extout_switch_play.active = CNC.vars["extoutmode"]
+
+            for control_name, setter, var_name, switch_id in (
+                ("autoblow_mode", self.controller.setAutoBlowMode, "autoblowmode", "autoblow_switch_play"),
+                (
+                    "autobedclean_mode",
+                    self.controller.setAutoBedCleanMode,
+                    "autobedcleanmode",
+                    "autobedclean_switch_play",
+                ),
+                ("ionizer_mode", self.controller.setIonizerMode, "ionizermode", "ionizer_switch_play"),
+            ):
+                elapsed = now - self.control_list[control_name][0]
+                if elapsed < 2:
+                    if elapsed > 0.5:
+                        setter(self.control_list[control_name][1])
+                        self.control_list[control_name][0] = now - 2
+                elif elapsed > 3 and self.coord_popup._is_open:
+                    switch = self.coord_popup.ids[switch_id]
+                    if switch.active != CNC.vars[var_name]:
+                        switch.set_flag = True
+                        switch.active = CNC.vars[var_name]
 
             elapsed = now - self.control_list["spindle_scale"][0]
             if elapsed < 2:

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3001,7 +3001,8 @@
                 BoxLayout:
                     padding: '0.5dp'
                     size_hint_y: None
-                    height: '30dp'
+                    height: '30dp' if app.model == 'C1' else '0dp'
+                    opacity: 1 if app.model == 'C1' else 0
                     disabled: app.model != 'C1'
                     Label:
                         text: tr._("Auto Vacuum")
@@ -3060,6 +3061,108 @@
                         on_active:
                             if self.set_flag: self.set_flag = False
                             else: app.root.update_control('extout_mode', self.active)
+
+                BoxLayout:
+                    padding: '0.5dp'
+                    size_hint_y: None
+                    height: '30dp' if app.model == 'Z1' else '0dp'
+                    opacity: 1 if app.model == 'Z1' else 0
+                    disabled: app.model != 'Z1'
+                    Label:
+                        text: tr._("Auto Blow")
+                        halign: "left"
+                        valign: "middle"
+                        font_size: '13sp'
+                        text_size: self.size
+
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                    ToolTipSwitch:
+                        id: autoblow_switch_play
+                        tooltip_txt: tr._("The spindle fan will always run with this minimum power while the spindle is on.")
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                        set_flag: False
+                        active: True if root.autoblowmode == 1 else False
+                        on_active:
+                            if self.set_flag: self.set_flag = False
+                            else: app.root.update_control('autoblow_mode', self.active)
+
+                BoxLayout:
+                    padding: '0.5dp'
+                    size_hint_y: None
+                    height: '30dp' if app.model == 'Z1' else '0dp'
+                    opacity: 1 if app.model == 'Z1' else 0
+                    disabled: app.model != 'Z1'
+                    Label:
+                        text: tr._("Auto Bed Clean")
+                        halign: "left"
+                        valign: "middle"
+                        font_size: '13sp'
+                        text_size: self.size
+
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                    ToolTipSwitch:
+                        id: autobedclean_switch_play
+                        tooltip_txt: tr._("Runs a cleaning cycle when gcode playback finishes.")
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                        set_flag: False
+                        active: True if root.autobedcleanmode == 1 else False
+                        on_active:
+                            if self.set_flag: self.set_flag = False
+                            else: app.root.update_control('autobedclean_mode', self.active)
+
+                BoxLayout:
+                    padding: '0.5dp'
+                    size_hint_y: None
+                    height: '30dp' if app.model == 'Z1' else '0dp'
+                    opacity: 1 if app.model == 'Z1' else 0
+                    disabled: app.model != 'Z1'
+                    Label:
+                        text: tr._("Ionizer")
+                        halign: "left"
+                        valign: "middle"
+                        font_size: '13sp'
+                        text_size: self.size
+
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                    ToolTipSwitch:
+                        id: ionizer_switch_play
+                        tooltip_txt: tr._("Turn on the static electricity removal unit on Z1.")
+                        canvas.before:
+                            Color:
+                                rgba: 50/255, 50/255, 50/255, 1
+                            Rectangle:
+                                pos: self.pos
+                                size: self.size
+                        set_flag: False
+                        active: True if root.ionizermode == 1 else False
+                        on_active:
+                            if self.set_flag: self.set_flag = False
+                            else: app.root.update_control('ionizer_mode', self.active)
 
                 Label:
                     size_hint_y: None


### PR DESCRIPTION
- Enhancement: Add Auto Blow, Auto Bed Clean, and Ionizer toggles to the Config and Run screen on Z1
- Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1

Adds the associated commands to intellisense and the related machine settings that I found were missing.

#692 

<img width="1269" height="749" alt="Screenshot 2026-08-27 at 11 18 20 am" src="https://github.com/user-attachments/assets/2195f115-d4df-475d-a49c-2cd071901e97" />

<img width="1231" height="710" alt="Screenshot 2026-08-27 at 11 24 50 am" src="https://github.com/user-attachments/assets/08863ea4-2bae-44dd-9cd4-335ca4ef1132" />

<img width="518" height="288" alt="Screenshot 2026-08-27 at 11 25 32 am" src="https://github.com/user-attachments/assets/b38ffa59-d643-4b6e-85e3-61e75e94dc98" />
