### PR TITLE
Time until toolchange details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 [unreleased]
+- Enhancement: Tool-change flags have tooltip showing time until the change
+- Enhancement: Remaining time text alternates with time until the next tool change and playback completion
+- Enhancement: Selected files show estimated run time on the playback bar before the job starts
 - Enhancement: Intellisense-like popups explaining commands in lines selected in the gcode viewer and MDI terminal
 - Enhancement: Support for connect to the Makera Z1 over USB
 - Enhancement: The step size is now synchronized between the main screen and the Probing screen

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -274,7 +274,13 @@ from .GcodeViewer import (
     GCodeViewer,
 )
 from .ui import widget_helpers
-from .ui.PlayProgressBar import play_percent_from_line, tool_change_markers_to_percents
+from .ui.PlayProgressBar import (
+    next_tool_change_after_line,
+    play_percent_from_line,
+    seconds_from_start,
+    seconds_until_target,
+    tool_change_markers_to_percents,
+)
 from .ui.popups.adv_calibrate import AdvCalibratePopup
 from .ui.popups.set_position import (
     ChangeToolPopup,
@@ -3397,6 +3403,8 @@ class Makera(RelativeLayout):
 
         self._load_gcode_highlight_settings()
         self._load_playbar_tool_change_marker_settings()
+        if self.wpb_play:
+            self.wpb_play.marker_tooltip_provider = self._playbar_tool_change_tooltip
 
         # blink timer
         Clock.schedule_interval(self.blink_state, 0.5)
@@ -3937,6 +3945,8 @@ class Makera(RelativeLayout):
         self.status_index = self.status_index + 1
         if self.status_index >= 6:
             self.status_index = 0
+        if self._progress_smooth_clock is not None:
+            self._update_progress_smooth(0)
 
     # -----------------------------------------------------------------------
     def check_model_metadata(self, *args):
@@ -6065,12 +6075,91 @@ class Makera(RelativeLayout):
             self.progressFinish()
             # Legend row durations become available once line_times are applied.
             self.refresh_gcode_color_legend()
+            self._refresh_idle_progress_info()
 
     # --------------------------------------------------------------`---------
     _PROGRESS_TIMER_PAUSED_STATES = frozenset({"Hold", "Pause", "Wait", "Tool"})
 
     def _current_remaining_sec(self):
         return max(0.0, self._remaining_anchor_sec - (time.time() - self._remaining_anchor_time))
+
+    def _seconds_until_line(self, line_no, live_remaining=None):
+        """Seconds until a line: from start when idle, from the playhead when running."""
+        if line_no is None or not self.selected_file_line_count:
+            return None
+        remaining_at = self.gcode_viewer.get_remaining_time_by_lineidx
+        total_time = self.gcode_viewer.total_time or 0.0
+        percent_target = play_percent_from_line(line_no, self.selected_file_line_count)
+        if live_remaining is None:
+            return seconds_from_start(
+                gcode_remaining_target=remaining_at(line_no, 0.0),
+                total_time=total_time,
+                percent_target=percent_target,
+            )
+        current_line = self.played_lines or 1
+        return seconds_until_target(
+            gcode_remaining_now=remaining_at(current_line, 0.5),
+            gcode_remaining_target=remaining_at(line_no, 0.0),
+            live_remaining=live_remaining,
+            percent_now=self.wpb_play.value,
+            percent_target=percent_target,
+        )
+
+    def _tool_change_display_name(self, label):
+        if label == "L":
+            return tr._("Laser")
+        if label == "P":
+            return tr._("Probe")
+        if label == "3DP":
+            return tr._("3D Probe")
+        return label
+
+    def _playbar_tool_change_tooltip(self, label, line_no):
+        app = App.get_running_app()
+        playing = bool(app and app.playing)
+        if playing and app.state in self._PROGRESS_TIMER_PAUSED_STATES:
+            live_remaining = max(0.0, self._remaining_anchor_sec)
+        elif playing:
+            live_remaining = self._current_remaining_sec()
+        else:
+            live_remaining = None
+        seconds = self._seconds_until_line(line_no, live_remaining)
+        tool_name = self._tool_change_display_name(label)
+        if seconds is None:
+            return tr._("Tool change to {}").format(tool_name)
+        if playing and seconds <= 0:
+            return tr._("Tool change to {} passed").format(tool_name)
+        return tr._("Tool change to {} in {}").format(tool_name, Utils.second2hour(int(seconds)))
+
+    def _format_file_progress_info(self, *, playing, remaining_sec=None):
+        """Progress-bar text while a file is selected, playing or idle."""
+        app = App.get_running_app()
+        path = (app.selected_remote_filename or app.selected_local_filename) if app else ""
+        filename = os.path.basename(path) if path else ""
+        if not playing:
+            duration_sec = self.gcode_viewer.total_time or 0.0
+            if duration_sec <= 0:
+                return f" {filename}" if filename else ""
+            return f" {filename} ({Utils.second2hour(int(duration_sec))} {tr._('estimated')})"
+        remaining = remaining_sec if remaining_sec is not None else 0.0
+        time_phrase = "{} to go".format(Utils.second2hour(int(remaining)))
+        next_change = next_tool_change_after_line(self.tool_change_markers, self.played_lines)
+        if next_change is not None and self.status_index % 2 == 1:
+            next_line, next_label = next_change
+            until_sec = self._seconds_until_line(next_line, remaining)
+            if until_sec is not None:
+                time_phrase = tr._("{} until {}").format(Utils.second2hour(int(until_sec)), next_label)
+        return (
+            f" {filename} ( {self.played_lines}/{self.selected_file_line_count} - {int(self.wpb_play.value)}%,"
+            f" {Utils.second2hour(int(CNC.vars.get('playedseconds', 0) or 0))} {tr._('elapsed')}, {time_phrase} )"
+        )
+
+    def _refresh_idle_progress_info(self):
+        app = App.get_running_app()
+        if app is None or app.playing:
+            return
+        if app.selected_remote_filename or app.selected_local_filename:
+            self.progress_info = self._format_file_progress_info(playing=False)
 
     def _update_progress_smooth(self, dt):
         """Refresh elapsed/remaining display every second while playing."""
@@ -6084,9 +6173,9 @@ class Makera(RelativeLayout):
         ):
             # While held/paused/disconnected, leave the last progress_info unchanged so both timers freeze.
             return
