### PR TITLE
Fix Intellisense tooltips being shown even when behind a modal

### DIFF
--- a/carveracontroller/addons/intellisense/ui.py
+++ b/carveracontroller/addons/intellisense/ui.py
@@ -21,6 +21,7 @@ from carveracontroller.addons.intellisense.engine import (
     explain_signature,
     highlight_mdi_line,
 )
+from carveracontroller.addons.tooltips.Tooltips import is_blocked_by_modal
 
 _POPUP_MAX_WIDTH = 440
 _POPUP_MAX_HEIGHT = 320
@@ -61,6 +62,9 @@ class IntellisensePopupBase(BoxLayout):
         self.disabled = True
 
     def display(self):
+        if is_blocked_by_modal():
+            self.hide()
+            return
         if self.parent is None:
             Window.add_widget(self)
         self.opacity = 1
@@ -198,12 +202,30 @@ class _IntellisenseHost:
         self._window_bound = False
         self._hover_rows = weakref.WeakSet()
         self._hover_bound = False
+        self._overlay_bound = False
 
     def _ensure_window_bind(self):
         if self._window_bound:
             return
         Window.bind(on_touch_down=self._on_window_touch, on_key_down=self._on_window_key)
         self._window_bound = True
+        self._ensure_overlay_bind()
+
+    def _ensure_overlay_bind(self):
+        if self._overlay_bound:
+            return
+        Window.bind(children=self._on_window_children)
+        self._overlay_bound = True
+
+    def _on_window_children(self, _window, _children):
+        if is_blocked_by_modal():
+            self._dismiss_for_overlay()
+
+    def _dismiss_for_overlay(self):
+        for row in tuple(self._hover_rows):
+            cancel_gcode_hover(row, hide=False)
+        self.hide_gcode()
+        self.hide_mdi()
 
     def _release_window_bind_if_idle(self):
         if not self._window_bound or self.gcode_popup.showing or self.mdi_popup.showing:
@@ -216,8 +238,12 @@ class _IntellisenseHost:
         if not self._hover_bound:
             Window.bind(mouse_pos=self._on_window_mouse_pos)
             self._hover_bound = True
+        self._ensure_overlay_bind()
 
     def _on_window_mouse_pos(self, _window, pos):
+        if is_blocked_by_modal():
+            self._dismiss_for_overlay()
+            return
         for row in tuple(self._hover_rows):
             if row.get_root_window() and _row_explainable(row) and row.collide_point(*row.to_widget(*pos)):
                 schedule_gcode_hover(row)
@@ -225,6 +251,9 @@ class _IntellisenseHost:
                 cancel_gcode_hover(row)
 
     def show_gcode(self, row: Widget, reason: str = "select"):
+        if is_blocked_by_modal(row):
+            self._dismiss_for_overlay()
+            return
         if not _row_explainable(row):
             if reason == "select":
                 self.hide_gcode(row)
@@ -258,6 +287,9 @@ class _IntellisenseHost:
         self._release_window_bind_if_idle()
 
     def update_mdi(self, textinput):
+        if is_blocked_by_modal(textinput):
+            self.hide_mdi()
+            return
         if not getattr(textinput, "focus", False):
             self.hide_mdi()
             return
@@ -511,6 +543,9 @@ def schedule_gcode_hover(row: Widget):
         delay = float(getattr(app, "tooltip_delay", 0.5) or 0.5)
 
     def _show(_dt):
+        if is_blocked_by_modal(row):
+            hide_gcode_explain(row)
+            return
         if row.get_root_window() and _row_explainable(row):
             show_gcode_explain(row, reason="hover")
 

--- a/carveracontroller/addons/tooltips/Tooltips.py
+++ b/carveracontroller/addons/tooltips/Tooltips.py
@@ -24,6 +24,31 @@ TOOLTIP_MIN_WIDTH = 200
 TOOLTIP_MAX_WIDTH = 360
 
 
+def is_blocked_by_modal(widget=None):
+    """True when a Popup or ModalView is on the Window and widget is not inside it."""
+    try:
+        children = Window.children
+    except Exception:
+        return False
+    for child in children:
+        if not isinstance(child, (Popup, ModalView)):
+            continue
+        if widget is None:
+            return True
+        try:
+            current = widget
+            depth = 0
+            while current is not None and depth < 20:
+                if current is child:
+                    return False
+                current = getattr(current, "parent", None)
+                depth += 1
+            return True
+        except Exception:
+            return True
+    return False
+
+
 def _compute_tooltip_box_size(
     text_width, text_height, image_width, image_height, *, has_text, has_image, horizontal, spacing=15
 ):
