### PR TITLE
Fix 4-axis viewer transform order to rotate around the WCS origin before centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed: Harden the gcode parser against "zero length" movement, and prevent division by zero in play slider
 - Fixed: Time estimates ignoring speed for some 4th-axis moves
 - Fixed: Allow to select the bottom element of the MDI, Gcode and probing confirmation lists
+- Fixed: Fixed rotary previews so toolpaths, pointers, and stock rotate around the WCS origin without unwanted orbiting.
 
 [2.2.0-RC3]
 - Enhancement: The step size is now synchronized between the main screen and the Probing screen

--- a/carveracontroller/GcodeViewer.py
+++ b/carveracontroller/GcodeViewer.py
@@ -179,6 +179,12 @@ def rotate_mat_by_x_axis_angle(angle_in_degree):
     return mat_rot_x
 
 
+def rotate_point_then_center(point, center, rotation):
+    """Rotate a viewer-space point around the WCS origin, then center the scene."""
+    rotated = rotation.transform_point(point[0], point[1], point[2])
+    return [rotated[0] - center[0], rotated[1] - center[1], rotated[2] - center[2]]
+
+
 #####function
 def vec3_add(v1, v2):
     return [v1[0] + v2[0], v1[1] + v2[1], v1[2] + v2[2]]
@@ -2719,23 +2725,21 @@ class GCodeViewer(Widget):
         if pointer_updated_pos < len(self.positions):
             base_start = int(line_index_withratio)
             ratio = line_index_withratio - base_start
-            offset = 0.0
 
-            last_pos = vec3_sub(self.meshmanager.get_vertex_position(int(line_index_withratio)), self.lines_center)
+            last_world_pos = self.meshmanager.get_vertex_position(int(line_index_withratio))
+            self.pointermesh["offset"] = vec3_sub(last_world_pos, self.lines_center)
 
             if self.is_4_axis:
                 last_angle = self.angles_of_vertices[int(pointer_updated_pos / 3)]
 
             if ratio > 0.0 and pointer_updated_pos + 5 < len(self.positions):
-                next_pos = vec3_sub(
-                    self.meshmanager.get_vertex_position(int(line_index_withratio) + 1), self.lines_center
-                )
-                lerp_pos = [
-                    next_pos[0] * ratio + (1.0 - ratio) * last_pos[0],
-                    next_pos[1] * ratio + (1.0 - ratio) * last_pos[1],
-                    next_pos[2] * ratio + (1.0 - ratio) * last_pos[2],
+                next_world_pos = self.meshmanager.get_vertex_position(int(line_index_withratio) + 1)
+                lerp_world_pos = [
+                    next_world_pos[0] * ratio + (1.0 - ratio) * last_world_pos[0],
+                    next_world_pos[1] * ratio + (1.0 - ratio) * last_world_pos[1],
+                    next_world_pos[2] * ratio + (1.0 - ratio) * last_world_pos[2],
                 ]
-                self.pointermesh["offset"] = lerp_pos
+                self.pointermesh["offset"] = vec3_sub(lerp_world_pos, self.lines_center)
 
                 if self.is_4_axis:
                     next_angle = self.angles_of_vertices[int(pointer_updated_pos / 3) + 1]
@@ -2746,27 +2750,16 @@ class GCodeViewer(Widget):
                         rot = rotate_mat_by_x_axis_angle(-lerp_angle)
                         self.linemesh["rotation_mat"] = rot
                         self._set_stock_rotation_mat(rot)
-                        len_to_center = len_2d(
-                            [lerp_pos[1], lerp_pos[2]], [-self.lines_center[1], -self.lines_center[2]]
-                        )
-                        rot_point = self.linemesh["rotation_mat"].transform_point(lerp_pos[0], lerp_pos[1], lerp_pos[2])
-
-                        self.pointermesh["offset"] = rot_point
+                        self.pointermesh["offset"] = rotate_point_then_center(lerp_world_pos, self.lines_center, rot)
             else:
                 if self.is_4_axis:
                     if not self.rotate_line_or_knife:
                         self.pointermesh["rotation"] = rotate_mat_by_x_axis_angle(last_angle)
                     else:
                         rot = rotate_mat_by_x_axis_angle(-last_angle)
-                        self.linemesh["view_mat"] = self.linemesh["view_mat"].multiply(rot)
+                        self.linemesh["rotation_mat"] = rot
                         self._set_stock_rotation_mat(rot)
-
-                        len_to_center = len_3d(last_pos, [-self.lines_center[0], -self.lines_center[1], 0])
-                        self.pointermesh["offset"] = [
-                            -self.lines_center[0],
-                            -self.lines_center[1],
-                            len_to_center - self.lines_center[2],
-                        ]
+                        self.pointermesh["offset"] = rotate_point_then_center(last_world_pos, self.lines_center, rot)
 
         self.pointermesh["modelview_mat"] = self.m_viewMatrix
 

--- a/carveracontroller/shaders/toolpath.glsl
+++ b/carveracontroller/shaders/toolpath.glsl
@@ -36,7 +36,7 @@ void main()
     if (vertex_id < 0.0) {
         gl_Position = proj_mat * view_mat * center_offset * world_pos;
     } else {
-        gl_Position = proj_mat * view_mat * rotation_mat * center_offset * world_pos;
+        gl_Position = proj_mat * view_mat * center_offset * rotation_mat * world_pos;
     }
 }
 