-        remaining_display = self._current_remaining_sec()
-        filename = os.path.basename(app.selected_remote_filename or app.selected_local_filename)
-        self.progress_info = f" {filename} ( {self.played_lines}/{self.selected_file_line_count} - {int(self.wpb_play.value)}%, {Utils.second2hour(CNC.vars['playedseconds'])} elapsed, {Utils.second2hour(int(remaining_display))} to go )"
+        self.progress_info = self._format_file_progress_info(
+            playing=True, remaining_sec=self._current_remaining_sec()
+        )
 
     # --------------------------------------------------------------`---------
     def updateCompressProgress(self, value):
@@ -6527,7 +6616,6 @@ class Makera(RelativeLayout):
                 self.wpb_zprobe.value = 0
                 self.wpb_leveling.value = 0
                 self.wpb_play.value = 0
-                self.progress_info = ""
                 # Stop smooth progress updates
                 if self._progress_smooth_clock is not None:
                     self._progress_smooth_clock.cancel()
@@ -6536,11 +6624,8 @@ class Makera(RelativeLayout):
                 last_job_elapsed = ""
                 if CNC.vars["playedseconds"] > 0:
                     last_job_elapsed = " ( {} elapsed )".format(Utils.second2hour(CNC.vars["playedseconds"]))
-                # show file name on progress bar area
-                if app.selected_remote_filename != "":
-                    self.progress_info = " " + app.selected_remote_filename + last_job_elapsed
-                elif app.selected_local_filename != "":
-                    self.progress_info = " " + app.selected_local_filename + last_job_elapsed
+                if app.selected_remote_filename or app.selected_local_filename:
+                    self.progress_info = self._format_file_progress_info(playing=False)
                 else:
                     self.progress_info = tr._(" No Remote File Selected") + last_job_elapsed
             else:

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6142,7 +6142,7 @@ class Makera(RelativeLayout):
                 return f" {filename}" if filename else ""
             return f" {filename} ({Utils.second2hour(int(duration_sec))} {tr._('estimated')})"
         remaining = remaining_sec if remaining_sec is not None else 0.0
