### PR TITLE
Keep thin tool icon fills visible by drawing the outline outside the silhouette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed: Harden the gcode parser against "zero length" movement, and prevent division by zero in play slider
 - Fixed: Time estimates ignoring speed for some 4th-axis moves
 - Fixed: Allow to select the bottom element of the MDI, Gcode and probing confirmation lists
+- Fixed: Keep thin tool icon fills visible by drawing the outline outside the silhouette.
 
 [2.2.0-RC3]
 - Enhancement: The step size is now synchronized between the main screen and the Probing screen

--- a/carveracontroller/addons/tool_visualization/icon_builder.py
+++ b/carveracontroller/addons/tool_visualization/icon_builder.py
@@ -137,7 +137,7 @@ def _stamp_coverage(coverage, width, height, x0, y0, x1, y1, thickness):
 
 
 def _draw_outline(buf, width, height, outline, rgba, thickness):
-    """Stroke the outline into a coverage set, then composite only those pixels."""
+    """Stroke the outline as an outside rim around the already-painted fill."""
     if len(outline) < 2:
         return
     coverage = set()
@@ -146,6 +146,9 @@ def _draw_outline(buf, width, height, outline, rgba, thickness):
         x1, y1 = outline[i + 1]
         _stamp_coverage(coverage, width, height, x0, y0, x1, y1, thickness)
     for index in coverage:
+        i = index * 4
+        if buf[i + 3] != 0:
+            continue
         _put_pixel(buf, width, height, index % width, index // width, rgba)
 
 

--- a/tests/unit/test_tool_visualization.py
+++ b/tests/unit/test_tool_visualization.py
@@ -1418,6 +1418,40 @@ class TestIconGeometry:
         opaque = sum(1 for i in range(3, len(buf), 4) if buf[i] > 0)
         assert opaque > 100
 
+    def test_thin_flute_keeps_gold_under_outline(self, monkeypatch):
+        """A hairline mill must stay gold; the outline must not overwrite the fill."""
+        from carveracontroller.addons.tool_visualization import icon_builder as ib
+
+        monkeypatch.setattr(ib, "_supersample_factor", lambda: 2)
+        monkeypatch.setattr(ib, "dp", lambda value: value)
+
+        tool_def = ToolDefinition(
+            number=2,
+            tool_type=ToolType.DRILL,
+            diameter=0.8,
+            shank_diameter=3.175,
+            flute_length=10.0,
+            taper_angle_deg=59.0,
+            length=38.0,
+        )
+        buf, width, height = ib._rasterize_icon(build_icon_geometry(tool_def), 34, 34)
+        assert (width, height) == (68, 68)
+
+        flute_rgba = ib._to_bytes_rgba(ib.ICON_FLUTE_COLOR)
+        outline_rgba = ib._to_bytes_rgba(ib.ICON_OUTLINE_COLOR)
+
+        def _count(rgba):
+            n = 0
+            for i in range(0, len(buf), 4):
+                if tuple(buf[i : i + 4]) == rgba:
+                    n += 1
+            return n
+
+        flute_pixels = _count(flute_rgba)
+        outline_pixels = _count(outline_rgba)
+        assert flute_pixels > 100
+        assert outline_pixels > 50
+
     def test_outline_stroke_scales_with_density_and_supersampling(self, monkeypatch):
         """The stroke must follow the render scale or it becomes a hairline on HiDPI."""
         from carveracontroller.addons.tool_visualization import icon_builder as ib


### PR DESCRIPTION
When drawing tool icons the outline was added over the silhouette which caused thin tools to only display a black rectangle. This changes it so the outline is now added outside of the silhouette.

<br/>

**Before:**
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/94c41e0d-e345-4f9a-ac58-cc2245ed4170" />

<br/>
<br/>

**After:**
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/850f3a9a-eb8e-439a-973a-60dca217ff83" />
