### PR TITLE
Improve Auto Leveling flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enhancement: Add bed settings and visualization to the G-Code viewer
 - Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1
 - Change: Config and Run preview now uses now uses the configured worksize_x/y for the bed size
+- Change: Auto Leveling auto-enables Auto Z Probe, but keeps the previous Z-probe location and allows the location config to be changed. Auto Z Probe can be turned off while leveling, but a warning is shown.
 - Fixed: Harden the gcode parser against "zero length" movement, and prevent division by zero in play slider
 - Fixed: Time estimates ignoring speed for some 4th-axis moves
 - Fixed: Allow to select the bottom element of the MDI, Gcode and probing confirmation lists

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -1157,23 +1157,6 @@ class AutoLevelPopup(ModalView):
                 and self.ids.txt_auto_yp_offset.text != "."
                 else 0.0,
             )
-            if self.ids.cbx_autolevelOffsets.active:
-                self.coord_popup.set_config(
-                    "zprobe",
-                    "x_offset",
-                    float(self.ids.txt_auto_xn_offset.text)
-                    if self.ids.txt_auto_xn_offset.text.strip() and self.ids.txt_auto_xn_offset.text != "."
-                    else 0.0,
-                )
-            if self.ids.cbx_autolevelOffsets.active:
-                self.coord_popup.set_config(
-                    "zprobe",
-                    "y_offset",
-                    float(self.ids.txt_auto_yn_offset.text)
-                    if self.ids.txt_auto_yn_offset.text.strip() and self.ids.txt_auto_yn_offset.text != "."
-                    else 0.0,
-                )
-
             self.coord_popup.load_leveling_label()
             if self.execute:
                 app = App.get_running_app()
@@ -1433,10 +1416,9 @@ class CoordPopup(ModalView):
         else:
             self.ionizermode = False
 
-        # init margin widgets
+        # Apply leveling before Z probe so turning both off does not warn.
         self.cbx_margin.active = self.config["margin"]["active"]
-
-        # init zprobe widgets
+        self.cbx_leveling.active = self.config["leveling"]["active"]
         self.cbx_zprobe.active = self.config["zprobe"]["active"]
         # init zprobe popup
         self.zprobe_popup.cbx_origin1.active = self.config["zprobe"]["origin"] == 1
@@ -1446,8 +1428,6 @@ class CoordPopup(ModalView):
 
         self.load_zprobe_label()
 
-        # init leveling widgets
-        self.cbx_leveling.active = self.config["leveling"]["active"]
         self.auto_level_popup.sp_x_points.text = str(self.config["leveling"]["x_points"])
         self.auto_level_popup.sp_y_points.text = str(self.config["leveling"]["y_points"])
         self.auto_level_popup.sp_height.text = str(self.config["leveling"]["height"])
@@ -1517,6 +1497,44 @@ class CoordPopup(ModalView):
                 + tr._(" +Y: ")
                 + "%g " % (round(self.config["leveling"]["yp_offset"], 4))
             )
+
+    def _zprobe_controls_allowed(self):
+        app = App.get_running_app()
+        lasering = bool(app and getattr(app, "lasering", False))
+        return self.mode in ("Run", "ZProbe", "Leveling") and not lasering
+
+    def on_zprobe_checkbox(self, active):
+        app = App.get_running_app()
+        has_4axis = bool(app and getattr(app, "has_4axis", False))
+        allowed = self._zprobe_controls_allowed()
+        self.lb_zprobe.disabled = not active or not allowed
+        self.btn_zprobe.disabled = not active or has_4axis or not allowed
+        self.set_config("zprobe", "active", active)
+        if not active and self.cbx_leveling.active:
+            self._warn_zprobe_disabled_during_leveling()
+        self.toggle_config()
+
+    def on_leveling_checkbox(self, active):
+        app = App.get_running_app()
+        has_4axis = bool(app and getattr(app, "has_4axis", False))
+        leveling_allowed = self.mode in ("Run", "Leveling") and not has_4axis
+        self.lb_leveling.disabled = not active or not leveling_allowed
+        self.btn_leveling.disabled = not active or not leveling_allowed
+        self.set_config("leveling", "active", active)
+        if active:
+            self.cbx_zprobe.active = True
+            self.set_config("zprobe", "active", True)
+        self.toggle_config()
+
+    def _warn_zprobe_disabled_during_leveling(self):
+        app = App.get_running_app()
+        if app is None or getattr(app, "root", None) is None:
+            return
+        message = tr._(
+            "Auto Leveling without Auto Z Probe will use the current Z zero. "
+            "Probe Z first or leave Auto Z Probe enabled, or job height may be wrong."
+        )
+        Clock.schedule_once(partial(app.root.show_message_popup, message, False), 0)
 
     def toggle_config(self):
         # upldate main status

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3327,7 +3327,7 @@
                 BoxLayout:
                     size_hint_y: None
                     height: '25dp'