-        time_phrase = "{} to go".format(Utils.second2hour(int(remaining)))
+        time_phrase = f"{Utils.second2hour(int(remaining))} to go"
         next_change = next_tool_change_after_line(self.tool_change_markers, self.played_lines)
         if next_change is not None and self.status_index % 2 == 1:
             next_line, next_label = next_change
@@ -6173,9 +6173,7 @@ class Makera(RelativeLayout):
         ):
             # While held/paused/disconnected, leave the last progress_info unchanged so both timers freeze.
             return
-        self.progress_info = self._format_file_progress_info(
-            playing=True, remaining_sec=self._current_remaining_sec()
-        )
+        self.progress_info = self._format_file_progress_info(playing=True, remaining_sec=self._current_remaining_sec())
 
     # --------------------------------------------------------------`---------
     def updateCompressProgress(self, value):

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -4638,6 +4638,8 @@
                         color: 244/255, 208/255, 63/255, 1
                     PlayProgressBar:
                         id: wpb_play
+                        show_tooltips: app.show_tooltips
+                        tooltip_delay: app.tooltip_delay
                         Label:
                             size_hint_x: None
                             width: '5dp'

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -4638,8 +4638,6 @@
                         color: 244/255, 208/255, 63/255, 1
                     PlayProgressBar:
                         id: wpb_play
-                        show_tooltips: app.show_tooltips
-                        tooltip_delay: app.tooltip_delay
                         Label:
                             size_hint_x: None
                             width: '5dp'

--- a/carveracontroller/ui/PlayProgressBar.py
+++ b/carveracontroller/ui/PlayProgressBar.py
@@ -1,8 +1,12 @@
+import sys
+
+from kivy.clock import Clock
 from kivy.core.text import Label as CoreLabel
+from kivy.core.window import Window
 from kivy.factory import Factory
 from kivy.graphics import Color, Line, Rectangle
 from kivy.metrics import dp
-from kivy.properties import ListProperty, NumericProperty
+from kivy.properties import BooleanProperty, ListProperty, NumericProperty, ObjectProperty
 from kivy.uix.boxlayout import BoxLayout
 
 from carveracontroller.CNC import LASER_TOOL_NUMBER, PROBE_3D_TOOL_NUMBER, ZPROBE_TOOL_NUMBER
@@ -10,6 +14,7 @@ from carveracontroller.GcodeViewer import tool_marker_palette_rgb
 
 DEFAULT_MARKER_LABEL_BG_COLOR = (210 / 255, 210 / 255, 210 / 255, 1)
 MARKER_LABEL_TEXT_COLOR = (30 / 255, 30 / 255, 30 / 255, 1)
+MARKER_HIT_PAD = dp(6)
 
 
 def play_percent_from_line(line_no, line_count):
@@ -18,13 +23,66 @@ def play_percent_from_line(line_no, line_count):
     return min(100.0, line_no / float(line_count) * 100.0)
 
 
+def unpack_tool_marker(entry):
+    """Return (percent, label, line_no) from a 2- or 3-tuple marker."""
+    percent = entry[0]
+    label = entry[1]
+    line_no = entry[2] if len(entry) > 2 else None
+    return percent, label, line_no
+
+
 def tool_change_markers_to_percents(markers, line_count):
     if line_count <= 0:
         return []
     percents = []
     for line_no, label in markers:
-        percents.append((play_percent_from_line(line_no, line_count), label))
+        percents.append((play_percent_from_line(line_no, line_count), label, line_no))
     return percents
