### PR TITLE
Show current rotation in the WCS button when available or when the description isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1
 - Change: Config and Run preview now uses now uses the configured worksize_x/y for the bed size
 - Change: Auto Leveling auto-enables Auto Z Probe, but keeps the previous Z-probe location and allows the location config to be changed. Auto Z Probe can be turned off while leveling, but a warning is shown.
+- Change: The WCS button now shows rotation in the subtext, alternating with the WCS name when a description is set.
 - Fixed: Harden the gcode parser against "zero length" movement, and prevent division by zero in play slider
 - Fixed: Time estimates ignoring speed for some 4th-axis moves
 - Fixed: Allow to select the bottom element of the MDI, Gcode and probing confirmation lists

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -6891,17 +6891,20 @@ class Makera(RelativeLayout):
             coord_system_index = CNC.vars["active_coord_system"]
             coord_system_name = self.wcs_names[coord_system_index]
             rotation_angle = CNC.vars["rotation_angle"]
+            has_rotation = abs(rotation_angle) > 0.01
             desc_key = coord_system_name.lower().replace(".", "_") + "_description"
             try:
                 wcs_description = Config.get("carvera", desc_key).strip()
             except Exception:
                 wcs_description = ""
-            if wcs_description:
-                self.coord_system_data_view.main_text = wcs_description
+            description_is_name = not wcs_description or wcs_description == coord_system_name
+            self.coord_system_data_view.main_text = wcs_description if not description_is_name else coord_system_name
+            rotation_text = f"{rotation_angle:.3f}°"
+            if description_is_name or has_rotation and self.status_index % 2 == 1:
+                self.coord_system_data_view.minr_text = rotation_text
             else:
-                self.coord_system_data_view.main_text = coord_system_name
-            self.coord_system_data_view.minr_text = coord_system_name
-            self.coord_system_data_view.scale = 80.0 if abs(rotation_angle) > 0.01 else 100.0
+                self.coord_system_data_view.minr_text = coord_system_name
+            self.coord_system_data_view.scale = 80.0 if has_rotation else 100.0
 
             if self.gcode_viewer is not None and self.gcode_viewer.bed_visible:
                 self.gcode_viewer.update_bed_wcs()


### PR DESCRIPTION
Closes #637 

This PR changes the behavior of the WCS button:

* if the WCS description isn't set or is equal to the WCS name: the subtext (`minr_text`) will always display the current rotation value (even if it is 0°, so we don't repeat the same string twice)
* else:
  * if the rotation angle is not set (< 0.01°, same check that we already had): the subtext will only display the WCS name
  * else: the subtext will alternate between the WCS name and the rotation angle