@@ -99,20 +124,7 @@ class ToolTipSwitch(Switch):
         self._build_tooltip()
 
     def _is_blocked_by_modal(self):
-        for child in Window.children:
-            if isinstance(child, (Popup, ModalView)):
-                try:
-                    current = self.parent
-                    depth = 0
-                    while current and depth < 20:
-                        if current == child:
-                            return False
-                        current = current.parent
-                        depth += 1
-                    return True
-                except:
-                    return True
-        return False
+        return is_blocked_by_modal(self)
 
     def _build_tooltip(self, *largs):
         # Only build the tooltip if it hasn't been created yet
@@ -267,20 +279,7 @@ class ToolTipTextInput(TextInput):
             App.get_running_app().root.toggle_keyboard_jog_control(True)
 
     def _is_blocked_by_modal(self):
-        for child in Window.children:
-            if isinstance(child, (Popup, ModalView)):
-                try:
-                    current = self.parent
-                    depth = 0
-                    while current and depth < 20:
-                        if current == child:
-                            return False
-                        current = current.parent
-                        depth += 1
-                    return True
-                except:
-                    return True
-        return False
+        return is_blocked_by_modal(self)
 
     def _build_tooltip(self, *largs):
         # Only build the tooltip if it hasn't been created yet
@@ -446,20 +445,7 @@ class ToolTipButton(Button):
         self._build_tooltip()
 
     def _is_blocked_by_modal(self):
-        for child in Window.children:
-            if isinstance(child, (Popup, ModalView)):
-                try:
-                    current = self.parent
-                    depth = 0
-                    while current and depth < 20:
-                        if current == child:
-                            return False
-                        current = current.parent
-                        depth += 1
-                    return True
-                except:
-                    return True
-        return False
+        return is_blocked_by_modal(self)
 
     def _build_tooltip(self, *largs):
         # Only build the tooltip if it hasn't been created yet
@@ -675,20 +661,7 @@ class ToolTipDropDown(DropDown):
         self._build_tooltip()
 
     def _is_blocked_by_modal(self):
-        for child in Window.children:
-            if isinstance(child, (Popup, ModalView)):
-                try:
-                    current = self.parent
-                    depth = 0
-                    while current and depth < 20:
-                        if current == child:
-                            return False
-                        current = current.parent
-                        depth += 1
-                    return True
-                except:
-                    return True
-        return False
+        return is_blocked_by_modal(self)
 
     def _build_tooltip(self, *largs):
         # Only build the tooltip if it hasn't been created yet
@@ -839,20 +812,7 @@ class ToolTipLabel(Label):
         self._build_tooltip()
 
     def _is_blocked_by_modal(self):
-        for child in Window.children:
-            if isinstance(child, (Popup, ModalView)):
-                try:
-                    current = self.parent
-                    depth = 0
-                    while current and depth < 20:
-                        if current == child:
-                            return False
-                        current = current.parent
-                        depth += 1
-                    return True
-                except:
-                    return True
-        return False
+        return is_blocked_by_modal(self)
 
     def _build_tooltip(self, *largs):
         # Only build the tooltip if it hasn't been created yet