+
+
+def next_tool_change_after_line(markers, current_line):
+    """Return (line_no, label) of the next tool change after current_line, or None."""
+    for line_no, label in markers:
+        if line_no > current_line:
+            return (line_no, label)
+    return None
+
+
+def seconds_from_start(*, gcode_remaining_target=None, total_time=None, percent_target=None):
+    """Seconds from program start until a line (loaded file, not yet playing)."""
+    if not total_time:
+        return None
+    if gcode_remaining_target is not None:
+        elapsed = max(0.0, total_time - gcode_remaining_target)
+        if elapsed > 0:
+            return elapsed
+    if percent_target:
+        return max(0.0, total_time * percent_target / 100.0)
+    return 0.0 if gcode_remaining_target is not None else None
+
+
+def seconds_until_target(
+    *,
+    gcode_remaining_now=None,
+    gcode_remaining_target=None,
+    live_remaining=None,
+    percent_now=None,
+    percent_target=None,
+):
+    """Seconds from the live play position until a future line."""
+    if gcode_remaining_now is not None and gcode_remaining_target is not None:
+        delta = gcode_remaining_now - gcode_remaining_target
+        if delta <= 0:
+            return 0.0
+        if live_remaining is not None and gcode_remaining_now > 0:
+            return max(0.0, live_remaining * (delta / gcode_remaining_now))
+        return delta
+    if live_remaining is not None and percent_now is not None and percent_target is not None:
+        remaining_pct = 100.0 - percent_now
+        if percent_target <= percent_now or remaining_pct <= 0:
+            return 0.0
+        return max(0.0, live_remaining * (percent_target - percent_now) / remaining_pct)
+    return None
 
 
 def _marker_label_bg_color(label):
@@ -114,15 +172,27 @@ def _layout_tool_marker_labels(items, track_w, gap=None):
     return items
 
 
+def _rect_contains(rect, x, y):
+    left, bottom, width, height = rect
+    return left <= x <= left + width and bottom <= y <= bottom + height
+
+
 class PlayProgressBar(BoxLayout):
     value = NumericProperty(0)
     color = ListProperty([52 / 255, 166 / 255, 208 / 255, 1])
     tool_markers = ListProperty([])
+    show_tooltips = BooleanProperty(True)
+    tooltip_delay = NumericProperty(0.5)
+    marker_tooltip_provider = ObjectProperty(None, allownone=True)
 
     LABEL_ROW_H = dp(12)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._marker_hitboxes = []
+        self._tooltip = None
+        self._hover_pos = None
+        self._hover_hitbox = None
         with self.canvas.before:
             Color(50 / 255, 50 / 255, 50 / 255, 1)
             self._bg_rect = Rectangle(pos=self.pos, size=(0, 0))
@@ -135,6 +205,17 @@ class PlayProgressBar(BoxLayout):
             color=self._update_fill_color,
             tool_markers=self._update_markers,
         )
+        if sys.platform != "ios":
+            Window.bind(mouse_pos=self._on_mouse_pos)
+
+    def on_parent(self, instance, parent):
+        if parent is None:
+            Clock.unschedule(self._display_marker_tooltip)
+            self._close_marker_tooltip()
+            try:
+                Window.unbind(mouse_pos=self._on_mouse_pos)
+            except Exception:
+                pass
 
     def _track_width(self):
         return max(0, self.width - dp(5)) if self.width > 0 else 0
@@ -161,7 +242,8 @@ class PlayProgressBar(BoxLayout):
     def _prepare_marker_draw_items(self, value, track_w):
         layout_w = track_w + self._fill_offset()
         items = []