-                    disabled:  (root.mode != 'Run' and root.mode != 'ZProbe') or root.cbx_leveling.active or app.lasering
+                    disabled:  (root.mode != 'Run' and root.mode != 'ZProbe' and root.mode != 'Leveling') or app.lasering
                     canvas.before:
                         Color:
                             rgba: 65/255, 65/255, 65/255, 1
@@ -3336,11 +3336,7 @@
                             size: self.size
                     MCQCheckBox:
                         id: cbx_zprobe
-                        on_active:
-                            root.lb_zprobe.disabled = not self.active or (root.mode != 'Run' and root.mode != 'ZProbe') or root.cbx_leveling.active
-                            root.btn_zprobe.disabled = not self.active or app.has_4axis or (root.mode != 'Run' and root.mode != 'ZProbe') or root.cbx_leveling.active
-                            root.set_config('zprobe', 'active', self.active)
-                            root.toggle_config()
+                        on_active: root.on_zprobe_checkbox(self.active)
                     MCQLabel:
                         on_press: cbx_zprobe._do_press()
                         text: tr._(' Auto Z Probe')
@@ -3357,7 +3353,7 @@
                     id: lb_zprobe
                     size_hint_y: None
                     height: '25dp'
-                    disabled:  (root.mode != 'Run' and root.mode != 'ZProbe') or root.cbx_leveling.active or app.lasering
+                    disabled:  not cbx_zprobe.active or (root.mode != 'Run' and root.mode != 'ZProbe' and root.mode != 'Leveling') or app.lasering
                     text: tr._(" (10, 10) from Path Origin")
                     halign: "left"
                     valign: "middle"
@@ -3373,7 +3369,7 @@
                         id: btn_zprobe
                         text: tr._("Config")
                         font_size: '13sp'
-                        disabled:  (root.mode != 'Run' and root.mode != 'ZProbe') or root.cbx_leveling.active or app.has_4axis
+                        disabled:  not cbx_zprobe.active or (root.mode != 'Run' and root.mode != 'ZProbe' and root.mode != 'Leveling') or app.has_4axis
                         on_release: root.zprobe_popup.open()
 
                 BoxLayout:
@@ -3388,18 +3384,7 @@
                             size: self.size
                     MCQCheckBox:
                         id: cbx_leveling
-                        on_active:
-                            root.lb_leveling.disabled = not self.active or app.has_4axis or (root.mode != 'Run' and root.mode != 'Leveling')
-                            root.btn_leveling.disabled = not self.active or app.has_4axis or (root.mode != 'Run' and root.mode != 'Leveling')
-                            root.set_config('leveling', 'active', self.active)
-                            if self.active:\
-                            root.cbx_zprobe.active = True;\
-                            root.set_config('zprobe', 'active', True);\
-                            root.set_config('zprobe', 'origin', 2);\
-                            root.set_config('zprobe', 'x_offset', 0);\
-                            root.set_config('zprobe', 'y_offset', 0);\
-                            root.load_zprobe_label()
-                            root.toggle_config()
+                        on_active: root.on_leveling_checkbox(self.active)
                     MCQLabel:
                         on_press: cbx_leveling._do_press()
                         text: tr._(' Auto Leveling')
@@ -4107,7 +4092,7 @@
                                                 on_release:
                                                     root.coord_popup.mode = 'Leveling'
                                                     root.coord_popup.set_config('margin', 'active', False)
-                                                    root.coord_popup.set_config('zprobe', 'active', False)
+                                                    root.coord_popup.set_config('zprobe', 'active', True)
                                                     root.coord_popup.set_config('leveling', 'active', True)
                                                     root.coord_popup.load_config()
                                                     root.coord_popup.open()


### PR DESCRIPTION
Per discussion in #783 

This change allows Auto Leveling to be enabled but allows setting the Z-probe location.

It also allows Auto Z Probe to be turned off while leveling. In this situtation a warning is shown.

<img width="2500" height="1586" alt="image" src="https://github.com/user-attachments/assets/822eb429-cb71-4e33-801c-00008af85480" />

<img width="1756" height="798" alt="image" src="https://github.com/user-attachments/assets/c52a58c7-e434-4210-bce5-b2507ba38613" />
