### PR TITLE
Allow to select the bottom element of the MDI, Gcode and probing confirmation lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1
 - Change: Config and Run preview now uses now uses the configured worksize_x/y for the bed size
 - Fixed: Harden the gcode parser against "zero length" movement, and prevent division by zero in play slider
+- Fixed: Allow to select the bottom element of the MDI, Gcode and probing confirmation lists
 
 [2.2.0-RC3]
 - Enhancement: The step size is now synchronized between the main screen and the Probing screen

--- a/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
+++ b/carveracontroller/addons/probing/preview/ProbingPreviewPopup.kv
@@ -38,6 +38,7 @@
                 scroll_wheel_distance: dp(114)
                 data: app.mdi_data
                 bar_width: dp(20)
+                do_scroll_x: False
                 viewclass: 'ProbingRow'
                 SelectableRecycleBoxLayout:
                     default_size: None, dp(20)

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -4242,6 +4242,7 @@
                                                 scroll_type: ['bars', 'content']
                                                 scroll_wheel_distance: dp(114)
                                                 bar_width: dp(20)
+                                                do_scroll_x: False
                                                 viewclass: 'GCodeRow'
                                                 SelectableRecycleBoxLayout:
                                                     default_size: None, dp(20)
@@ -4315,6 +4316,7 @@
                                                 scroll_type: ['bars', 'content']
                                                 scroll_wheel_distance: dp(114)
                                                 bar_width: dp(20)
+                                                do_scroll_x: False
                                                 viewclass: 'Row'
                                                 SelectableRecycleBoxLayout:
                                                     default_size: None, dp(20)


### PR DESCRIPTION
Fixes #756 

The bottom element of the MDI, Gcode and probing confirmation lists couldn't be selected because Kivy adds some kind of reserved space for the X scrollbar (that we don't need) unless it is explicitly disabled through `do_scroll_x: False`.

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/16d7d7a8-2092-4578-ab8c-c68490ab092a" />

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/bd03ab17-bca4-4a7b-9213-ffacccbaa3c3" />

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/dbdefcbc-5317-4936-88be-e7aded8d18ec" />