-        for percent, label in value:
+        for entry in value:
+            percent, label, line_no = unpack_tool_marker(entry)
             local_x = self._position_for_percent(track_w, percent)
             label_bg_color = _marker_label_bg_color(label)
             core = CoreLabel(
@@ -176,6 +258,7 @@ class PlayProgressBar(BoxLayout):
                 {
                     "percent": percent,
                     "label": label,
+                    "line_no": line_no,
                     "local_x": local_x,
                     "label_w": label_w,
                     "label_h": label_h,
@@ -195,9 +278,12 @@ class PlayProgressBar(BoxLayout):
 
     def _update_markers(self, _instance, value):
         self.canvas.after.clear()
+        self._marker_hitboxes = []
         track_w = self._track_width()
         bar_h = self.height if self.width > 0 else 0
         if track_w <= 0 or bar_h <= 0 or not value:
+            if not value:
+                self._close_marker_tooltip()
             return
         label_pad = dp(2)
         ox, oy = self.pos
@@ -225,6 +311,102 @@ class PlayProgressBar(BoxLayout):
                     pos=(label_x, label_y),
                     size=(label_w, label_h),
                 )
+        self._marker_hitboxes = self._hitboxes_for_items(draw_items, ox, oy, bar_h, label_pad)
+
+    def _hitboxes_for_items(self, draw_items, ox, oy, bar_h, label_pad):
+        hitboxes = []
+        for item in draw_items:
+            rects = []
+            x = ox + item["local_x"]
+            rects.append((x - MARKER_HIT_PAD, oy, MARKER_HIT_PAD * 2, bar_h))
+            if item.get("show_label", True):
+                label_x = ox + item["left"] - label_pad
+                label_y = self._label_y_for_row(oy, item["row"], item["label_h"]) - label_pad / 2.0
+                rects.append(
+                    (
+                        label_x,
+                        label_y,
+                        item["label_w"] + label_pad * 2,
+                        item["label_h"] + label_pad,
+                    )
+                )
+            hitboxes.append(
+                {
+                    "label": item["label"],
+                    "line_no": item.get("line_no"),
+                    "local_x": x,
+                    "rects": rects,
+                }
+            )
+        return hitboxes
+
+    def _hitbox_at(self, x, y):
+        hits = [box for box in self._marker_hitboxes if any(_rect_contains(rect, x, y) for rect in box["rects"])]
+        if not hits:
+            return None
+        return min(hits, key=lambda box: abs(box["local_x"] - x))
+
+    def _marker_tooltip_text(self, hitbox):
+        provider = self.marker_tooltip_provider
+        if callable(provider):
+            text = provider(hitbox["label"], hitbox["line_no"])
+            if text:
+                return text
+        return hitbox["label"]
+
+    def _ensure_tooltip(self):
+        if self._tooltip is not None:
+            return
+        from carveracontroller.addons.tooltips.Tooltips import Tooltip
+
+        self._tooltip = Tooltip()
+
+    def _layout_tooltip_at(self, pos, text):
+        self._ensure_tooltip()
+        tooltip_label = self._tooltip.ids.tooltip_label
+        tooltip_label.text = text
+        tooltip_label.texture_update()
+        text_width, text_height = tooltip_label.texture_size
+        tooltip_width = max(text_width + 20, 0)
+        tooltip_height = text_height + 20
+        self._tooltip.size = (tooltip_width, tooltip_height)
+        window_width, window_height = Window.size
+        x, y = pos
+        if x + tooltip_width > window_width:
+            x = window_width - tooltip_width - 30
+        if y + tooltip_height > window_height - 30:
+            y = window_height - tooltip_height - 40
+        self._tooltip.pos = (x, y)
+
+    def _on_mouse_pos(self, *args):
+        if not self.show_tooltips or not self.get_root_window() or not self._marker_hitboxes:
+            self._close_marker_tooltip()
+            return
+        pos = args[1]
+        local = self.to_widget(*pos)
+        hitbox = self._hitbox_at(*local)
+        Clock.unschedule(self._display_marker_tooltip)
+        self._close_marker_tooltip()
+        if hitbox is None:
+            return
+        self._hover_pos = pos
+        self._hover_hitbox = hitbox
+        Clock.schedule_once(self._display_marker_tooltip, self.tooltip_delay)
+
+    def _display_marker_tooltip(self, *_args):
+        hitbox = self._hover_hitbox
+        pos = self._hover_pos
+        if hitbox is None or pos is None:
+            return
+        text = self._marker_tooltip_text(hitbox)
+        if not text:
+            return
+        self._layout_tooltip_at(pos, text)
+        Window.add_widget(self._tooltip)
+
+    def _close_marker_tooltip(self, *_args):
+        if self._tooltip is not None:
+            Window.remove_widget(self._tooltip)
 
 
 Factory.register("PlayProgressBar", cls=PlayProgressBar)

--- a/carveracontroller/ui/PlayProgressBar.py
+++ b/carveracontroller/ui/PlayProgressBar.py
@@ -1,14 +1,11 @@
-import sys
-
-from kivy.clock import Clock
 from kivy.core.text import Label as CoreLabel
-from kivy.core.window import Window
 from kivy.factory import Factory
 from kivy.graphics import Color, Line, Rectangle
 from kivy.metrics import dp
-from kivy.properties import BooleanProperty, ListProperty, NumericProperty, ObjectProperty
+from kivy.properties import ListProperty, NumericProperty, ObjectProperty
 from kivy.uix.boxlayout import BoxLayout
 
+from carveracontroller.addons.tooltips.Tooltips import ToolTipButton
 from carveracontroller.CNC import LASER_TOOL_NUMBER, PROBE_3D_TOOL_NUMBER, ZPROBE_TOOL_NUMBER
 from carveracontroller.GcodeViewer import tool_marker_palette_rgb
 
@@ -177,12 +174,56 @@ def _rect_contains(rect, x, y):
     return left <= x <= left + width and bottom <= y <= bottom + height
 
 
+class _MarkerHoverToolTip(ToolTipButton):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("text", "")
+        kwargs.setdefault("size_hint", (None, None))
+        kwargs.setdefault("size", (0, 0))
+        kwargs.setdefault("opacity", 0)
+        kwargs.setdefault("background_normal", "")
+        kwargs.setdefault("background_down", "")
+        kwargs.setdefault("background_color", (0, 0, 0, 0))
+        kwargs.setdefault("border", (0, 0, 0, 0))
+        kwargs.setdefault("color", (0, 0, 0, 0))
+        super().__init__(**kwargs)
+
+    def collide_point(self, x, y):
+        parent = self.parent
+        if parent is None:
+            return False
+        return parent._hitbox_at(x, y) is not None
+
+    def to_widget(self, x, y, relative=False):
+        parent = self.parent
+        if parent is None:
+            return super().to_widget(x, y, relative)
+        return parent.to_widget(x, y, relative)
+
+    def on_mouse_pos(self, *args):
+        parent = self.parent
+        if parent is None:
+            self.tooltip_txt = ""
+            super().on_mouse_pos(*args)
+            return
+        pos = args[1]
+        hitbox = parent._hitbox_at(*parent.to_widget(*pos))
+        self.tooltip_txt = parent._marker_tooltip_text(hitbox) if hitbox else ""
+        super().on_mouse_pos(*args)
+
+    def on_touch_down(self, touch):
+        return False
+
+    def on_touch_move(self, touch):
+        return False
+
+    def on_touch_up(self, touch):
+        return False
+
+
 class PlayProgressBar(BoxLayout):
     value = NumericProperty(0)
     color = ListProperty([52 / 255, 166 / 255, 208 / 255, 1])
     tool_markers = ListProperty([])
-    show_tooltips = BooleanProperty(True)
-    tooltip_delay = NumericProperty(0.5)
     marker_tooltip_provider = ObjectProperty(None, allownone=True)
 
     LABEL_ROW_H = dp(12)
@@ -190,9 +231,8 @@ class PlayProgressBar(BoxLayout):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._marker_hitboxes = []
-        self._tooltip = None
-        self._hover_pos = None
-        self._hover_hitbox = None
+        self._hover_tip = _MarkerHoverToolTip()
+        self.add_widget(self._hover_tip)
         with self.canvas.before:
             Color(50 / 255, 50 / 255, 50 / 255, 1)
             self._bg_rect = Rectangle(pos=self.pos, size=(0, 0))
@@ -205,17 +245,6 @@ class PlayProgressBar(BoxLayout):
             color=self._update_fill_color,
             tool_markers=self._update_markers,
         )