--- a/tests/unit/test_gcode_viewer_rotary.py
+++ b/tests/unit/test_gcode_viewer_rotary.py
@@ -1,0 +1,28 @@
+"""Regression tests for rotary viewer transforms."""
+
+from pathlib import Path
+
+import pytest
+
+from carveracontroller.GcodeViewer import (
+    rotate_mat_by_x_axis_angle,
+    rotate_point_then_center,
+    rotate_pt_by_x_axis_angle,
+)
+
+
+def test_rotary_pointer_rotates_around_wcs_origin_before_centering():
+    center = [0.0, 4.0, -2.0]
+    point = rotate_pt_by_x_axis_angle(0.0, 0.0, 10.0, 120.0)
+    inverse_rotation = rotate_mat_by_x_axis_angle(-120.0)
+
+    displayed = rotate_point_then_center(point, center, inverse_rotation)
+
+    assert displayed == pytest.approx([0.0, -4.0, 12.0])
+
+
+def test_toolpath_shader_rotates_before_centering():
+    shader = (Path(__file__).parents[2] / "carveracontroller" / "shaders" / "toolpath.glsl").read_text()
+
+    assert "center_offset * rotation_mat * world_pos" in shader
+    assert "rotation_mat * center_offset * world_pos" not in shader


### PR DESCRIPTION
Fixes an issue with how the 4 axis paths are rendered when they do not wrap evenly around the X axis (which is why we didn't notice it on files like Nefertiti).

This was caused by a wrong application order of some transforms:
* Before: world position -> center translation -> rotary rotation -> camera/view -> projection
* After: world position -> rotary rotation -> center translation -> camera/view -> projection

<br/>

For instance, using the following code:
```
(@F360|STOCK|id=cylinder|width=20|depth=20|height=20|diameter=20)
(@F360|ORIGIN|type_name=leftCenter|x=-10|y=0|z=0)
M321
G0Z10
G00 G17 G21 G54
G90
G0 X0 Y0 Z10 A0
M3
G1 A60 S0.6 F300
G1 A120
G1 A180
G1 S0
M5
M2
```

<br/>
<br/>

**Before:**
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/06f5a650-45e0-4960-85ef-1f931ea3e2de" />

<br/>
<br/>

**After:**
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/b8669fe1-96b9-408c-a5cc-3f4bb58daa2f" />