--- a/tests/unit/test_intellisense_modal.py
+++ b/tests/unit/test_intellisense_modal.py
@@ -1,0 +1,122 @@
+"""IntelliSense popups must not appear over modal dialogs."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kivy.uix.dropdown import DropDown
+from kivy.uix.modalview import ModalView
+from kivy.uix.popup import Popup
+
+from carveracontroller.addons.intellisense import ui as intel_ui
+from carveracontroller.addons.tooltips.Tooltips import is_blocked_by_modal
+
+
+def _modal():
+    return ModalView.__new__(ModalView)
+
+
+@contextmanager
+def _window_children(children):
+    with patch("carveracontroller.addons.tooltips.Tooltips.Window", SimpleNamespace(children=children)):
+        yield
+
+
+def test_is_blocked_when_modal_is_on_window():
+    with _window_children([_modal()]):
+        assert is_blocked_by_modal()
+        assert is_blocked_by_modal(SimpleNamespace(parent=None))
+
+
+def test_is_blocked_when_popup_is_on_window():
+    with _window_children([Popup.__new__(Popup)]):
+        assert is_blocked_by_modal()
+
+
+def test_not_blocked_without_modal():
+    with _window_children([SimpleNamespace()]):
+        assert not is_blocked_by_modal()
+        assert not is_blocked_by_modal(SimpleNamespace(parent=None))
+
+
+def test_not_blocked_by_dropdown_alone():
+    with _window_children([DropDown.__new__(DropDown)]):
+        assert not is_blocked_by_modal()
+
+
+def test_widget_inside_modal_is_not_blocked():
+    modal = _modal()
+    child = SimpleNamespace(parent=modal)
+    with _window_children([modal]):
+        assert not is_blocked_by_modal(child)
+
+
+def test_widget_behind_modal_is_blocked():
+    modal = _modal()
+    other = SimpleNamespace(parent=SimpleNamespace(parent=None))
+    with _window_children([modal]):
+        assert is_blocked_by_modal(other)
+
+
+def test_show_gcode_does_not_display_when_modal_open(monkeypatch):
+    host = intel_ui._IntellisenseHost()
+    monkeypatch.setattr(intel_ui, "is_blocked_by_modal", lambda widget=None: True)
+    row = SimpleNamespace(plain_text="G54", get_root_window=lambda: True)
+
+    host.show_gcode(row, reason="hover")
+
+    assert host.gcode_popup.showing is False
+
+
+def test_mouse_pos_dismisses_instead_of_hovering_when_modal_open(monkeypatch):
+    host = intel_ui._IntellisenseHost()
+    scheduled = []
+    dismissed = []
+    monkeypatch.setattr(intel_ui, "is_blocked_by_modal", lambda widget=None: True)
+    monkeypatch.setattr(intel_ui, "schedule_gcode_hover", lambda row: scheduled.append(row))
+    host._dismiss_for_overlay = lambda: dismissed.append(True)
+
+    host._on_window_mouse_pos(None, (10, 10))
+
+    assert scheduled == []
+    assert dismissed == [True]
+
+
+def test_display_refuses_when_modal_open(monkeypatch):
+    popup = intel_ui.IntellisensePopupBase()
+    monkeypatch.setattr(intel_ui, "is_blocked_by_modal", lambda widget=None: True)
+
+    popup.display()
+
+    assert popup.showing is False
+    assert popup.parent is None
+
+
+def test_scheduled_hover_aborts_if_modal_opens_during_delay(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(intel_ui.Clock, "schedule_once", lambda cb, dt: captured.setdefault("cb", cb))
+    monkeypatch.setattr(intel_ui.Clock, "unschedule", lambda cb: None)
+    monkeypatch.setattr(intel_ui, "is_blocked_by_modal", lambda widget=None: True)
+    hidden = []
+    shown = []
+    monkeypatch.setattr(intel_ui, "hide_gcode_explain", lambda row=None: hidden.append(row))
+    monkeypatch.setattr(intel_ui, "show_gcode_explain", lambda row, reason="hover": shown.append(row))
+    row = SimpleNamespace(get_root_window=lambda: True, plain_text="G54")
+
+    intel_ui.schedule_gcode_hover(row)
+    captured["cb"](0)
+
+    assert hidden == [row]
+    assert shown == []
+
+
+def test_window_children_change_dismisses_open_popup(monkeypatch):
+    host = intel_ui._IntellisenseHost()
+    host.gcode_popup.showing = True
+    dismissed = []
+    monkeypatch.setattr(intel_ui, "is_blocked_by_modal", lambda widget=None: True)
+    host._dismiss_for_overlay = lambda: dismissed.append(True)
+
+    host._on_window_children(None, [])
+
+    assert dismissed == [True]


### PR DESCRIPTION
This PR prevents Intellisense tooltips from being displayed if a modal is active:

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/0cc766bc-f3da-4eff-a3ec-ba1b139e1d28" />

<br/>
<br/>

We already had a code snippet that checked this for other tooltips but it was just copy/pasted multiple times in `Tooltips.py` so I extracted it into a separate method that is then reused in `intellisense/ui.py`.

No changelog entry since the Intellisense feature hasn't been released yet.