-        if sys.platform != "ios":
-            Window.bind(mouse_pos=self._on_mouse_pos)
-
-    def on_parent(self, instance, parent):
-        if parent is None:
-            Clock.unschedule(self._display_marker_tooltip)
-            self._close_marker_tooltip()
-            try:
-                Window.unbind(mouse_pos=self._on_mouse_pos)
-            except Exception:
-                pass
 
     def _track_width(self):
         return max(0, self.width - dp(5)) if self.width > 0 else 0
@@ -282,8 +311,6 @@ class PlayProgressBar(BoxLayout):
         track_w = self._track_width()
         bar_h = self.height if self.width > 0 else 0
         if track_w <= 0 or bar_h <= 0 or not value:
-            if not value:
-                self._close_marker_tooltip()
             return
         label_pad = dp(2)
         ox, oy = self.pos
@@ -353,60 +380,6 @@ class PlayProgressBar(BoxLayout):
             if text:
                 return text
         return hitbox["label"]
-
-    def _ensure_tooltip(self):
-        if self._tooltip is not None:
-            return
-        from carveracontroller.addons.tooltips.Tooltips import Tooltip
-
-        self._tooltip = Tooltip()
-
-    def _layout_tooltip_at(self, pos, text):
-        self._ensure_tooltip()
-        tooltip_label = self._tooltip.ids.tooltip_label
-        tooltip_label.text = text
-        tooltip_label.texture_update()
-        text_width, text_height = tooltip_label.texture_size
-        tooltip_width = max(text_width + 20, 0)
-        tooltip_height = text_height + 20
-        self._tooltip.size = (tooltip_width, tooltip_height)
-        window_width, window_height = Window.size
-        x, y = pos
-        if x + tooltip_width > window_width:
-            x = window_width - tooltip_width - 30
-        if y + tooltip_height > window_height - 30:
-            y = window_height - tooltip_height - 40
-        self._tooltip.pos = (x, y)
-
-    def _on_mouse_pos(self, *args):
-        if not self.show_tooltips or not self.get_root_window() or not self._marker_hitboxes:
-            self._close_marker_tooltip()
-            return
-        pos = args[1]
-        local = self.to_widget(*pos)
-        hitbox = self._hitbox_at(*local)
-        Clock.unschedule(self._display_marker_tooltip)
-        self._close_marker_tooltip()
-        if hitbox is None:
-            return
-        self._hover_pos = pos
-        self._hover_hitbox = hitbox
-        Clock.schedule_once(self._display_marker_tooltip, self.tooltip_delay)
-
-    def _display_marker_tooltip(self, *_args):
-        hitbox = self._hover_hitbox
-        pos = self._hover_pos
-        if hitbox is None or pos is None:
-            return
-        text = self._marker_tooltip_text(hitbox)
-        if not text:
-            return
-        self._layout_tooltip_at(pos, text)
-        Window.add_widget(self._tooltip)
-
-    def _close_marker_tooltip(self, *_args):
-        if self._tooltip is not None:
-            Window.remove_widget(self._tooltip)
 
 
 Factory.register("PlayProgressBar", cls=PlayProgressBar)


### PR DESCRIPTION
Using the Z1 has made me want a bit of information that isn't as relevant for the ATC machine; when will the next tool change occur.

This PR adds this information in two ways:
1. As a tooltip on the Toolchange flags
<img width="1321" height="177" alt="Screenshot 2026-08-29 at 11 35 32 am" src="https://github.com/user-attachments/assets/1bac61d1-9f4c-4e88-8191-c4215893e36c" />

2. In the progressbar itself, alternating between time remaining for the entire program and until the next tool change. Ignore the difference in time here in the screenshot, I pushed play but then hovered...

<img width="761" height="136" alt="Screenshot 2026-08-29 at 11 39 33 am" src="https://github.com/user-attachments/assets/dadc39d8-72c5-4843-a903-57fca4d3458c" />


In adding this I noticed that a time estimate wasn't shown when a file had been selected but not running, so I've added that now too:
<img width="622" height="121" alt="Screenshot 2026-08-29 at 11 41 34 am" src="https://github.com/user-attachments/assets/5f48778f-a546-4b93-955b-d48bd92e1ff2" />


@Lyrkan Tell me what you think, I think the design language is a bit funny to have tooltips on the tool flags but I can't imagine a better way