### PR TITLE
Auto LED lights on connect/disconnect and app closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 [unreleased]
+- Enhancement: Auto enclosure/LED lights on connect and off on disconnect or app close. Controller setting is available to enable/disable this feature, default is enabled.
 - Enhancement: Tool-change flags have tooltip showing time until the change
 - Enhancement: Remaining time text alternates with time until the next tool change and playback completion
 - Enhancement: Selected files show estimated run time on the playback bar before the job starts

--- a/carveracontroller/Controller.py
+++ b/carveracontroller/Controller.py
@@ -79,6 +79,15 @@ LOAD_CONN_WIFI = 8
 
 SEND_FILE = 1
 
+
+def session_light_commands(turn_on, is_community_firmware):
+    """G-code to apply for a connect (on) or disconnect (off) light change."""
+    commands = ["M821" if turn_on else "M822"]
+    if is_community_firmware:
+        commands.append("M337 B104" if turn_on else "M337 B0 U0 R0")
+    return commands
+
+
 CONN_USB = 0
 CONN_WIFI = 1
 
@@ -182,6 +191,7 @@ class Controller:
         self.diagnosing = False
 
         self.is_community_firmware = False
+        self._session_lights_applied = False
 
         # Connection-scoped comms protocol (detect on open; follows M485 switches)
         self.comms = ProtocolSession(on_change=self._on_comms_protocol_changed)
@@ -524,6 +534,33 @@ class Controller:
             self.executeCommand("M821\n")
         else:
             self.executeCommand("M822\n")
+
+    def _auto_lights_enabled(self):
+        if App is None:
+            return False
+        try:
+            from kivy.config import Config
+
+            return Config.getboolean("carvera", "auto_lights_on_connect", fallback=True)
+        except Exception:
+            return False
+
+    def apply_session_lights(self, turn_on, *, enabled=None):
+        """Turn enclosure/LED lights on at connect or off before disconnect."""
+        if turn_on and self._session_lights_applied:
+            return
+        if enabled is None:
+            enabled = self._auto_lights_enabled()
+        if not enabled:
+            # Remember that this session already decided, so connect is not retried.
+            if turn_on:
+                self._session_lights_applied = True
+            return
+        if self.stream is None:
+            return
+        for command in session_light_commands(turn_on, self.is_community_firmware):
+            self.executeCommand(command + "\n")
+        self._session_lights_applied = turn_on
 
     def setExternalControl(self, pwm=100):
         if pwm > 0:
@@ -1551,6 +1588,7 @@ class Controller:
             return
         self.stopRun()
         self._join_stream_io()
+        self.apply_session_lights(False)
         if self.stream is not None:
             try:
                 self.stream.close()
@@ -1627,6 +1665,7 @@ class Controller:
             CNC.vars["alarm_message"] = ""
             # Reset manual disconnect flag when connection is established
             self._manual_disconnect = False
+            self._session_lights_applied = False
             try:
                 self.clearRun()
             except Exception:
@@ -1658,6 +1697,7 @@ class Controller:
             self.log.put((self.MSG_ERROR, "Controller stop thread error!"))
         self._runLines = 0
         self._join_stream_io()
+        self.apply_session_lights(False)
         try:
             self.stream.close()
         except Exception:
@@ -1684,6 +1724,7 @@ class Controller:
             self.log.put((self.MSG_ERROR, "Controller stop thread error!"))
         self._runLines = 0
         self._join_stream_io()
+        self.apply_session_lights(False)
         try:
             self.stream.close()
         except Exception:

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -225,6 +225,14 @@
         "default": "true"
     },
     {
+        "type": "bool",
+        "title": "Auto lights on connect",
+        "desc": "Turn the enclosure light on when connecting and off when disconnecting or closing the app. On Community Firmware, also sets the LED bar to blue on connect and off on disconnect",
+        "section": "carvera",
+        "key": "auto_lights_on_connect",
+        "default": "1"
+    },
+    {
         "type": "options",
         "title": "Preferred reconnection method",
         "desc": "Connection method used for auto-connect on app launch. After you connect manually, Reconnect uses the last successful method instead",

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6576,6 +6576,7 @@ class Makera(RelativeLayout):
                     if self.gcode_viewer is not None:
                         self.gcode_viewer.set_bed(None, visible=False)
                     self.controller.is_community_firmware = False
+                    self.controller._session_lights_applied = False
                     self.machine_metadata_query_time = 0
 
                     # Clean up light toggle binding when disconnected
@@ -6636,6 +6637,10 @@ class Makera(RelativeLayout):
                     self.status_drop_down.btn_unlock.text = "Reset"
                 else:
                     self.status_drop_down.btn_unlock.text = "Unlock"
+
+            # Turn session lights on once firmware is known
+            if app.state != NOT_CONNECTED and self.fw_version and not self.controller._session_lights_applied:
+                self.controller.apply_session_lights(True)
 
             # load config, only one time per connection
             if (
@@ -9091,6 +9096,8 @@ def set_config_defaults(default_lang):
         Config.set("carvera", "instantFSoverride", "1")
     if not Config.has_option("carvera", "show_playbar_tool_change_markers"):
         Config.set("carvera", "show_playbar_tool_change_markers", "1")
+    if not Config.has_option("carvera", "auto_lights_on_connect"):
+        Config.set("carvera", "auto_lights_on_connect", "1")
 
     # G-code viewer defaults
     if not Config.has_option("carvera", "gcode_auto_show_stock"):


### PR DESCRIPTION
Adds a Controller setting (default on) which turns on the enclosure lights and status leds on connect, and on disconnect turns them off.

Right now it uses `M337 B104` to turn the status LEDs back on, which isn't ideal if the status isn't idle. Pending on https://github.com/Carvera-Community/Carvera_Community_Firmware/pull/433 to add a M338 to return the LED to match the current machine status.

<img width="1087" height="421" alt="Screenshot 2026-09-01 at 1 52 47 pm" src="https://github.com/user-attachments/assets/6c4e7280-50fb-49e6-a78c-701b8cec1a51" />
