### PR TITLE
Add keyboard shortcuts settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enhancement: Alarm popup now notes an engaged e-stop when the halt reason is not the e-stop code
 - Enhancement: Use machine limits when available to calculate time estimates
 - Enhancement: Add bed settings and visualization to the G-Code viewer
+- Enhancement: Add keyboard shortcuts settings
 - Change: Facing wizard now supports center WCS origin
 - Change: Hide Auto Vacuum on the Config and Run screen when the machine is not a C1
 - Change: Config and Run preview now uses now uses the configured worksize_x/y for the bed size

--- a/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
+++ b/carveracontroller/addons/cmm_workbench/ui/CMMWorkbenchPopup.py
@@ -120,6 +120,10 @@ class JogCMMWorkbenchPopup(ModalView):
         Clock.schedule_once(self._snap_modal_height_to_inner, -1)
         Clock.schedule_once(self._snap_modal_height_to_inner, 0.05)
 
+    def allows_external_jog(self) -> bool:
+        """This overlay exists specifically to expose the jog controls."""
+        return self._is_open
+
     def _snap_modal_height_to_inner(self, _dt=None):
         try:
             inner = self.ids.jog_modal_inner

--- a/carveracontroller/addons/keyboard_shortcuts/__init__.py
+++ b/carveracontroller/addons/keyboard_shortcuts/__init__.py
@@ -1,0 +1,27 @@
+"""Configurable keyboard shortcuts for the controller UI."""
+
+from .bindings import (
+    ACTIONS,
+    BINDING_GROUPS,
+    ActionDefinition,
+    KeyChord,
+    ShortcutBindings,
+    chord_from_event,
+    format_chord,
+    format_chord_parts,
+)
+from .manager import ShortcutManager
+from .ui import SettingKeyboardShortcuts
+
+__all__ = [
+    "ACTIONS",
+    "BINDING_GROUPS",
+    "ActionDefinition",
+    "KeyChord",
+    "SettingKeyboardShortcuts",
+    "ShortcutBindings",
+    "ShortcutManager",
+    "chord_from_event",
+    "format_chord",
+    "format_chord_parts",
+]

--- a/carveracontroller/addons/keyboard_shortcuts/bindings.py
+++ b/carveracontroller/addons/keyboard_shortcuts/bindings.py
@@ -1,0 +1,342 @@
+"""Shortcut definitions, normalisation, persistence, and conflict detection."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+
+from kivy.core.window import Keyboard
+
+logger = logging.getLogger(__name__)
+
+CONFIG_VERSION = 1
+VALID_MODIFIERS = frozenset({"ctrl", "alt", "shift", "meta", "primary"})
+LOCK_MODIFIERS = frozenset({"capslock", "numlock", "scrolllock", "mode"})
+MODIFIER_ORDER = ("primary", "ctrl", "alt", "shift", "meta")
+MODIFIER_KEY_NAMES = frozenset(
+    {
+        "alt",
+        "alt-gr",
+        "ctrl",
+        "lalt",
+        "lctrl",
+        "lmeta",
+        "lshift",
+        "lsuper",
+        "meta",
+        "ralt",
+        "rctrl",
+        "rmeta",
+        "rshift",
+        "rsuper",
+        "shift",
+        "super",
+    }
+)
+MODIFIER_KEY_CODES = frozenset(code for name in MODIFIER_KEY_NAMES if (code := Keyboard.keycodes.get(name)) is not None)
+MODIFIER_SCANCODES = frozenset(range(224, 232))
+
+KEY_ALIASES = {
+    "comma": ",",
+    "numpadenter": "enter",
+    "return": "enter",
+    "pgup": "pageup",
+    "pgdown": "pagedown",
+    "esc": "escape",
+}
+
+# Prefer Kivy names/aliases over SDL scancodes.
+PREFERRED_KEY_NAMES = {
+    9: "tab",
+    13: "enter",
+    27: "escape",
+    32: "spacebar",
+    44: ",",
+    271: "enter",
+    273: "up",
+    274: "down",
+    275: "right",
+    276: "left",
+    280: "pageup",
+    281: "pagedown",
+}
+for _number in range(1, 16):
+    _name = f"f{_number}"
+    _code = Keyboard.keycodes.get(_name)
+    if _code is not None:
+        PREFERRED_KEY_NAMES[_code] = _name
+
+
+def _normalise_key_name(key: str) -> str:
+    raw = str(key).strip().lower()
+    value = KEY_ALIASES.get(raw, raw)
+    if len(value) == 1:
+        return value
+    if value not in Keyboard.keycodes:
+        raise ValueError(f"Unknown key: {key}")
+    return value
+
+
+def _normalise_modifiers(modifiers) -> tuple[str, ...]:
+    values = {str(modifier).lower() for modifier in modifiers}
+    values -= LOCK_MODIFIERS
+    unknown = values - VALID_MODIFIERS
+    if unknown:
+        raise ValueError(f"Unknown modifiers: {', '.join(sorted(unknown))}")
+    if "primary" in values and ({"ctrl", "meta"} & values):
+        raise ValueError("Primary cannot be combined with Ctrl or Meta")
+    return tuple(modifier for modifier in MODIFIER_ORDER if modifier in values)
+
+
+@dataclass(frozen=True)
+class KeyChord:
+    """One non-modifier key and its exact modifier set."""
+
+    key: str
+    modifiers: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        key = _normalise_key_name(self.key)
+        if key in MODIFIER_KEY_NAMES:
+            raise ValueError("A shortcut requires a non-modifier key")
+        object.__setattr__(self, "key", key)
+        object.__setattr__(self, "modifiers", _normalise_modifiers(self.modifiers))
+
+    def to_dict(self) -> dict:
+        return {"key": self.key, "modifiers": list(self.modifiers)}
+
+    @classmethod
+    def from_dict(cls, value: dict) -> KeyChord:
+        if not isinstance(value, dict) or not isinstance(value.get("key"), str):
+            raise ValueError("A shortcut must contain a key name")
+        modifiers = value.get("modifiers", [])
+        if not isinstance(modifiers, list):
+            raise ValueError("Shortcut modifiers must be a list")
+        return cls(value["key"], tuple(modifiers))
+
+    def resolved_modifiers(self, platform: str | None = None) -> frozenset[str]:
+        resolved = set(self.modifiers)
+        if "primary" in resolved:
+            resolved.remove("primary")
+            resolved.add("meta" if (platform or sys.platform) == "darwin" else "ctrl")
+        return frozenset(resolved)
+
+    def matches(self, other: KeyChord, platform: str | None = None) -> bool:
+        return self.key == other.key and self.resolved_modifiers(platform) == other.resolved_modifiers(platform)
+
+
+@dataclass(frozen=True)
+class ActionDefinition:
+    action_id: str
+    label: str
+    category: str
+    context: str
+    default: KeyChord | None
+
+
+ACTIONS = (
+    ActionDefinition("open_start_job", "Open Start Job", "Global", "global", None),
+    ActionDefinition("open_online_docs", "Open Online Documentation", "Global", "global", KeyChord("f1")),
+    ActionDefinition("open_settings", "Open Settings", "Global", "global", KeyChord(",", ("primary",))),
+    ActionDefinition("open_mdi", "Open / Focus MDI", "Global", "global", KeyChord("m", ("ctrl",))),
+    ActionDefinition("open_file_browser", "Open File Browser", "Global", "global", KeyChord("o", ("ctrl",))),
+    ActionDefinition(
+        "toggle_keyboard_jogging",
+        "Toggle Keyboard Jogging",
+        "Global",
+        "global",
+        KeyChord("j", ("ctrl",)),
+    ),
+    ActionDefinition("jog_x_positive", "Jog X+", "Jogging", "jogging", KeyChord("right")),
+    ActionDefinition("jog_x_negative", "Jog X−", "Jogging", "jogging", KeyChord("left")),
+    ActionDefinition("jog_y_positive", "Jog Y+", "Jogging", "jogging", KeyChord("down")),
+    ActionDefinition("jog_y_negative", "Jog Y−", "Jogging", "jogging", KeyChord("up")),
+    ActionDefinition("jog_z_positive", "Jog Z+", "Jogging", "jogging", KeyChord("pageup")),
+    ActionDefinition("jog_z_negative", "Jog Z−", "Jogging", "jogging", KeyChord("pagedown")),
+    ActionDefinition("jog_a_positive", "Jog A+", "Jogging", "jogging", None),
+    ActionDefinition("jog_a_negative", "Jog A−", "Jogging", "jogging", None),
+    ActionDefinition("mdi_send", "Send Command", "MDI", "mdi", KeyChord("enter", ("ctrl",))),
+    ActionDefinition("mdi_newline", "Insert New Line", "MDI", "mdi", KeyChord("enter")),
+)
+ACTION_BY_ID = {action.action_id: action for action in ACTIONS}
+BINDING_GROUPS = tuple(
+    (category, tuple(action.action_id for action in ACTIONS if action.category == category))
+    for category in ("Global", "Jogging", "MDI")
+)
+
+
+def key_name_from_code(key_code: int, codepoint: str = "") -> str | None:
+    if key_code in PREFERRED_KEY_NAMES:
+        return PREFERRED_KEY_NAMES[key_code]
+    if codepoint and len(codepoint) == 1 and codepoint.isprintable():
+        return codepoint.lower()
+    if 32 <= key_code <= 126:
+        return chr(key_code).lower()
+    names = [name for name, code in Keyboard.keycodes.items() if code == key_code]
+    if not names:
+        return None
+    return min(names, key=lambda name: (len(name), name))
+
+
+def is_modifier_key_event(key_code: int, scancode: int | None = None) -> bool:
+    return key_code in MODIFIER_KEY_CODES or scancode in MODIFIER_SCANCODES
+
+
+def chord_from_event(key_code: int, modifiers, codepoint: str = "", scancode: int | None = None) -> KeyChord | None:
+    if is_modifier_key_event(key_code, scancode):
+        return None
+    key_name = key_name_from_code(key_code, codepoint)
+    if key_name is None:
+        return None
+    try:
+        return KeyChord(key_name, tuple(modifiers))
+    except ValueError:
+        return None
+
+
+def format_chord_parts(chord: KeyChord, platform: str | None = None) -> tuple[str, ...]:
+    """Return the display label for each physical key in a chord."""
+    modifier_labels = {
+        "ctrl": "Ctrl",
+        "alt": "Alt",
+        "shift": "Shift",
+        "meta": "Cmd" if (platform or sys.platform) == "darwin" else "Meta",
+        "primary": "Cmd" if (platform or sys.platform) == "darwin" else "Ctrl",
+    }
+    key_labels = {
+        "enter": "Enter",
+        "escape": "Escape",
+        "spacebar": "Space",
+        "pageup": "Page Up",
+        "pagedown": "Page Down",
+        "left": "Left",
+        "right": "Right",
+        "up": "Up",
+        "down": "Down",
+        "tab": "Tab",
+        ",": ",",
+    }
+    parts = [modifier_labels[modifier] for modifier in chord.modifiers]
+    key_label = key_labels.get(chord.key, chord.key.upper())
+    parts.append(key_label)
+    return tuple(parts)
+
+
+def format_chord(chord: KeyChord | None, platform: str | None = None) -> str:
+    if chord is None:
+        return "Unbound"
+    return "+".join(format_chord_parts(chord, platform))
+
+
+def _contexts_overlap(first: str, second: str) -> bool:
+    return first == second or "global" in (first, second)
+
+
+class ShortcutBindings:
+    """Resolved shortcut map with sparse, forward-compatible persistence."""
+
+    def __init__(
+        self,
+        bindings: dict[str, KeyChord | None] | None = None,
+        *,
+        invert_y_axis_jogging: bool = False,
+    ):
+        defaults = {action.action_id: action.default for action in ACTIONS}
+        if bindings:
+            defaults.update({key: value for key, value in bindings.items() if key in ACTION_BY_ID})
+        self._bindings = dict(defaults)
+        self.set_invert_y_axis_jogging(invert_y_axis_jogging)
+
+    @classmethod
+    def from_json(cls, raw: str | None, *, invert_y_axis_jogging: bool = False) -> ShortcutBindings:
+        if not raw:
+            return cls(invert_y_axis_jogging=invert_y_axis_jogging)
+        try:
+            payload = json.loads(raw)
+            if not isinstance(payload, dict) or payload.get("version") != CONFIG_VERSION:
+                raise ValueError("Unsupported shortcut config version")
+            overrides = payload.get("bindings", {})
+            if not isinstance(overrides, dict):
+                raise ValueError("Shortcut bindings must be an object")
+            parsed = {}
+            for action_id, value in overrides.items():
+                if action_id not in ACTION_BY_ID:
+                    continue
+                try:
+                    parsed[action_id] = None if value is None else KeyChord.from_dict(value)
+                except (TypeError, ValueError) as exc:
+                    logger.warning("Ignoring invalid keyboard shortcut %s: %s", action_id, exc)
+            bindings = cls(parsed, invert_y_axis_jogging=invert_y_axis_jogging)
+            for action in ACTIONS:
+                chord = bindings.binding_for(action.action_id)
+                if chord is not None and bindings.conflict_for(action.action_id, chord) is not None:
+                    raise ValueError("Shortcut config contains conflicting bindings")
+            return bindings
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning("Invalid keyboard_shortcuts config, using defaults: %s", exc)
+            return cls(invert_y_axis_jogging=invert_y_axis_jogging)
+
+    def to_json(self) -> str:
+        overrides = {}
+        for action in ACTIONS:
+            binding = self._bindings[action.action_id]
+            if binding == action.default:
+                continue
+            overrides[action.action_id] = None if binding is None else binding.to_dict()
+        if not overrides:
+            return ""
+        return json.dumps({"version": CONFIG_VERSION, "bindings": overrides}, separators=(",", ":"), sort_keys=True)
+
+    def copy(self) -> ShortcutBindings:
+        return ShortcutBindings(
+            dict(self._bindings),
+            invert_y_axis_jogging=self._invert_y_axis_jogging,
+        )
+
+    def set_invert_y_axis_jogging(self, inverted: bool) -> None:
+        self._invert_y_axis_jogging = inverted
+        self._defaults = {action.action_id: action.default for action in ACTIONS}
+        self._defaults["jog_y_positive"] = KeyChord("up" if inverted else "down")
+        self._defaults["jog_y_negative"] = KeyChord("down" if inverted else "up")
+
+    def default_for(self, action_id: str) -> KeyChord | None:
+        return self._defaults[action_id]
+
+    def binding_for(self, action_id: str) -> KeyChord | None:
+        return self._bindings[action_id]
+
+    def action_for(self, chord: KeyChord, context: str) -> ActionDefinition | None:
+        for action in ACTIONS:
+            if action.context != context:
+                continue
+            binding = self._bindings[action.action_id]
+            if binding is not None and binding.matches(chord):
+                return action
+        return None
+
+    def conflict_for(self, action_id: str, chord: KeyChord) -> ActionDefinition | None:
+        target = ACTION_BY_ID[action_id]
+        for action in ACTIONS:
+            if action.action_id == action_id or not _contexts_overlap(target.context, action.context):
+                continue
+            binding = self._bindings[action.action_id]
+            if binding is not None and binding.matches(chord):
+                return action
+        return None
+
+    def assign(self, action_id: str, chord: KeyChord | None) -> None:
+        if action_id not in ACTION_BY_ID:
+            raise KeyError(action_id)
+        if chord is not None:
+            conflict = self.conflict_for(action_id, chord)
+            if conflict is not None:
+                raise ValueError(f"{format_chord(chord)} is already assigned to {conflict.label}")
+        self._bindings[action_id] = chord
+
+    def reset(self, action_id: str) -> None:
+        self._bindings[action_id] = self._defaults[action_id]
+
+    def reset_all(self) -> None:
+        self._bindings = dict(self._defaults)

--- a/carveracontroller/addons/keyboard_shortcuts/bindings.py
+++ b/carveracontroller/addons/keyboard_shortcuts/bindings.py
@@ -245,10 +245,15 @@ class ShortcutBindings:
         *,
         invert_y_axis_jogging: bool = False,
     ):
-        defaults = {action.action_id: action.default for action in ACTIONS}
+        live = {action.action_id: action.default for action in ACTIONS}
+        # No saved map yet: honor invert for live Y keys so first launch matches
+        # the previous keyboard behavior. A saved map must not be rewritten here.
+        if invert_y_axis_jogging and bindings is None:
+            live["jog_y_positive"] = KeyChord("up")
+            live["jog_y_negative"] = KeyChord("down")
         if bindings:
-            defaults.update({key: value for key, value in bindings.items() if key in ACTION_BY_ID})
-        self._bindings = dict(defaults)
+            live.update({key: value for key, value in bindings.items() if key in ACTION_BY_ID})
+        self._bindings = live
         self.set_invert_y_axis_jogging(invert_y_axis_jogging)
 
     @classmethod
@@ -287,8 +292,7 @@ class ShortcutBindings:
             if binding == action.default:
                 continue
             overrides[action.action_id] = None if binding is None else binding.to_dict()
-        if not overrides:
-            return ""
+        # Always emit a versioned object so "" remains "never initialized".
         return json.dumps({"version": CONFIG_VERSION, "bindings": overrides}, separators=(",", ":"), sort_keys=True)
 
     def copy(self) -> ShortcutBindings:

--- a/carveracontroller/addons/keyboard_shortcuts/bindings.py
+++ b/carveracontroller/addons/keyboard_shortcuts/bindings.py
@@ -141,6 +141,7 @@ ACTIONS = (
     ActionDefinition("open_online_docs", "Open Online Documentation", "Global", "global", KeyChord("f1")),
     ActionDefinition("open_settings", "Open Settings", "Global", "global", KeyChord(",", ("primary",))),
     ActionDefinition("open_mdi", "Open / Focus MDI", "Global", "global", KeyChord("m", ("ctrl",))),
+    ActionDefinition("open_gcode", "Open / Focus G-Code", "Global", "global", KeyChord("g", ("ctrl",))),
     ActionDefinition("open_file_browser", "Open File Browser", "Global", "global", KeyChord("o", ("ctrl",))),
     ActionDefinition(
         "toggle_keyboard_jogging",
@@ -149,6 +150,7 @@ ACTIONS = (
         "global",
         KeyChord("j", ("ctrl",)),
     ),
+    ActionDefinition("switch_jog_mode", "Switch Jog Mode", "Global", "global", KeyChord("k", ("ctrl",))),
     ActionDefinition("jog_x_positive", "Jog X+", "Jogging", "jogging", KeyChord("right")),
     ActionDefinition("jog_x_negative", "Jog X−", "Jogging", "jogging", KeyChord("left")),
     ActionDefinition("jog_y_positive", "Jog Y+", "Jogging", "jogging", KeyChord("down")),

--- a/carveracontroller/addons/keyboard_shortcuts/keyboard_shortcuts_config.json
+++ b/carveracontroller/addons/keyboard_shortcuts/keyboard_shortcuts_config.json
@@ -1,0 +1,10 @@
+[
+    {
+        "type": "keyboard_shortcuts",
+        "title": "Keyboard Shortcuts",
+        "desc": "Configure shortcuts by context. Jogging shortcuts only work while Keyboard Jogging is enabled.",
+        "section": "carvera",
+        "key": "keyboard_shortcuts",
+        "default": ""
+    }
+]

--- a/carveracontroller/addons/keyboard_shortcuts/manager.py
+++ b/carveracontroller/addons/keyboard_shortcuts/manager.py
@@ -182,10 +182,16 @@ class ShortcutManager:
             if not self.root._is_popup_open():
                 self.root.open_mdi()
                 return True
+        elif action_id == "open_gcode":
+            if not self.root._is_popup_open():
+                self.root.open_gcode()
+                return True
         elif action_id == "open_file_browser":
             return bool(self.root.open_file_browser())
         elif action_id == "toggle_keyboard_jogging":
             return bool(self.root.toggle_keyboard_jog_control())
+        elif action_id == "switch_jog_mode":
+            return bool(self.root.toggle_jog_mode())
         elif action_id == "open_start_job":
             return bool(self.root.open_start_job_popup())
         return False

--- a/carveracontroller/addons/keyboard_shortcuts/manager.py
+++ b/carveracontroller/addons/keyboard_shortcuts/manager.py
@@ -16,12 +16,20 @@ from .bindings import KeyChord, ShortcutBindings, chord_from_event, format_chord
 logger = logging.getLogger(__name__)
 
 
+def _invert_y_axis_from_config() -> bool:
+    return Config.get("carvera", "invert_y_axis_jogging", fallback="0") == "1"
+
+
+def _shortcut_config_raw() -> str:
+    return Config.get("carvera", "keyboard_shortcuts", fallback="") or ""
+
+
 class ShortcutManager:
     """Own the application-level key handlers and dispatch by context."""
 
     def __init__(self, root):
         self.root = root
-        self.bindings = ShortcutBindings.from_json(Config.get("carvera", "keyboard_shortcuts", fallback=""))
+        self.bindings = self._bindings_from_config()
         self.paused = False
         self._installed = False
         self._held_global_keys: set[int] = set()
@@ -60,6 +68,21 @@ class ShortcutManager:
         self._suppressed_jog_keys.clear()
         self._installed = False
 
+    @staticmethod
+    def _bindings_from_config() -> ShortcutBindings:
+        return ShortcutBindings.from_json(
+            _shortcut_config_raw(),
+            invert_y_axis_jogging=_invert_y_axis_from_config(),
+        )
+
+    @classmethod
+    def seed_config_if_uninitialized(cls) -> None:
+        if _shortcut_config_raw():
+            return
+        bindings = ShortcutBindings.from_json("", invert_y_axis_jogging=_invert_y_axis_from_config())
+        Config.set("carvera", "keyboard_shortcuts", bindings.to_json())
+        Config.write()
+
     def on_window_children(self, _window, children) -> None:
         for child in children:
             if not isinstance(child, ModalView) or not getattr(child, "_is_open", False):
@@ -71,7 +94,7 @@ class ShortcutManager:
 
     def reload_from_config(self) -> None:
         self.release_all_jogs()
-        self.bindings = ShortcutBindings.from_json(Config.get("carvera", "keyboard_shortcuts", fallback=""))
+        self.bindings = self._bindings_from_config()
         self.update_mdi_hint()
 
     def update_mdi_hint(self) -> None:

--- a/carveracontroller/addons/keyboard_shortcuts/manager.py
+++ b/carveracontroller/addons/keyboard_shortcuts/manager.py
@@ -1,0 +1,231 @@
+"""Runtime routing for configurable keyboard shortcuts."""
+
+from __future__ import annotations
+
+import logging
+
+from kivy.config import Config
+from kivy.core.window import Window
+from kivy.uix.modalview import ModalView
+from kivy.uix.textinput import TextInput
+
+from carveracontroller.translation import tr
+
+from .bindings import KeyChord, ShortcutBindings, chord_from_event, format_chord
+
+logger = logging.getLogger(__name__)
+
+
+class ShortcutManager:
+    """Own the application-level key handlers and dispatch by context."""
+
+    def __init__(self, root):
+        self.root = root
+        self.bindings = ShortcutBindings.from_json(Config.get("carvera", "keyboard_shortcuts", fallback=""))
+        self.paused = False
+        self._installed = False
+        self._held_global_keys: set[int] = set()
+        self._held_jog_keys: set[int] = set()
+        self._suppressed_jog_keys: set[int] = set()
+        self._active_jog_key: int | None = None
+
+    def install(self) -> None:
+        if self._installed:
+            return
+        Window.bind(
+            on_key_down=self.on_key_down,
+            on_key_up=self.on_key_up,
+            on_minimize=self.on_window_inactive,
+            on_hide=self.on_window_inactive,
+            focus=self.on_window_focus,
+            children=self.on_window_children,
+        )
+        self._installed = True
+        self.update_mdi_hint()
+
+    def uninstall(self) -> None:
+        if not self._installed:
+            return
+        self.release_all_jogs()
+        Window.unbind(
+            on_key_down=self.on_key_down,
+            on_key_up=self.on_key_up,
+            on_minimize=self.on_window_inactive,
+            on_hide=self.on_window_inactive,
+            focus=self.on_window_focus,
+            children=self.on_window_children,
+        )
+        self._held_global_keys.clear()
+        self._held_jog_keys.clear()
+        self._suppressed_jog_keys.clear()
+        self._installed = False
+
+    def on_window_children(self, _window, children) -> None:
+        for child in children:
+            if not isinstance(child, ModalView) or not getattr(child, "_is_open", False):
+                continue
+            if hasattr(child, "allows_external_jog") and child.allows_external_jog():
+                continue
+            self.release_all_jogs()
+            return
+
+    def reload_from_config(self) -> None:
+        self.release_all_jogs()
+        self.bindings = ShortcutBindings.from_json(Config.get("carvera", "keyboard_shortcuts", fallback=""))
+        self.update_mdi_hint()
+
+    def update_mdi_hint(self) -> None:
+        mdi = getattr(self.root, "manual_cmd", None)
+        if mdi is None:
+            return
+        send_binding = self.bindings.binding_for("mdi_send")
+        if send_binding is None:
+            mdi.hint_text = tr._("Enter command...")
+        else:
+            mdi.hint_text = tr._("Enter command... <{0} to send>").format(format_chord(send_binding))
+
+    def on_window_inactive(self, *_args) -> None:
+        self.release_all_jogs()
+        # Focus loss can prevent the matching key-up from reaching Kivy.
+        self._held_global_keys.clear()
+        self._held_jog_keys.clear()
+        self._suppressed_jog_keys.clear()
+
+    def on_window_focus(self, _window, focused) -> None:
+        if not focused:
+            self.on_window_inactive()
+
+    def on_key_down(self, _window, key, scancode, codepoint, modifiers):
+        if self.paused:
+            return False
+        chord = chord_from_event(key, modifiers, codepoint, scancode)
+        if chord is None:
+            return False
+
+        global_action = self.bindings.action_for(chord, "global")
+        if global_action is not None:
+            if key in self._held_global_keys:
+                return True
+            if self._text_producing_global_blocked_while_typing(chord):
+                return False
+            handled = self._dispatch_global(global_action.action_id)
+            if handled:
+                self._held_global_keys.add(key)
+            return handled
+
+        jog_action = self.bindings.action_for(chord, "jogging")
+        if jog_action is not None:
+            if key in self._held_jog_keys:
+                return True
+            if key in self._suppressed_jog_keys:
+                return False
+            if (
+                self._text_input_has_focus()
+                or not getattr(self.root, "keyboard_jog_control", False)
+                or not self._can_jog_with_keyboard()
+            ):
+                # Keep repeats from starting a jog if the context becomes
+                # eligible before this physical key is released.
+                self._suppressed_jog_keys.add(key)
+                return False
+            self._held_jog_keys.add(key)
+            self._start_jog(key, jog_action.action_id)
+            return True
+        return False
+
+    def on_key_up(self, _window, key, *_args):
+        was_global = key in self._held_global_keys
+        self._held_global_keys.discard(key)
+        was_held = key in self._held_jog_keys
+        self._held_jog_keys.discard(key)
+        was_suppressed = key in self._suppressed_jog_keys
+        self._suppressed_jog_keys.discard(key)
+        if key != self._active_jog_key:
+            return was_global or (was_held and not was_suppressed)
+        self._active_jog_key = None
+        controller = getattr(self.root, "controller", None)
+        if controller is None:
+            return False
+        controller.stopContinuousJog()
+        return True
+
+    def handle_mdi_keydown(self, widget, key, modifiers, text="") -> bool:
+        if self.paused or not widget.focus:
+            return False
+        chord = chord_from_event(key, modifiers, text)
+        if chord is None:
+            return False
+        action = self.bindings.action_for(chord, "mdi")
+        if action is None:
+            # Multiline TextInput inserts a newline for Enter on its own.
+            # Consume its built-in Enter only while newline is explicitly remapped.
+            return chord.key == "enter" and self.bindings.binding_for("mdi_newline") is not None
+        if action.action_id == "mdi_send":
+            if self.root.can_send_mdi_command():
+                widget.send_mdi_command()
+            return True
+        if action.action_id == "mdi_newline":
+            widget.insert_text("\n")
+            return True
+        return False
+
+    def _dispatch_global(self, action_id: str) -> bool:
+        self.release_all_jogs()
+        if action_id == "open_online_docs":
+            self.root.open_online_docs()
+            return True
+        if action_id == "open_settings":
+            if not self.root._is_popup_open() and not self.root.manual_cmd.focus:
+                self.root.config_popup.open()
+                return True
+        elif action_id == "open_mdi":
+            if not self.root._is_popup_open():
+                self.root.open_mdi()
+                return True
+        elif action_id == "open_file_browser":
+            return bool(self.root.open_file_browser())
+        elif action_id == "toggle_keyboard_jogging":
+            return bool(self.root.toggle_keyboard_jog_control())
+        elif action_id == "open_start_job":
+            return bool(self.root.open_start_job_popup())
+        return False
+
+    def _text_producing_global_blocked_while_typing(self, chord: KeyChord) -> bool:
+        command_modifiers = {"primary", "ctrl", "alt", "meta"}
+        produces_text = len(chord.key) == 1 or chord.key == "spacebar"
+        return produces_text and not command_modifiers.intersection(chord.modifiers) and self._text_input_has_focus()
+
+    def _text_input_has_focus(self) -> bool:
+        for child in Window.children:
+            widgets = child.walk() if hasattr(child, "walk") else (child,)
+            if any(isinstance(widget, TextInput) and widget.focus for widget in widgets):
+                return True
+        return False
+
+    def _can_jog_with_keyboard(self) -> bool:
+        return bool(
+            getattr(self.root, "keyboard_jog_control", False)
+            and self.root.is_jogging_enabled()
+            and not self._text_input_has_focus()
+        )
+
+    def _start_jog(self, key: int, action_id: str) -> None:
+        # Do not switch axes while another physical jog key is still held.
+        # Continuous-jog cancellation is asynchronous, so starting the second
+        # direction immediately would be ignored by the controller anyway.
+        if self._active_jog_key is not None:
+            return
+        self._active_jog_key = key
+        try:
+            self.root.perform_keyboard_jog(action_id)
+        except Exception:
+            self._active_jog_key = None
+            logger.exception("Failed to execute keyboard jog action %s", action_id)
+
+    def release_all_jogs(self) -> None:
+        if self._active_jog_key is None:
+            return
+        self._active_jog_key = None
+        controller = getattr(self.root, "controller", None)
+        if controller is not None:
+            controller.stopContinuousJog()

--- a/carveracontroller/addons/keyboard_shortcuts/ui.py
+++ b/carveracontroller/addons/keyboard_shortcuts/ui.py
@@ -1,0 +1,415 @@
+"""Kivy settings widget for editing keyboard shortcuts."""
+
+from __future__ import annotations
+
+from kivy.app import App
+from kivy.clock import Clock
+from kivy.core.window import Window
+from kivy.graphics import Color, Line, Rectangle, RoundedRectangle
+from kivy.metrics import dp, sp
+from kivy.uix.anchorlayout import AnchorLayout
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.button import Button
+from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.label import Label
+from kivy.uix.modalview import ModalView
+from kivy.uix.settings import SettingItem
+
+from carveracontroller.translation import tr
+
+from .bindings import (
+    ACTION_BY_ID,
+    BINDING_GROUPS,
+    MODIFIER_KEY_NAMES,
+    ShortcutBindings,
+    chord_from_event,
+    format_chord,
+    format_chord_parts,
+    is_modifier_key_event,
+)
+
+
+class _CategoryHeader(Label):
+    """A prominent heading separating one shortcut context."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("markup", True)
+        kwargs.setdefault("size_hint_y", None)
+        kwargs.setdefault("height", dp(36))
+        kwargs.setdefault("halign", "left")
+        kwargs.setdefault("valign", "middle")
+        kwargs.setdefault("font_size", sp(15))
+        kwargs.setdefault("color", (0.94, 0.94, 0.96, 1))
+        kwargs.setdefault("padding", (dp(4), dp(3)))
+        super().__init__(**kwargs)
+        with self.canvas.after:
+            Color(52 / 255, 166 / 255, 208 / 255, 1)
+            self._underline = Rectangle(pos=self.pos, size=(self.width, dp(1)))
+        self.bind(pos=self._sync_canvas, size=self._sync_canvas)
+        self.bind(size=self._sync_text_size)
+        self._sync_text_size()
+
+    def _sync_canvas(self, *_args) -> None:
+        self._underline.pos = self.pos
+        self._underline.size = (self.width, dp(1))
+
+    def _sync_text_size(self, *_args) -> None:
+        self.text_size = (max(0, self.width - dp(8)), self.height - dp(6))
+
+
+class _CategorySection(BoxLayout):
+    """Container that keeps a category heading and its rows together."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("orientation", "vertical")
+        kwargs.setdefault("size_hint_y", None)
+        kwargs.setdefault("spacing", dp(4))
+        kwargs.setdefault("padding", [dp(4), dp(6), dp(4), dp(10)])
+        super().__init__(**kwargs)
+        self.bind(minimum_height=self.setter("height"))
+
+
+class _KeyCap(Label):
+    """Compact keyboard-key visualization sized to its label."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("size_hint", (None, None))
+        kwargs.setdefault("height", dp(27))
+        kwargs.setdefault("font_size", sp(13))
+        kwargs.setdefault("color", (0.96, 0.96, 0.98, 1))
+        kwargs.setdefault("halign", "center")
+        kwargs.setdefault("valign", "middle")
+        kwargs.setdefault("padding", (dp(8), dp(2)))
+        super().__init__(**kwargs)
+        with self.canvas.before:
+            Color(0.28, 0.29, 0.31, 1)
+            self._background = RoundedRectangle(pos=self.pos, size=self.size, radius=[dp(5)])
+        with self.canvas.after:
+            Color(0.47, 0.49, 0.52, 1)
+            self._outline = Line(rounded_rectangle=(*self.pos, *self.size, dp(5)), width=1)
+        self.bind(texture_size=self._sync_width, pos=self._sync_canvas, size=self._sync_canvas)
+        self._sync_width()
+
+    def _sync_width(self, *_args) -> None:
+        self.width = max(dp(30), self.texture_size[0] + dp(16))
+
+    def _sync_canvas(self, *_args) -> None:
+        self._background.pos = self.pos
+        self._background.size = self.size
+        self._outline.rounded_rectangle = (*self.pos, *self.size, dp(5))
+
+
+class _ShortcutChordDisplay(AnchorLayout):
+    """Centered row of keycaps for one shortcut chord."""
+
+    def __init__(self, chord=None, **kwargs):
+        kwargs.setdefault("anchor_x", "center")
+        kwargs.setdefault("anchor_y", "center")
+        super().__init__(**kwargs)
+        self.key_labels = ()
+        self._keycaps = []
+        self._content = BoxLayout(
+            size_hint=(None, None),
+            height=dp(27),
+            spacing=dp(3),
+        )
+        self._content.bind(minimum_width=self._content.setter("width"))
+        self.add_widget(self._content)
+        self.set_chord(chord)
+
+    def set_chord(self, chord) -> None:
+        self._content.clear_widgets()
+        self._keycaps = []
+        if chord is None:
+            self.key_labels = ()
+            unbound = Label(
+                text=tr._("Unbound"),
+                size_hint=(None, None),
+                size=(dp(72), dp(27)),
+                color=(0.62, 0.62, 0.65, 1),
+                font_size=sp(13),
+            )
+            self._content.add_widget(unbound)
+            return
+
+        self.key_labels = format_chord_parts(chord)
+        for index, label in enumerate(self.key_labels):
+            if index:
+                self._content.add_widget(
+                    Label(
+                        text="+",
+                        size_hint=(None, None),
+                        size=(dp(10), dp(27)),
+                        color=(0.68, 0.68, 0.7, 1),
+                        font_size=sp(12),
+                    )
+                )
+            keycap = _KeyCap(text=label)
+            self._keycaps.append(keycap)
+            self._content.add_widget(keycap)
+
+
+class SettingKeyboardShortcuts(SettingItem):
+    """Inline categorized shortcut editor with deferred settings semantics."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # SettingItem's stock rule creates a title/control row. This setting is
+        # the whole page, so collapse its label and use the complete row.
+        self.content.size_hint_x = 1
+        content_parent = self.content.parent
+        for sibling in tuple(content_parent.children):
+            if sibling != self.content:
+                content_parent.remove_widget(sibling)
+        self._bindings = ShortcutBindings.from_json(
+            self.value,
+            invert_y_axis_jogging=self._invert_y_axis_jogging(),
+        )
+        self._listening_for = None
+        self._listening_button = None
+        self._capture_manager = None
+        self._capture_modal = None
+        self._capture_panel = None
+        self._manager_was_paused = False
+        self._binding_displays = {}
+
+        row_count = sum(len(actions) for _, actions in BINDING_GROUPS)
+        self.size_hint_y = None
+        # Establish the complete height before SettingsPanel first measures
+        # this item. Kivy updates nested BoxLayout minimum heights over several
+        # layout passes, which is too late for the panel's initial measurement.
+        self._editor_height = dp(
+            16  # editor vertical padding
+            + len(BINDING_GROUPS) * (16 + 36)  # section padding and headers
+            + row_count * (40 + 4)  # action rows and section spacing
+            + len(BINDING_GROUPS) * 14  # spacing between sections/footer
+            + 42  # footer
+        )
+        self.height = self._editor_height
+        self.bind(height=self._keep_editor_height)
+
+        layout = BoxLayout(
+            orientation="vertical",
+            spacing=dp(14),
+            padding=[dp(10), dp(8)],
+            size_hint_y=None,
+            height=self._editor_height,
+        )
+        self._editor_layout = layout
+        for category, actions in BINDING_GROUPS:
+            section = _CategorySection()
+            header = _CategoryHeader(text=f"[b]{tr._(category)}[/b]")
+            section.add_widget(header)
+            for action_id in actions:
+                section.add_widget(self._build_action_row(action_id))
+            layout.add_widget(section)
+
+        app = App.get_running_app()
+        if app is not None:
+            app.bind(invert_y_axis_jogging=self._on_invert_y_axis_jogging)
+
+        footer = BoxLayout(size_hint_y=None, height=dp(42), spacing=dp(8))
+        self._error_label = Label(halign="left", valign="middle")
+        self._error_label.bind(size=lambda widget, size: setattr(widget, "text_size", size))
+        reset_all = Button(text=tr._("Reset All"), size_hint_x=None, width=dp(120))
+        reset_all.bind(on_release=self._reset_all)
+        footer.add_widget(self._error_label)
+        footer.add_widget(reset_all)
+        layout.add_widget(footer)
+        self.add_widget(layout)
+        layout.bind(minimum_height=self._set_editor_height)
+        Clock.schedule_once(self._restore_editor_height, 0)
+
+    def _set_editor_height(self, _layout, minimum_height) -> None:
+        self._editor_height = max(self._editor_height, minimum_height)
+        self._restore_editor_height(0)
+
+    def _keep_editor_height(self, _instance, height) -> None:
+        if height != self._editor_height:
+            Clock.schedule_once(self._restore_editor_height, 0)
+
+    def _restore_editor_height(self, _dt) -> None:
+        self._editor_height = max(self._editor_height, self._editor_layout.minimum_height)
+        self.height = self._editor_height
+        self._editor_layout.height = self._editor_height
+
+    def _build_action_row(self, action_id: str):
+        action = ACTION_BY_ID[action_id]
+        row = BoxLayout(size_hint_y=None, height=dp(40), spacing=dp(6), padding=[dp(5), 0])
+        name = Label(text=tr._(action.label), size_hint_x=0.36, halign="left", valign="middle")
+        name.bind(size=lambda widget, size: setattr(widget, "text_size", size))
+
+        binding = _ShortcutChordDisplay(
+            chord=self._bindings.binding_for(action_id),
+            size_hint_x=0.24,
+        )
+        self._binding_displays[action_id] = binding
+
+        bind_button = Button(text=tr._("Bind..."), size_hint_x=0.16)
+        bind_button.bind(on_release=lambda button, selected=action_id: self._start_capture(selected, button))
+        unbind_button = Button(text=tr._("Unbind"), size_hint_x=0.12)
+        unbind_button.bind(on_release=lambda *_args, selected=action_id: self._assign(selected, None))
+        reset_button = Button(text=tr._("Reset"), size_hint_x=0.12)
+        reset_button.bind(on_release=lambda *_args, selected=action_id: self._reset(selected))
+
+        row.add_widget(name)
+        row.add_widget(binding)
+        row.add_widget(bind_button)
+        row.add_widget(unbind_button)
+        row.add_widget(reset_button)
+        return row
+
+    def _shortcut_manager(self):
+        app = App.get_running_app()
+        root = getattr(app, "root", None) if app is not None else None
+        return getattr(root, "shortcut_manager", None)
+
+    @staticmethod
+    def _invert_y_axis_jogging() -> bool:
+        app = App.get_running_app()
+        return bool(getattr(app, "invert_y_axis_jogging", False))
+
+    def _on_invert_y_axis_jogging(self, _app, inverted) -> None:
+        self._bindings.set_invert_y_axis_jogging(bool(inverted))
+
+    def _start_capture(self, action_id: str, button) -> None:
+        self._stop_capture()
+        self._listening_for = action_id
+        self._listening_button = button
+        button.text = tr._("Press keys...")
+        self._error_label.text = tr._("Press a key combination, or Escape to cancel.")
+        manager = self._shortcut_manager()
+        if manager is not None:
+            self._capture_manager = manager
+            self._manager_was_paused = manager.paused
+            manager.paused = True
+            manager.release_all_jogs()
+        modal = self._containing_modal()
+        if modal is not None:
+            modal.bind(on_dismiss=self._on_capture_modal_dismiss)
+            self._capture_modal = modal
+        self.panel.bind(parent=self._on_capture_panel_parent)
+        self._capture_panel = self.panel
+        Window.bind(on_key_down=self._capture_key)
+
+    def _stop_capture(self) -> None:
+        if self._listening_for is None:
+            return
+        Window.unbind(on_key_down=self._capture_key)
+        if self._capture_modal is not None:
+            self._capture_modal.unbind(on_dismiss=self._on_capture_modal_dismiss)
+            self._capture_modal = None
+        if self._capture_panel is not None:
+            self._capture_panel.unbind(parent=self._on_capture_panel_parent)
+            self._capture_panel = None
+        if self._listening_button is not None:
+            self._listening_button.text = tr._("Bind...")
+        manager = self._capture_manager
+        if manager is not None:
+            manager.paused = self._manager_was_paused
+            self._capture_manager = None
+        self._listening_for = None
+        self._listening_button = None
+        self._error_label.text = ""
+
+    def _containing_modal(self):
+        widget = self.parent
+        while widget is not None:
+            if isinstance(widget, ModalView):
+                return widget
+            widget = widget.parent
+        return None
+
+    def _on_capture_modal_dismiss(self, *_args) -> None:
+        self._stop_capture()
+
+    def _on_capture_panel_parent(self, _panel, parent) -> None:
+        if parent is None:
+            self._stop_capture()
+
+    def _capture_key(self, _window, key, scancode, codepoint, modifiers):
+        if key == 27:
+            self._error_label.text = ""
+            self._stop_capture()
+            return True
+        if is_modifier_key_event(key, scancode):
+            return True
+        chord = chord_from_event(key, modifiers, codepoint, scancode)
+        if chord is None or chord.key in MODIFIER_KEY_NAMES:
+            self._error_label.text = tr._("Press a non-modifier key to complete the shortcut.")
+            return True
+        action_id = self._listening_for
+        if action_id is None:
+            return False
+        conflict = self._bindings.conflict_for(action_id, chord)
+        if conflict is not None:
+            self._error_label.text = tr._("{0} is already assigned to {1}.").format(
+                format_chord(chord), tr._(conflict.label)
+            )
+            return True
+        self._bindings.assign(action_id, chord)
+        self._commit()
+        self._error_label.text = ""
+        self._stop_capture()
+        return True
+
+    def _assign(self, action_id: str, chord) -> None:
+        self._stop_capture()
+        self._bindings.assign(action_id, chord)
+        self._commit()
+        self._error_label.text = ""
+
+    def _reset(self, action_id: str) -> None:
+        self._stop_capture()
+        default = self._bindings.default_for(action_id)
+        conflict = self._bindings.conflict_for(action_id, default) if default is not None else None
+        if conflict is not None:
+            self._error_label.text = tr._("Default conflicts with {0}; unbind it first.").format(tr._(conflict.label))
+            return
+        self._bindings.reset(action_id)
+        self._commit()
+        self._error_label.text = ""
+
+    def _reset_all(self, *_args) -> None:
+        self._stop_capture()
+        self._bindings.reset_all()
+        self._commit()
+        self._error_label.text = ""
+
+    def _commit(self) -> None:
+        new_value = self._bindings.to_json()
+        previous_value = self.value
+        matches_saved_value = str(self.panel.get_value(self.section, self.key)) == str(new_value)
+        self.panel.set_value(self.section, self.key, new_value)
+        self.value = new_value
+        if str(previous_value) != str(new_value) and matches_saved_value and self.panel.settings is not None:
+            # DeferredSettingsPanel normally dispatches this notification.
+            # When a user returns to the saved value it exits early because
+            # Config already contains that value, so explicitly clear the
+            # pending-change bookkeeping.
+            self.panel.settings.dispatch("on_config_change", self.panel.config, self.section, self.key, new_value)
+        self._refresh_labels()
+
+    def _refresh_labels(self) -> None:
+        for action_id, display in self._binding_displays.items():
+            display.set_chord(self._bindings.binding_for(action_id))
+
+    def on_value(self, _instance, value) -> None:
+        self._bindings = ShortcutBindings.from_json(
+            value,
+            invert_y_axis_jogging=self._invert_y_axis_jogging(),
+        )
+        if hasattr(self, "_binding_displays"):
+            self._refresh_labels()
+
+    def on_parent(self, _instance, parent) -> None:
+        if parent is None and hasattr(self, "_listening_for"):
+            self._stop_capture()
+
+    def on_touch_down(self, touch):
+        # SettingItem highlights and grabs the whole row on every click. This
+        # editor contains real buttons, so dispatch directly to its children.
+        return FloatLayout.on_touch_down(self, touch)
+
+    def on_touch_up(self, touch):
+        return FloatLayout.on_touch_up(self, touch)

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -129,8 +129,8 @@
     },
     {
         "type": "bool",
-        "title": "Invert Y-Axis Jogging Buttons and Default Keyboard Controls",
-        "desc": "When enabled, the upper jogging button and default up-arrow shortcut move the spindle away from the user; the lower button and default down-arrow shortcut move it towards the user",
+        "title": "Invert Y-Axis Jogging Buttons",
+        "desc": "When enabled, the upper jogging button shortcut move the spindle away from the user and the lower button move it towards the user. To invert the keyboard controls, use the Keyboard Shortcuts settings.",
         "section": "carvera",
         "key": "invert_y_axis_jogging",
         "default": "false"

--- a/carveracontroller/controller_config.json
+++ b/carveracontroller/controller_config.json
@@ -129,8 +129,8 @@
     },
     {
         "type": "bool",
-        "title": "Invert Y-Axis Jogging Buttons and Keyboard Controls",
-        "desc": "When enabled, the up arrow key will move the spindle up (away from user) relative to the work bed and the down arrow key will move the spindle down (towards the user)",
+        "title": "Invert Y-Axis Jogging Buttons and Default Keyboard Controls",
+        "desc": "When enabled, the upper jogging button and default up-arrow shortcut move the spindle away from the user; the lower button and default down-arrow shortcut move it towards the user",
         "section": "carvera",
         "key": "invert_y_axis_jogging",
         "default": "false"

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3255,6 +3255,7 @@ class Makera(RelativeLayout):
                 Config.setdefault(setting["section"], setting["key"], setting["default"])
                 setting.pop("default", None)
             shortcut_config.append(setting)
+        ShortcutManager.seed_config_if_uninitialized()
         self.config_popup.settings_panel.add_json_panel(
             tr._("Keyboard Shortcuts"), Config, data=json.dumps(shortcut_config)
         )

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -3358,6 +3358,13 @@ class Makera(RelativeLayout):
         self.cmd_manager.current = "manual_cmd_page"
         self.manual_cmd.focus = True
 
+    def open_gcode(self):
+        self.content.transition.direction = "right"
+        self.content.current = "File"
+        self.cmd_manager.transition.direction = "left"
+        self.cmd_manager.current = "gcode_cmd_page"
+        self.manual_cmd.focus = False
+
     def can_send_mdi_command(self):
         app = App.get_running_app()
         return app.state in ("Idle", "Pause") or str(self.allow_mdi_while_machine_running).lower() in ("1", "true")
@@ -7598,12 +7605,18 @@ class Makera(RelativeLayout):
         return True
 
     # -----------------------------------------------------------------------
+    def can_toggle_jog_mode(self):
+        app = App.get_running_app()
+        return bool(app.is_community_firmware and app.fw_version_digitized >= Utils.digitize_v("2.0.0"))
+
     def toggle_jog_mode(self):
+        if not self.can_toggle_jog_mode():
+            return False
         if self.controller.jog_mode == Controller.JOG_MODE_STEP:
             self.update_ui_for_jog_mode_cont()
-
         elif self.controller.jog_mode == Controller.JOG_MODE_CONTINUOUS:
             self.update_ui_for_jog_mode_step()
+        return True
 
     def update_ui_for_jog_mode_step(self):
         self.controller.setJogMode(Controller.JOG_MODE_STEP)

--- a/carveracontroller/main.py
+++ b/carveracontroller/main.py
@@ -137,6 +137,7 @@ from carveracontroller.addons.beds.store import (
 from carveracontroller.addons.beds.ui.BedSettingsPopup import BedSettingsPopup
 from carveracontroller.addons.cam import CamMetadata, extract_cam_metadata
 from carveracontroller.addons.facing.FacingWizardPopup import FacingWizardPopup
+from carveracontroller.addons.keyboard_shortcuts import SettingKeyboardShortcuts, ShortcutManager
 from carveracontroller.addons.pendant import (
     SUPPORTED_PENDANTS,
     OverrideController,
@@ -413,6 +414,10 @@ class MDITextInput(TextInput):
 
     def keyboard_on_key_down(self, window, keycode, text, modifiers):
         key = keycode[0] if isinstance(keycode, (tuple, list)) else keycode
+        app = App.get_running_app()
+        manager = getattr(getattr(app, "root", None), "shortcut_manager", None)
+        if manager is not None and manager.handle_mdi_keydown(self, key, modifiers, text):
+            return True
         if handle_mdi_intellisense_key(self, key, modifiers):
             return True
         if self._handle_navigation_key(key, modifiers):
@@ -420,12 +425,8 @@ class MDITextInput(TextInput):
         return super().keyboard_on_key_down(window, keycode, text, modifiers)
 
     def _handle_navigation_key(self, key, modifiers):
-        ENTER_KEY = 13
         UP_ARROW_KEY = 273
         DOWN_ARROW_KEY = 274
-        if self.focus and "ctrl" in modifiers and key == ENTER_KEY:
-            self.send_mdi_command()
-            return True
         if self.focus and key == UP_ARROW_KEY:
             cursor_is_at_top_left = self.cursor_index() == 0
             can_move_backward_in_history = len(self.past_mdi_commands) > 0 and self.active_past_mdi_index > 0
@@ -1946,6 +1947,14 @@ class MakeraConfigPanel(SettingsWithSidebar):
         self.register_type("gcodesnippet", custom_widgets.SettingGCodeSnippet)
         self.register_type("colorpicker", custom_widgets.SettingColorPicker)
         self.register_type("gamepad_bindings", SettingGamepadBindings)
+        self.register_type("keyboard_shortcuts", SettingKeyboardShortcuts)
+        self.interface.content.bind(current_uid=self._reset_panel_scroll)
+
+    @staticmethod
+    def _reset_panel_scroll(content, _uid):
+        # ContentPanel reuses one ScrollView for every settings page. Without
+        # resetting it, a tall page opens at the previous page's scroll offset.
+        Clock.schedule_once(lambda _dt: setattr(content, "scroll_y", 1), 0)
 
     def create_json_panel(self, title, config, filename=None, data=None):
         panel = super().create_json_panel(title, config, filename, data)
@@ -2785,7 +2794,6 @@ class Makera(RelativeLayout):
     show_advanced_jog_controls = BooleanProperty(False)
     keyboard_jog_control = BooleanProperty(False)
     pendant_jog_control = BooleanProperty(False)
-    _held_jog_keys = set()
 
     gcode_viewer = ObjectProperty()
     gcode_playing = BooleanProperty(False)
@@ -2905,7 +2913,6 @@ class Makera(RelativeLayout):
         super().__init__()
 
         Window.bind(on_request_close=self.on_request_close)
-        Window.bind(on_key_down=self._global_keyboard_keydown)
 
         self.temp_dir = tempfile.mkdtemp()
         self.ctl_version = ctl_version
@@ -3055,8 +3062,11 @@ class Makera(RelativeLayout):
         self.machine_settings_model = None
         self.controller_setting_change_list = {}
         self.load_controller_config()
+        self.load_keyboard_shortcuts_config()
         self.load_gcode_viewer_config()
         self.load_pendant_config()
+        self.shortcut_manager = ShortcutManager(self)
+        self.shortcut_manager.install()
 
         self.usb_event = lambda instance, device_path: self.openUSB(device_path)
         self.wifi_event = lambda instance, x: self.openWIFI(x)
@@ -3188,6 +3198,10 @@ class Makera(RelativeLayout):
 
     def on_request_close(self, *args):
         # Cleanup the temporary directory when the app is closed
+        shortcut_manager = getattr(self, "shortcut_manager", None)
+        if shortcut_manager is not None:
+            shortcut_manager.uninstall()
+
         try:
             shutil.rmtree(self.temp_dir)
         except Exception as e:
@@ -3228,6 +3242,22 @@ class Makera(RelativeLayout):
         self.config_popup.settings_panel.add_json_panel(tr._("Controller"), Config, data=json.dumps(controller_config))
 
         self._update_macro_button_text()
+
+    def load_keyboard_shortcuts_config(self):
+        config_def_file = os.path.join(
+            os.path.dirname(__file__), "addons", "keyboard_shortcuts", "keyboard_shortcuts_config.json"
+        )
+        with open(config_def_file) as file:
+            shortcut_config_definition = json.load(file)
+        shortcut_config = []
+        for setting in shortcut_config_definition:
+            if "default" in setting:
+                Config.setdefault(setting["section"], setting["key"], setting["default"])
+                setting.pop("default", None)
+            shortcut_config.append(setting)
+        self.config_popup.settings_panel.add_json_panel(
+            tr._("Keyboard Shortcuts"), Config, data=json.dumps(shortcut_config)
+        )
 
     def load_gcode_viewer_config(self):
         config_def_file = os.path.join(os.path.dirname(__file__), "gcode_viewer_config.json")
@@ -3312,6 +3342,46 @@ class Makera(RelativeLayout):
 
     def open_online_docs(self):
         webbrowser.open("https://carvera-community.gitbook.io/docs/controller/")
+
+    def open_file_browser(self):
+        app = App.get_running_app()
+        unavailable = app.state not in ("Idle", NOT_CONNECTED) and not app.playing
+        if unavailable or self._is_popup_open():
+            return False
+        self.file_popup.open_for_jobs()
+        return True
+
+    def open_mdi(self):
+        self.content.transition.direction = "right"
+        self.content.current = "File"
+        self.cmd_manager.transition.direction = "left"
+        self.cmd_manager.current = "manual_cmd_page"
+        self.manual_cmd.focus = True
+
+    def can_send_mdi_command(self):
+        app = App.get_running_app()
+        return app.state in ("Idle", "Pause") or str(self.allow_mdi_while_machine_running).lower() in ("1", "true")
+
+    def can_open_start_job_popup(self):
+        app = App.get_running_app()
+        return (
+            app.state == "Idle" and bool(app.selected_remote_filename) and not app.playing and not self._is_popup_open()
+        )
+
+    def open_start_job_popup(self):
+        if not self.can_open_start_job_popup():
+            return False
+        self.coord_popup.mode = "Run"
+        self.coord_popup.load_config()
+        self.coord_popup.open()
+        return True
+
+    def handle_start_file_action(self):
+        app = App.get_running_app()
+        if app.state == "Pause":
+            self.controller.resumeCommand()
+        else:
+            self.open_start_job_popup()
 
     def send_bug_report(self):
         webbrowser.open("https://github.com/Carvera-Community/Carvera_Controller/issues/new")
@@ -7560,10 +7630,11 @@ class Makera(RelativeLayout):
         self.update_pendant_jog_text()
 
     def _popup_prevents_jogging(self):
-        modals = [self.probing_popup]
-        if self.cmm_workbench_popup is not None:
-            modals.append(self.cmm_workbench_popup)
-        return self._is_popup_open() and not any(m.allows_external_jog() for m in modals)
+        for popup in self._open_popups():
+            if hasattr(popup, "allows_external_jog") and popup.allows_external_jog():
+                continue
+            return True
+        return False
 
     def _bind_jog_control_deps(self):
         app = App.get_running_app()
@@ -7579,7 +7650,12 @@ class Makera(RelativeLayout):
         app = App.get_running_app()
         if app is None:
             return
-        app.jog_controls_enabled = self._machine_allows_jogging()
+        jogging_allowed = self._machine_allows_jogging()
+        app.jog_controls_enabled = jogging_allowed
+        if not jogging_allowed:
+            shortcut_manager = getattr(self, "shortcut_manager", None)
+            if shortcut_manager is not None:
+                shortcut_manager.release_all_jogs()
 
     def _machine_allows_jogging(self):
         app = App.get_running_app()
@@ -7616,16 +7692,20 @@ class Makera(RelativeLayout):
 
     def toggle_keyboard_jog_control(self, disable=False):
         app = App.get_running_app()
+        if not disable and not app.jog_controls_enabled:
+            return False
         app.root.keyboard_jog_control = not app.root.keyboard_jog_control  # toggle the boolean
         if disable:
             app.root.keyboard_jog_control = False
 
         if app.root.keyboard_jog_control:
-            Window.bind(on_key_down=self._keyboard_jog_keydown, on_key_up=self._keyboard_jog_keyup)
             app.jog_keyboard_enable = "down"
         else:
-            Window.unbind(on_key_down=self._keyboard_jog_keydown, on_key_up=self._keyboard_jog_keyup)
+            shortcut_manager = getattr(self, "shortcut_manager", None)
+            if shortcut_manager is not None:
+                shortcut_manager.release_all_jogs()
             app.jog_keyboard_enable = "normal"
+        return True
 
     def toggle_pendant_jog_control(self):
         app = App.get_running_app()
@@ -7754,28 +7834,14 @@ class Makera(RelativeLayout):
         elif button_action == "step_size_changed":
             self.update_pendant_jog_text()
 
-    def _is_popup_open(self):
-        """Checks to see if any of the popups objects are open."""
-        popups_to_check = [
-            self.file_popup._is_open,
-            self.coord_popup._is_open,
-            self.xyz_probe_popup._is_open,
-            self.pairing_popup._is_open,
-            self.upgrade_popup._is_open,
-            self.language_popup._is_open,
-            self.diagnose_popup._is_open,
-            self.confirm_popup._is_open,
-            self.unlock_popup._is_open,
-            self.message_popup._is_open,
-            self.progress_popup._is_open,
-            self.input_popup._is_open,
-            self.config_popup._is_open,
-            self.probing_popup._is_open,
-            (self.cmm_workbench_popup._is_open if self.cmm_workbench_popup is not None else False),
-            self.facing_popup._is_open,
+    def _open_popups(self):
+        return [
+            child for child in Window.children if isinstance(child, ModalView) and getattr(child, "_is_open", False)
         ]
 
-        return any(popups_to_check)
+    def _is_popup_open(self):
+        """Return whether any application modal is currently open."""
+        return bool(self._open_popups())
 
     def bind_light_toggle_to_property(self):
         """Bind the light toggle button state to the LightProperty"""
@@ -7797,59 +7863,20 @@ class Makera(RelativeLayout):
             property_obj.update_from_state(self)
             logger.debug("Light state manually refreshed from CNC.vars")
 
-    def _global_keyboard_keydown(self, window, key, scancode, codepoint, modifiers):
-        COMMA_KEY = 44
-        M_KEY = 109
-        cmd_mod = "meta" if sys.platform == "darwin" else "ctrl"
-
-        # Cmd+Comma (macOS) or Ctrl+Comma (Windows/Linux) to open settings
-        if key == COMMA_KEY and cmd_mod in modifiers:
-            if not self._is_popup_open() and not self.manual_cmd.focus:
-                self.config_popup.open()
-                return True
-
-        # Ctrl+M to open manual command (MDI) page
-        if key == M_KEY and "ctrl" in modifiers:
-            self.content.transition.direction = "right"
-            self.content.current = "File"
-            self.cmd_manager.current = "manual_cmd_page"
-            self.manual_cmd.focus = True
-
-        return False
-
-    def _keyboard_jog_keydown(self, *args):
-        app = App.get_running_app()
-
-        # Only allow keyboard jogging when machine in a suitable state and has no popups open
-        if self.is_jogging_enabled() and not self.manual_cmd.focus:
-            key = args[1]  # keycode
-
-            if app.root.controller.jog_mode == Controller.JOG_MODE_STEP:
-                if key in self._held_jog_keys:
-                    # Ignore - only move once per keypress in step mode
-                    return
-                if key in (273, 274, 275, 276, 280, 281):
-                    self._held_jog_keys.add(key)
-
-            if key == 274:  # down button
-                app.root.controller.jog(f"Y{'-' if app.invert_y_axis_jogging else ''}{app.root.step_xy.text}")
-            elif key == 273:  # up button
-                app.root.controller.jog(f"Y{'' if app.invert_y_axis_jogging else '-'}{app.root.step_xy.text}")
-            elif key == 275:  # right button
-                app.root.controller.jog(f"X{app.root.step_xy.text}")
-            elif key == 276:  # left button
-                app.root.controller.jog(f"X-{app.root.step_xy.text}")
-            elif key == 280:  # page up
-                app.root.controller.jog(f"Z{app.root.step_z.text}")
-            elif key == 281:  # page down
-                app.root.controller.jog(f"Z-{app.root.step_z.text}")
-
-    def _keyboard_jog_keyup(self, *args):
-        app = App.get_running_app()
-        key = args[1]  # keycode
-        if key in (273, 274, 275, 276, 280, 281):  # only if a jog button is released
-            self._held_jog_keys.discard(key)
-            app.root.controller.stopContinuousJog()
+    def perform_keyboard_jog(self, action_id):
+        commands = {
+            "jog_x_positive": f"X{self.step_xy.text}",
+            "jog_x_negative": f"X-{self.step_xy.text}",
+            "jog_y_positive": f"Y{self.step_xy.text}",
+            "jog_y_negative": f"Y-{self.step_xy.text}",
+            "jog_z_positive": f"Z{self.step_z.text}",
+            "jog_z_negative": f"Z-{self.step_z.text}",
+            "jog_a_positive": f"A{self.step_a.text}",
+            "jog_a_negative": f"A-{self.step_a.text}",
+        }
+        command = commands.get(action_id)
+        if command is not None:
+            self.controller.jog(command)
 
     def apply_setting_changes(self):
         if self.setting_change_list:
@@ -7873,13 +7900,10 @@ class Makera(RelativeLayout):
             self.message_popup.lb_content.text = tr._("UI Density changed, restart application to apply.")
             self.message_popup.open()
 
-        if (
-            self.controller_setting_change_list.get("allow_mdi_while_machine_running")
-            != self.allow_mdi_while_machine_running
-        ):
-            self.allow_mdi_while_machine_running = self.controller_setting_change_list.get(
+        if "allow_mdi_while_machine_running" in self.controller_setting_change_list:
+            self.allow_mdi_while_machine_running = self.controller_setting_change_list[
                 "allow_mdi_while_machine_running"
-            )
+            ]
 
         if "allow_jogging_while_machine_running" in self.controller_setting_change_list:
             self.allow_jogging_while_machine_running = self.controller_setting_change_list[
@@ -7895,7 +7919,10 @@ class Makera(RelativeLayout):
         ):
             self.update_jog_controls_enabled()
 
-        if self.controller_setting_change_list.get("invert_y_axis_jogging"):
+        if "keyboard_shortcuts" in self.controller_setting_change_list:
+            self.shortcut_manager.reload_from_config()
+
+        if "invert_y_axis_jogging" in self.controller_setting_change_list:
             App.get_running_app().invert_y_axis_jogging = (
                 self.controller_setting_change_list.get("invert_y_axis_jogging") == "1"
             )
@@ -8904,6 +8931,8 @@ class MakeraApp(App):
         # Cancel any ongoing reconnection attempts to prevent hanging
         if hasattr(self.root, "controller") and self.root.controller:
             self.root.controller.cancel_reconnection()
+        if hasattr(self.root, "shortcut_manager"):
+            self.root.shortcut_manager.uninstall()
         # Stop all scheduled Clock events
         if hasattr(self.root, "blink_state"):
             Clock.unschedule(self.root.blink_state)
@@ -8959,6 +8988,8 @@ class MakeraApp(App):
             print(f"safe area query skipped: {e}")
 
     def on_pause(self):
+        if hasattr(self.root, "shortcut_manager"):
+            self.root.shortcut_manager.on_window_inactive()
         return True
 
 

--- a/carveracontroller/makera.kv
+++ b/carveracontroller/makera.kv
@@ -3679,7 +3679,7 @@
                                                 height: '66dp'
                                                 MDITextInput:
                                                     id: manual_cmd
-                                                    hint_text: tr._('Enter command... <control+enter to send>')
+                                                    hint_text: tr._('Enter command...')
                                                     multiline: True
                                                     on_text_validate:
                                                         if app.state == 'Idle' or app.state == 'Pause' or root.allow_mdi_while_machine_running == '1' : root.send_cmd()
@@ -3918,8 +3918,7 @@
                     tooltip_txt: tr._('Select File')
                     icon_size: 21
                     disabled: app.state != 'Idle' and app.state != 'N/A' and not app.playing
-                    on_release:
-                        root.file_popup.open_for_jobs()
+                    on_release: root.open_file_browser()
                 Label:
                     size_hint_x: None
                     width: '3dp'
@@ -3928,13 +3927,7 @@
                     icon_size: 25
                     tooltip_txt: tr._('Start File')
                     disabled: (app.state != 'Idle' or app.selected_remote_filename == '' or app.playing) and app.state != 'Pause'
-                    on_release:
-                        if app.state == 'Pause':\
-                        app.root.controller.resumeCommand()
-                        else:\
-                        root.coord_popup.mode = 'Run';\
-                        root.coord_popup.load_config();\
-                        root.coord_popup.open()
+                    on_release: root.handle_start_file_action()
                 IconButton:
                     icon: 'data/suspend.png'
                     disabled: app.state != 'Run' or not app.playing

--- a/tests/unit/test_settings_persistence.py
+++ b/tests/unit/test_settings_persistence.py
@@ -324,19 +324,20 @@ def test_shortcut_capture_reports_conflicts_and_escape_clears_the_prompt():
 
 
 def test_shortcut_reset_to_saved_value_dispatches_change_notification():
-    panel, item, config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    initialized = '{"bindings":{},"version":1}'
+    panel, item, config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, initialized, {})
     changes = []
     panel.settings.bind(on_config_change=lambda *_args: changes.append(_args[-1]))
 
     item._assign("open_online_docs", None)
-    assert config.get("test", "key") == ""
+    assert config.get("test", "key") == initialized
     changes.clear()
 
     item._reset_all()
 
-    assert item.value == ""
-    assert changes == [""]
-    assert config.get("test", "key") == ""
+    assert item.value == initialized
+    assert changes == [initialized]
+    assert config.get("test", "key") == initialized
 
 
 def test_shortcut_editor_bypasses_setting_item_blue_selection_animation():

--- a/tests/unit/test_settings_persistence.py
+++ b/tests/unit/test_settings_persistence.py
@@ -16,14 +16,21 @@ type, register it in CASES.
 """
 
 import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
+from kivy.clock import Clock
 from kivy.config import ConfigParser
+from kivy.metrics import dp
 from kivy.uix.settings import SettingItem, Settings
 
+from carveracontroller.addons.keyboard_shortcuts import SettingKeyboardShortcuts
+from carveracontroller.addons.keyboard_shortcuts.bindings import KeyChord
+from carveracontroller.addons.keyboard_shortcuts.ui import _CategoryHeader, _CategorySection
 from carveracontroller.addons.pendant.pendant import SettingPendantSelector
 from carveracontroller.custom_widgets import SettingColorPicker, SettingGCodeSnippet
-from carveracontroller.main import DeferredSettingsPanel
+from carveracontroller.main import DeferredSettingsPanel, MakeraConfigPanel
 
 # (test_id, registered_type, type_class_or_None, initial, new_value, panel_def_extras)
 # type_class_or_None is None for built-in Kivy types that Settings registers
@@ -35,6 +42,14 @@ CASES = [
     ("options", "options", None, "a", "b", {"options": ["a", "b"]}),
     ("pendant", "pendant", SettingPendantSelector, "None", "WHB04", {}),
     ("colorpicker", "colorpicker", SettingColorPicker, "0,255,255,255", "255,0,0,255", {}),
+    (
+        "keyboard_shortcuts",
+        "keyboard_shortcuts",
+        SettingKeyboardShortcuts,
+        "",
+        '{"version":1,"bindings":{"open_online_docs":null}}',
+        {},
+    ),
     (
         "gcodesnippet",
         "gcodesnippet",
@@ -123,3 +138,216 @@ def test_pendant_spinner_change_propagates():
         "Pendant change did not reach widget.value — would silently drop user selections on restart."
     )
     assert config.get("test", "key") == "None", "Config write must remain deferred"
+
+
+def test_settings_page_switch_resets_shared_scroll_view_to_top():
+    settings = MakeraConfigPanel()
+    config = ConfigParser()
+    config.add_section("test")
+    config.set("test", "first", "a")
+    config.set("test", "second", "b")
+    settings.add_json_panel(
+        "First",
+        config,
+        data=json.dumps([{"type": "string", "title": "First", "section": "test", "key": "first"}]),
+    )
+    content = settings.interface.content
+    first_uid = next(iter(content.panels))
+    settings.add_json_panel(
+        "Second",
+        config,
+        data=json.dumps([{"type": "string", "title": "Second", "section": "test", "key": "second"}]),
+    )
+    second_uid = next(uid for uid in content.panels if uid != first_uid)
+    content.current_uid = first_uid
+    content.scroll_y = 0
+
+    content.current_uid = second_uid
+    Clock.tick()
+
+    assert content.scroll_y == 1
+
+
+def test_shortcut_editor_keeps_full_content_height_after_kivy_layout():
+    panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+
+    Clock.tick()
+
+    assert item.height == item._editor_height
+    assert item._editor_layout.height == item._editor_height
+    assert panel.minimum_height >= item.height
+    settled_height = item.height
+    for _ in range(3):
+        Clock.tick()
+    assert item.height == settled_height
+    assert item._editor_layout.height == settled_height
+
+
+def test_shortcut_editor_visually_groups_categories_and_renders_keycaps():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+
+    sections = [widget for widget in item._editor_layout.children if isinstance(widget, _CategorySection)]
+    headers = [widget for section in sections for widget in section.children if isinstance(widget, _CategoryHeader)]
+
+    assert len(sections) == 3
+    assert len(headers) == 3
+    assert all(header.height > dp(30) for header in headers)
+    assert item._binding_displays["jog_y_positive"].key_labels == ("Down",)
+    assert item._binding_displays["jog_y_negative"].key_labels == ("Up",)
+
+    item._on_invert_y_axis_jogging(None, True)
+    assert item._binding_displays["jog_y_positive"].key_labels == ("Down",)
+    assert item._binding_displays["jog_y_negative"].key_labels == ("Up",)
+    assert item._bindings.default_for("jog_y_positive") == KeyChord("up")
+    assert item._bindings.default_for("jog_y_negative") == KeyChord("down")
+
+    display = item._binding_displays["mdi_send"]
+    assert display.key_labels == ("Ctrl", "Enter")
+    assert [keycap.text for keycap in display._keycaps] == ["Ctrl", "Enter"]
+
+    item._assign("mdi_send", KeyChord("f2"))
+    assert display.key_labels == ("F2",)
+    assert [keycap.text for keycap in display._keycaps] == ["F2"]
+
+    item._assign("mdi_send", None)
+    assert display.key_labels == ()
+    assert display._keycaps == []
+    assert display._content.children[0].text == "Unbound"
+
+
+def test_shortcut_keycap_width_settles_without_layout_feedback():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    keycaps = item._binding_displays["mdi_send"]._keycaps
+
+    Clock.tick()
+    settled_widths = [keycap.width for keycap in keycaps]
+    for _ in range(3):
+        Clock.tick()
+
+    assert [keycap.width for keycap in keycaps] == settled_widths
+    assert all(width < dp(100) for width in settled_widths)
+
+
+def test_shortcut_capture_waits_for_non_modifier_key():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    button = SimpleNamespace(text="")
+    item._start_capture("mdi_send", button)
+    try:
+        assert item._capture_key(None, 305, 224, "i", ["ctrl"]) is True
+        assert item._listening_for == "mdi_send"
+        assert button.text != "Bind..."
+
+        assert item._capture_key(None, 13, 40, "\r", ["ctrl"]) is True
+        assert item._listening_for is None
+        assert item._bindings.binding_for("mdi_send") == KeyChord("enter", ("ctrl",))
+    finally:
+        item._stop_capture()
+
+
+def test_shortcut_capture_stops_when_settings_popup_dismisses():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    manager = SimpleNamespace(paused=False, release_all_jogs=Mock())
+    modal = Mock()
+
+    with (
+        patch.object(item, "_shortcut_manager", return_value=manager),
+        patch.object(item, "_containing_modal", return_value=modal),
+    ):
+        item._start_capture("mdi_send", SimpleNamespace(text=""))
+        assert manager.paused is True
+        item._on_capture_modal_dismiss()
+
+    assert item._listening_for is None
+    assert manager.paused is False
+    assert item._error_label.text == ""
+    modal.unbind.assert_called_once_with(on_dismiss=item._on_capture_modal_dismiss)
+
+
+def test_shortcut_capture_stops_when_switching_settings_pages():
+    settings = MakeraConfigPanel()
+    config = ConfigParser()
+    config.add_section("test")
+    config.set("test", "shortcuts", "")
+    config.set("test", "other", "")
+    settings.add_json_panel(
+        "Shortcuts",
+        config,
+        data=json.dumps(
+            [
+                {
+                    "type": "keyboard_shortcuts",
+                    "title": "Shortcuts",
+                    "section": "test",
+                    "key": "shortcuts",
+                }
+            ]
+        ),
+    )
+    content = settings.interface.content
+    shortcut_uid = next(iter(content.panels))
+    panel = content.panels[shortcut_uid]
+    item = next(widget for widget in panel.walk() if isinstance(widget, SettingKeyboardShortcuts))
+    settings.add_json_panel(
+        "Other",
+        config,
+        data=json.dumps([{"type": "string", "title": "Other", "section": "test", "key": "other"}]),
+    )
+    other_uid = next(uid for uid in content.panels if uid != shortcut_uid)
+    content.current_uid = shortcut_uid
+    manager = SimpleNamespace(paused=False, release_all_jogs=Mock())
+
+    with patch.object(item, "_shortcut_manager", return_value=manager):
+        item._start_capture("mdi_send", SimpleNamespace(text=""))
+        content.current_uid = other_uid
+
+    assert item._listening_for is None
+    assert manager.paused is False
+    assert item._error_label.text == ""
+
+
+def test_shortcut_capture_reports_conflicts_and_escape_clears_the_prompt():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    button = SimpleNamespace(text="")
+    item._start_capture("open_start_job", button)
+    try:
+        assert item._capture_key(None, 282, 58, "", []) is True
+        assert item._listening_for == "open_start_job"
+        assert item._bindings.binding_for("open_start_job") is None
+        assert "Open Online Documentation" in item._error_label.text
+
+        assert item._capture_key(None, 27, 41, "", []) is True
+        assert item._listening_for is None
+        assert item._error_label.text == ""
+        assert button.text == "Bind..."
+    finally:
+        item._stop_capture()
+
+
+def test_shortcut_reset_to_saved_value_dispatches_change_notification():
+    panel, item, config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    changes = []
+    panel.settings.bind(on_config_change=lambda *_args: changes.append(_args[-1]))
+
+    item._assign("open_online_docs", None)
+    assert config.get("test", "key") == ""
+    changes.clear()
+
+    item._reset_all()
+
+    assert item.value == ""
+    assert changes == [""]
+    assert config.get("test", "key") == ""
+
+
+def test_shortcut_editor_bypasses_setting_item_blue_selection_animation():
+    _panel, item, _config = _make_panel("keyboard_shortcuts", SettingKeyboardShortcuts, "", {})
+    touch = object()
+
+    with patch(
+        "carveracontroller.addons.keyboard_shortcuts.ui.FloatLayout.on_touch_down",
+        return_value=True,
+    ) as dispatch:
+        assert item.on_touch_down(touch) is True
+
+    dispatch.assert_called_once_with(item, touch)
+    assert item.selected_alpha == 0

--- a/tests/unit/test_shortcut_dispatch.py
+++ b/tests/unit/test_shortcut_dispatch.py
@@ -7,7 +7,9 @@ from kivy.uix.modalview import ModalView
 from carveracontroller.addons.cmm_workbench.ui.CMMWorkbenchPopup import JogCMMWorkbenchPopup
 from carveracontroller.addons.keyboard_shortcuts.bindings import KeyChord, ShortcutBindings
 from carveracontroller.addons.keyboard_shortcuts.manager import ShortcutManager
+from carveracontroller.Controller import Controller
 from carveracontroller.main import Makera
+from carveracontroller.Utils import digitize_v
 
 
 def _root():
@@ -20,7 +22,9 @@ def _root():
     root.open_start_job_popup = Mock()
     root.open_file_browser = Mock(return_value=True)
     root.open_mdi = Mock()
+    root.open_gcode = Mock()
     root.toggle_keyboard_jog_control = Mock(return_value=True)
+    root.toggle_jog_mode = Mock(return_value=True)
     root._is_popup_open = Mock(return_value=False)
     root.manual_cmd = SimpleNamespace(focus=False, hint_text="")
     root.config_popup = SimpleNamespace(open=Mock())
@@ -72,6 +76,10 @@ def test_global_settings_and_mdi_shortcuts_dispatch_when_available():
 
     assert manager.on_key_down(None, ord("m"), 16, "m", ["ctrl"]) is True
     manager.root.open_mdi.assert_called_once_with()
+    assert manager.on_key_up(None, ord("m")) is True
+
+    assert manager.on_key_down(None, ord("g"), 10, "g", ["ctrl"]) is True
+    manager.root.open_gcode.assert_called_once_with()
 
 
 def test_file_browser_and_keyboard_jog_toggle_shortcuts_dispatch():
@@ -83,6 +91,11 @@ def test_file_browser_and_keyboard_jog_toggle_shortcuts_dispatch():
 
     assert manager.on_key_down(None, ord("j"), 13, "j", ["ctrl"]) is True
     manager.root.toggle_keyboard_jog_control.assert_called_once_with()
+    assert manager.on_key_up(None, ord("j")) is True
+
+    manager.root.keyboard_jog_control = False
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    manager.root.toggle_jog_mode.assert_called_once_with()
 
 
 def test_file_browser_shortcut_propagates_when_browser_is_unavailable():
@@ -97,6 +110,53 @@ def test_keyboard_jog_toggle_shortcut_propagates_when_control_is_unavailable():
     manager.root.toggle_keyboard_jog_control.return_value = False
 
     assert manager.on_key_down(None, ord("j"), 13, "j", ["ctrl"]) is False
+
+
+def test_switch_jog_mode_shortcut_dispatches_without_starting_a_jog():
+    manager = _manager()
+
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    manager.root.toggle_jog_mode.assert_called_once_with()
+    manager.root.perform_keyboard_jog.assert_not_called()
+    manager.root.controller.stopContinuousJog.assert_not_called()
+
+
+def test_held_switch_jog_mode_shortcut_only_dispatches_once_until_key_up():
+    manager = _manager()
+
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    manager.root.toggle_jog_mode.assert_called_once_with()
+
+    assert manager.on_key_up(None, ord("k")) is True
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    assert manager.root.toggle_jog_mode.call_count == 2
+
+
+def test_switch_jog_mode_shortcut_stops_an_active_keyboard_jog():
+    manager = _manager()
+    manager.on_key_down(None, 275, 0, "", [])
+
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+    manager.root.toggle_jog_mode.assert_called_once_with()
+    manager.root.perform_keyboard_jog.assert_called_once_with("jog_x_positive")
+
+
+def test_switch_jog_mode_shortcut_propagates_when_mode_is_unavailable():
+    manager = _manager()
+    manager.root.toggle_jog_mode.return_value = False
+
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is False
+
+
+def test_switch_jog_mode_shortcut_dispatches_when_keyboard_jogging_is_off():
+    manager = _manager()
+    manager.root.keyboard_jog_control = False
+
+    assert manager.on_key_down(None, ord("k"), 0, "k", ["ctrl"]) is True
+    manager.root.toggle_jog_mode.assert_called_once_with()
 
 
 def test_unmodified_printable_global_shortcut_is_suppressed_while_typing():
@@ -293,6 +353,10 @@ def test_blocked_global_shortcut_is_not_consumed():
 
     assert manager.on_key_down(None, 44, 0, ",", ["ctrl"]) is False
     manager.root.config_popup.open.assert_not_called()
+    assert manager.on_key_down(None, ord("g"), 0, "g", ["ctrl"]) is False
+    manager.root.open_gcode.assert_not_called()
+    assert manager.on_key_down(None, ord("m"), 0, "m", ["ctrl"]) is False
+    manager.root.open_mdi.assert_not_called()
 
 
 def test_open_file_browser_matches_the_existing_file_button_behavior():
@@ -456,3 +520,64 @@ def test_keyboard_jog_toggle_matches_button_availability_but_forced_disable_stil
     assert root.keyboard_jog_control is False
     assert app.jog_keyboard_enable == "normal"
     shortcut_manager.release_all_jogs.assert_called_once_with()
+
+
+def test_open_gcode_switches_to_the_file_tab_and_unfocuses_mdi():
+    content = SimpleNamespace(transition=SimpleNamespace(direction=""), current="Control")
+    cmd_manager = SimpleNamespace(transition=SimpleNamespace(direction=""), current="manual_cmd_page")
+    root = SimpleNamespace(
+        content=content,
+        cmd_manager=cmd_manager,
+        manual_cmd=SimpleNamespace(focus=True),
+    )
+
+    Makera.open_gcode(root)
+
+    assert content.current == "File"
+    assert cmd_manager.current == "gcode_cmd_page"
+    assert root.manual_cmd.focus is False
+
+
+def test_toggle_jog_mode_matches_the_jog_mode_button_availability():
+    root = SimpleNamespace()
+    app = SimpleNamespace(is_community_firmware=False, fw_version_digitized=0)
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=app):
+        assert Makera.can_toggle_jog_mode(root) is False
+        app.is_community_firmware = True
+        app.fw_version_digitized = digitize_v("1.9.0")
+        assert Makera.can_toggle_jog_mode(root) is False
+        app.fw_version_digitized = digitize_v("2.0.0")
+        assert Makera.can_toggle_jog_mode(root) is True
+
+
+def test_toggle_jog_mode_switches_step_and_continuous_when_available():
+    controller = SimpleNamespace(jog_mode=Controller.JOG_MODE_STEP)
+    root = SimpleNamespace(
+        controller=controller,
+        can_toggle_jog_mode=lambda: True,
+        update_ui_for_jog_mode_cont=Mock(),
+        update_ui_for_jog_mode_step=Mock(),
+    )
+
+    assert Makera.toggle_jog_mode(root) is True
+    root.update_ui_for_jog_mode_cont.assert_called_once_with()
+    root.update_ui_for_jog_mode_step.assert_not_called()
+
+    controller.jog_mode = Controller.JOG_MODE_CONTINUOUS
+    assert Makera.toggle_jog_mode(root) is True
+    root.update_ui_for_jog_mode_step.assert_called_once_with()
+
+
+def test_toggle_jog_mode_is_a_no_op_when_unavailable():
+    controller = SimpleNamespace(jog_mode=Controller.JOG_MODE_STEP)
+    root = SimpleNamespace(
+        controller=controller,
+        can_toggle_jog_mode=lambda: False,
+        update_ui_for_jog_mode_cont=Mock(),
+        update_ui_for_jog_mode_step=Mock(),
+    )
+
+    assert Makera.toggle_jog_mode(root) is False
+    root.update_ui_for_jog_mode_cont.assert_not_called()
+    root.update_ui_for_jog_mode_step.assert_not_called()

--- a/tests/unit/test_shortcut_dispatch.py
+++ b/tests/unit/test_shortcut_dispatch.py
@@ -1,0 +1,458 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from kivy.uix.modalview import ModalView
+
+from carveracontroller.addons.cmm_workbench.ui.CMMWorkbenchPopup import JogCMMWorkbenchPopup
+from carveracontroller.addons.keyboard_shortcuts.bindings import KeyChord, ShortcutBindings
+from carveracontroller.addons.keyboard_shortcuts.manager import ShortcutManager
+from carveracontroller.main import Makera
+
+
+def _root():
+    root = SimpleNamespace()
+    root.controller = SimpleNamespace(stopContinuousJog=Mock())
+    root.keyboard_jog_control = True
+    root.is_jogging_enabled = Mock(return_value=True)
+    root.perform_keyboard_jog = Mock()
+    root.open_online_docs = Mock()
+    root.open_start_job_popup = Mock()
+    root.open_file_browser = Mock(return_value=True)
+    root.open_mdi = Mock()
+    root.toggle_keyboard_jog_control = Mock(return_value=True)
+    root._is_popup_open = Mock(return_value=False)
+    root.manual_cmd = SimpleNamespace(focus=False, hint_text="")
+    root.config_popup = SimpleNamespace(open=Mock())
+    root.can_send_mdi_command = Mock(return_value=True)
+    return root
+
+
+def _manager(root=None):
+    manager = ShortcutManager(root or _root())
+    manager.bindings = ShortcutBindings()
+    manager._text_input_has_focus = Mock(return_value=False)
+    return manager
+
+
+def test_global_documentation_shortcut_is_dispatched_and_consumed():
+    manager = _manager()
+    assert manager.on_key_down(None, 282, 0, "", []) is True
+    manager.root.open_online_docs.assert_called_once_with()
+
+
+def test_held_global_shortcut_only_dispatches_once_until_key_up():
+    manager = _manager()
+
+    assert manager.on_key_down(None, 282, 0, "", []) is True
+    assert manager.on_key_down(None, 282, 0, "", []) is True
+    manager.root.open_online_docs.assert_called_once_with()
+
+    assert manager.on_key_up(None, 282) is True
+    assert manager.on_key_down(None, 282, 0, "", []) is True
+    assert manager.root.open_online_docs.call_count == 2
+
+
+def test_global_action_stops_active_keyboard_jog():
+    manager = _manager()
+    manager.on_key_down(None, 275, 0, "", [])
+
+    assert manager.on_key_down(None, 282, 0, "", []) is True
+
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+    manager.root.open_online_docs.assert_called_once_with()
+
+
+def test_global_settings_and_mdi_shortcuts_dispatch_when_available():
+    manager = _manager()
+
+    assert manager.on_key_down(None, 44, 54, ",", ["ctrl"]) is True
+    manager.root.config_popup.open.assert_called_once_with()
+    assert manager.on_key_up(None, 44) is True
+
+    assert manager.on_key_down(None, ord("m"), 16, "m", ["ctrl"]) is True
+    manager.root.open_mdi.assert_called_once_with()
+
+
+def test_file_browser_and_keyboard_jog_toggle_shortcuts_dispatch():
+    manager = _manager()
+
+    assert manager.on_key_down(None, ord("o"), 18, "o", ["ctrl"]) is True
+    manager.root.open_file_browser.assert_called_once_with()
+    assert manager.on_key_up(None, ord("o")) is True
+
+    assert manager.on_key_down(None, ord("j"), 13, "j", ["ctrl"]) is True
+    manager.root.toggle_keyboard_jog_control.assert_called_once_with()
+
+
+def test_file_browser_shortcut_propagates_when_browser_is_unavailable():
+    manager = _manager()
+    manager.root.open_file_browser.return_value = False
+
+    assert manager.on_key_down(None, ord("o"), 18, "o", ["ctrl"]) is False
+
+
+def test_keyboard_jog_toggle_shortcut_propagates_when_control_is_unavailable():
+    manager = _manager()
+    manager.root.toggle_keyboard_jog_control.return_value = False
+
+    assert manager.on_key_down(None, ord("j"), 13, "j", ["ctrl"]) is False
+
+
+def test_unmodified_printable_global_shortcut_is_suppressed_while_typing():
+    manager = _manager()
+    manager.bindings.assign("open_start_job", KeyChord("s"))
+    manager._text_input_has_focus.return_value = True
+
+    assert manager.on_key_down(None, ord("s"), 0, "s", []) is False
+    manager.root.open_start_job_popup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("chord", "key", "codepoint", "modifiers"),
+    [
+        (KeyChord("s", ("shift",)), ord("s"), "S", ["shift"]),
+        (KeyChord("spacebar"), 32, " ", []),
+    ],
+)
+def test_text_producing_global_shortcut_is_suppressed_while_typing(chord, key, codepoint, modifiers):
+    manager = _manager()
+    manager.bindings.assign("open_start_job", chord)
+    manager._text_input_has_focus.return_value = True
+
+    assert manager.on_key_down(None, key, 0, codepoint, modifiers) is False
+    manager.root.open_start_job_popup.assert_not_called()
+
+
+def test_mdi_send_and_newline_are_exact_and_context_scoped():
+    manager = _manager()
+    widget = SimpleNamespace(focus=True, send_mdi_command=Mock(), insert_text=Mock())
+
+    assert manager.handle_mdi_keydown(widget, 13, ["ctrl"], "\r") is True
+    widget.send_mdi_command.assert_called_once_with()
+    assert manager.handle_mdi_keydown(widget, 13, [], "\r") is True
+    widget.insert_text.assert_called_once_with("\n")
+    assert manager.handle_mdi_keydown(widget, 13, ["ctrl", "shift"], "\r") is True
+    widget.insert_text.assert_called_once_with("\n")
+
+
+def test_remapped_mdi_newline_suppresses_text_inputs_builtin_enter_behavior():
+    manager = _manager()
+    manager.bindings.assign("mdi_newline", KeyChord("enter", ("shift",)))
+    widget = SimpleNamespace(focus=True, send_mdi_command=Mock(), insert_text=Mock())
+
+    assert manager.handle_mdi_keydown(widget, 13, [], "\r") is True
+    widget.insert_text.assert_not_called()
+    assert manager.handle_mdi_keydown(widget, 13, ["shift"], "\r") is True
+    widget.insert_text.assert_called_once_with("\n")
+
+
+def test_unbound_mdi_newline_restores_text_inputs_builtin_enter_behavior():
+    manager = _manager()
+    manager.bindings.assign("mdi_newline", None)
+    widget = SimpleNamespace(focus=True, send_mdi_command=Mock(), insert_text=Mock())
+
+    assert manager.handle_mdi_keydown(widget, 13, [], "\r") is False
+    widget.insert_text.assert_not_called()
+
+
+def test_mdi_send_is_consumed_but_not_sent_when_machine_state_blocks_it():
+    manager = _manager()
+    manager.root.can_send_mdi_command.return_value = False
+    widget = SimpleNamespace(focus=True, send_mdi_command=Mock(), insert_text=Mock())
+
+    assert manager.handle_mdi_keydown(widget, 13, ["ctrl"], "\r") is True
+    widget.send_mdi_command.assert_not_called()
+
+
+def test_reloading_bindings_updates_the_mdi_hint():
+    manager = _manager()
+    raw = '{"version":1,"bindings":{"mdi_send":{"key":"f2","modifiers":[]}}}'
+
+    with patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", return_value=raw):
+        manager.reload_from_config()
+
+    assert manager.root.manual_cmd.hint_text == "Enter command... <F2 to send>"
+
+
+def test_jog_press_repeat_release_and_disable_are_safe():
+    manager = _manager()
+
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    manager.root.perform_keyboard_jog.assert_called_once_with("jog_x_positive")
+
+    assert manager.on_key_up(None, 275) is True
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+
+    manager.on_key_down(None, 275, 0, "", [])
+    manager.release_all_jogs()
+    assert manager.root.controller.stopContinuousJog.call_count == 2
+
+
+def test_jog_propagates_without_motion_when_context_blocks_it():
+    manager = _manager()
+    manager.root.is_jogging_enabled.return_value = False
+    assert manager.on_key_down(None, 275, 0, "", []) is False
+    manager.root.perform_keyboard_jog.assert_not_called()
+
+    manager._text_input_has_focus.return_value = True
+    assert manager.on_key_down(None, 275, 0, "", []) is False
+    manager._text_input_has_focus.return_value = False
+    manager.root.keyboard_jog_control = False
+    assert manager.on_key_down(None, 275, 0, "", []) is False
+
+
+def test_jog_release_does_not_depend_on_current_modifiers():
+    manager = _manager()
+    manager.bindings.assign("jog_x_positive", KeyChord("right", ("ctrl",)))
+    manager.on_key_down(None, 275, 0, "", ["ctrl"])
+    assert manager.on_key_up(None, 275, 0, "", []) is True
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+
+
+def test_blocking_modal_stops_jog_and_held_repeat_cannot_restart_it():
+    manager = _manager()
+    modal = ModalView()
+    modal._is_open = True
+
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    manager.on_window_children(None, [modal])
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+
+    # Repeats from the physical key that was held while the modal opened must
+    # remain suppressed until its matching key-up arrives.
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    manager.root.perform_keyboard_jog.assert_called_once_with("jog_x_positive")
+    assert manager.on_key_up(None, 275) is True
+
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    assert manager.root.perform_keyboard_jog.call_count == 2
+
+
+def test_modal_that_explicitly_allows_external_jog_does_not_stop_it():
+    class JogModal(ModalView):
+        def allows_external_jog(self):
+            return True
+
+    manager = _manager()
+    modal = JogModal()
+    modal._is_open = True
+
+    manager.on_key_down(None, 275, 0, "", [])
+    manager.on_window_children(None, [modal])
+
+    manager.root.controller.stopContinuousJog.assert_not_called()
+
+
+def test_cmm_jog_overlay_remains_an_external_jog_context():
+    overlay = SimpleNamespace(_is_open=True)
+    overlay.allows_external_jog = lambda: JogCMMWorkbenchPopup.allows_external_jog(overlay)
+    parent = SimpleNamespace(allows_external_jog=lambda: True)
+    root = SimpleNamespace(_open_popups=lambda: [parent, overlay])
+
+    assert Makera._popup_prevents_jogging(root) is False
+
+
+def test_blocking_modal_wins_when_another_modal_allows_external_jog():
+    allowed = SimpleNamespace(allows_external_jog=lambda: True)
+    blocked = SimpleNamespace()
+    root = SimpleNamespace(_open_popups=lambda: [allowed, blocked])
+
+    assert Makera._popup_prevents_jogging(root) is True
+
+
+def test_second_jog_key_does_not_interrupt_the_active_direction():
+    manager = _manager()
+
+    manager.on_key_down(None, 275, 0, "", [])
+    manager.on_key_down(None, 273, 0, "", [])
+    manager.root.perform_keyboard_jog.assert_called_once_with("jog_x_positive")
+
+    assert manager.on_key_up(None, 273) is True
+    manager.root.controller.stopContinuousJog.assert_not_called()
+    assert manager.on_key_up(None, 275) is True
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+
+
+def test_window_focus_loss_stops_jog_and_clears_stale_key_state():
+    manager = _manager()
+
+    manager.on_key_down(None, 275, 0, "", [])
+    manager.on_window_focus(None, False)
+
+    manager.root.controller.stopContinuousJog.assert_called_once_with()
+    assert manager._held_jog_keys == set()
+    assert manager.on_key_down(None, 275, 0, "", []) is True
+    assert manager.root.perform_keyboard_jog.call_count == 2
+
+
+def test_blocked_global_shortcut_is_not_consumed():
+    manager = _manager()
+    manager.root._is_popup_open.return_value = True
+
+    assert manager.on_key_down(None, 44, 0, ",", ["ctrl"]) is False
+    manager.root.config_popup.open.assert_not_called()
+
+
+def test_open_file_browser_matches_the_existing_file_button_behavior():
+    popup = SimpleNamespace(open_for_jobs=Mock())
+    root = SimpleNamespace(file_popup=popup, _is_popup_open=Mock(return_value=False))
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=SimpleNamespace(state="Idle", playing=False)):
+        assert Makera.open_file_browser(root) is True
+
+    popup.open_for_jobs.assert_called_once_with()
+
+
+def test_open_file_browser_is_blocked_when_the_file_button_would_be_unavailable():
+    popup = SimpleNamespace(open_for_jobs=Mock())
+    root = SimpleNamespace(file_popup=popup, _is_popup_open=Mock(return_value=False))
+
+    with patch(
+        "carveracontroller.main.App.get_running_app", return_value=SimpleNamespace(state="Pause", playing=False)
+    ):
+        assert Makera.open_file_browser(root) is False
+
+    popup.open_for_jobs.assert_not_called()
+
+
+def test_start_job_applicability_and_opening():
+    app = SimpleNamespace(state="Idle", selected_remote_filename="job.nc", playing=False)
+    popup = SimpleNamespace(mode="", load_config=Mock(), open=Mock())
+    root = SimpleNamespace(_is_popup_open=Mock(return_value=False), coord_popup=popup)
+    root.can_open_start_job_popup = lambda: Makera.can_open_start_job_popup(root)
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=app):
+        assert Makera.can_open_start_job_popup(root) is True
+        assert Makera.open_start_job_popup(root) is True
+
+    assert popup.mode == "Run"
+    popup.load_config.assert_called_once_with()
+    popup.open.assert_called_once_with()
+
+
+def test_start_job_is_blocked_without_idle_selected_file():
+    popup = SimpleNamespace(mode="", load_config=Mock(), open=Mock())
+    root = SimpleNamespace(_is_popup_open=Mock(return_value=False), coord_popup=popup)
+    root.can_open_start_job_popup = lambda: Makera.can_open_start_job_popup(root)
+
+    for app in (
+        SimpleNamespace(state="Run", selected_remote_filename="job.nc", playing=True),
+        SimpleNamespace(state="Idle", selected_remote_filename="", playing=False),
+    ):
+        with patch("carveracontroller.main.App.get_running_app", return_value=app):
+            assert Makera.open_start_job_popup(root) is False
+    popup.open.assert_not_called()
+
+
+def test_mdi_machine_state_guard():
+    root = SimpleNamespace(allow_mdi_while_machine_running="0")
+    with patch(
+        "carveracontroller.main.App.get_running_app",
+        return_value=SimpleNamespace(state="Run"),
+    ):
+        assert Makera.can_send_mdi_command(root) is False
+        root.allow_mdi_while_machine_running = None
+        assert Makera.can_send_mdi_command(root) is False
+        root.allow_mdi_while_machine_running = "1"
+        assert Makera.can_send_mdi_command(root) is True
+
+
+def test_applying_shortcuts_does_not_change_unrelated_mdi_permission():
+    shortcut_manager = SimpleNamespace(reload_from_config=Mock())
+    root = SimpleNamespace(
+        controller_setting_change_list={"keyboard_shortcuts": "{}"},
+        allow_mdi_while_machine_running="0",
+        shortcut_manager=shortcut_manager,
+        _update_macro_button_text=Mock(),
+        config_popup=SimpleNamespace(btn_apply=SimpleNamespace(disabled=False)),
+    )
+
+    Makera.apply_controller_setting_changes(root)
+
+    assert root.allow_mdi_while_machine_running == "0"
+    shortcut_manager.reload_from_config.assert_called_once_with()
+    assert root.controller_setting_change_list == {}
+
+
+def test_applying_y_inversion_does_not_reload_current_shortcuts():
+    shortcut_manager = SimpleNamespace(reload_from_config=Mock())
+    root = SimpleNamespace(
+        controller_setting_change_list={"invert_y_axis_jogging": "0"},
+        shortcut_manager=shortcut_manager,
+        _update_macro_button_text=Mock(),
+        config_popup=SimpleNamespace(btn_apply=SimpleNamespace(disabled=False)),
+    )
+    app = SimpleNamespace(invert_y_axis_jogging=True)
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=app):
+        Makera.apply_controller_setting_changes(root)
+
+    assert app.invert_y_axis_jogging is False
+    shortcut_manager.reload_from_config.assert_not_called()
+
+
+def test_keyboard_jog_commands_follow_action_sign_and_add_a_axis():
+    controller = SimpleNamespace(jog=Mock())
+    root = SimpleNamespace(
+        controller=controller,
+        step_xy=SimpleNamespace(text="10"),
+        step_z=SimpleNamespace(text="1"),
+        step_a=SimpleNamespace(text="90"),
+    )
+
+    Makera.perform_keyboard_jog(root, "jog_y_positive")
+    Makera.perform_keyboard_jog(root, "jog_a_negative")
+    assert controller.jog.call_args_list[0].args == ("Y10",)
+    assert controller.jog.call_args_list[1].args == ("A-90",)
+
+    controller.jog.reset_mock()
+    Makera.perform_keyboard_jog(root, "jog_y_negative")
+    Makera.perform_keyboard_jog(root, "jog_a_positive")
+
+    assert [call.args for call in controller.jog.call_args_list] == [("Y-10",), ("A90",)]
+
+
+def test_machine_state_change_stops_active_keyboard_jog():
+    shortcut_manager = SimpleNamespace(release_all_jogs=Mock())
+    root = SimpleNamespace(
+        _machine_allows_jogging=Mock(return_value=False),
+        shortcut_manager=shortcut_manager,
+    )
+    app = SimpleNamespace(jog_controls_enabled=True)
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=app):
+        Makera.update_jog_controls_enabled(root)
+
+    assert app.jog_controls_enabled is False
+    shortcut_manager.release_all_jogs.assert_called_once_with()
+
+
+def test_keyboard_jog_toggle_matches_button_availability_but_forced_disable_still_works():
+    shortcut_manager = SimpleNamespace(release_all_jogs=Mock())
+    root = SimpleNamespace(
+        keyboard_jog_control=False,
+        shortcut_manager=shortcut_manager,
+    )
+    app = SimpleNamespace(
+        root=root,
+        jog_controls_enabled=False,
+        jog_keyboard_enable="normal",
+    )
+
+    with patch("carveracontroller.main.App.get_running_app", return_value=app):
+        assert Makera.toggle_keyboard_jog_control(root) is False
+        assert root.keyboard_jog_control is False
+
+        app.jog_controls_enabled = True
+        assert Makera.toggle_keyboard_jog_control(root) is True
+        assert root.keyboard_jog_control is True
+        assert app.jog_keyboard_enable == "down"
+
+        app.jog_controls_enabled = False
+        assert Makera.toggle_keyboard_jog_control(root, True) is True
+
+    assert root.keyboard_jog_control is False
+    assert app.jog_keyboard_enable == "normal"
+    shortcut_manager.release_all_jogs.assert_called_once_with()

--- a/tests/unit/test_shortcut_dispatch.py
+++ b/tests/unit/test_shortcut_dispatch.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -229,7 +230,12 @@ def test_reloading_bindings_updates_the_mdi_hint():
     manager = _manager()
     raw = '{"version":1,"bindings":{"mdi_send":{"key":"f2","modifiers":[]}}}'
 
-    with patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", return_value=raw):
+    def _config_get(_section, key, fallback=""):
+        if key == "keyboard_shortcuts":
+            return raw
+        return fallback
+
+    with patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", side_effect=_config_get):
         manager.reload_from_config()
 
     assert manager.root.manual_cmd.hint_text == "Enter command... <F2 to send>"
@@ -455,6 +461,74 @@ def test_applying_y_inversion_does_not_reload_current_shortcuts():
 
     assert app.invert_y_axis_jogging is False
     shortcut_manager.reload_from_config.assert_not_called()
+
+
+def test_uninitialized_config_seeds_live_y_bindings_from_invert():
+    values = {"keyboard_shortcuts": "", "invert_y_axis_jogging": "1"}
+
+    def _config_get(_section, key, fallback=""):
+        return values.get(key, fallback)
+
+    with patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", side_effect=_config_get):
+        manager = ShortcutManager(_root())
+
+    assert manager.bindings.binding_for("jog_y_positive") == KeyChord("up")
+    assert manager.bindings.binding_for("jog_y_negative") == KeyChord("down")
+
+
+def test_initialized_config_keeps_factory_y_bindings_when_invert_is_on():
+    values = {"keyboard_shortcuts": '{"bindings":{},"version":1}', "invert_y_axis_jogging": "1"}
+
+    def _config_get(_section, key, fallback=""):
+        return values.get(key, fallback)
+
+    with patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", side_effect=_config_get):
+        manager = ShortcutManager(_root())
+
+    assert manager.bindings.binding_for("jog_y_positive") == KeyChord("down")
+    assert manager.bindings.binding_for("jog_y_negative") == KeyChord("up")
+
+
+def test_first_launch_persists_invert_aware_defaults_once():
+    values = {"keyboard_shortcuts": "", "invert_y_axis_jogging": "1"}
+
+    def _config_get(_section, key, fallback=""):
+        return values.get(key, fallback)
+
+    with (
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", side_effect=_config_get),
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.set") as config_set,
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.write") as config_write,
+    ):
+        ShortcutManager.seed_config_if_uninitialized()
+        persisted = config_set.call_args.args[2]
+        values["keyboard_shortcuts"] = persisted
+        config_set.reset_mock()
+        config_write.reset_mock()
+        ShortcutManager.seed_config_if_uninitialized()
+
+    payload = json.loads(persisted)
+    assert set(payload["bindings"]) == {"jog_y_positive", "jog_y_negative"}
+    assert payload["bindings"]["jog_y_positive"] == {"key": "up", "modifiers": []}
+    assert payload["bindings"]["jog_y_negative"] == {"key": "down", "modifiers": []}
+    config_set.assert_not_called()
+    config_write.assert_not_called()
+
+
+def test_first_launch_without_invert_persists_an_initialized_empty_map():
+    values = {"keyboard_shortcuts": "", "invert_y_axis_jogging": "0"}
+
+    def _config_get(_section, key, fallback=""):
+        return values.get(key, fallback)
+
+    with (
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.get", side_effect=_config_get),
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.set") as config_set,
+        patch("carveracontroller.addons.keyboard_shortcuts.manager.Config.write"),
+    ):
+        ShortcutManager.seed_config_if_uninitialized()
+
+    assert config_set.call_args.args == ("carvera", "keyboard_shortcuts", '{"bindings":{},"version":1}')
 
 
 def test_keyboard_jog_commands_follow_action_sign_and_add_a_axis():

--- a/tests/unit/test_shortcuts.py
+++ b/tests/unit/test_shortcuts.py
@@ -11,6 +11,8 @@ from carveracontroller.addons.keyboard_shortcuts.bindings import (
     format_chord_parts,
 )
 
+INITIALIZED_EMPTY_JSON = '{"bindings":{},"version":1}'
+
 
 def test_requested_defaults():
     bindings = ShortcutBindings()
@@ -35,16 +37,38 @@ def test_requested_defaults():
     assert ACTION_BY_ID["switch_jog_mode"].category == "Global"
 
     inverted = ShortcutBindings(invert_y_axis_jogging=True)
-    assert inverted.binding_for("jog_y_positive") == KeyChord("down")
-    assert inverted.binding_for("jog_y_negative") == KeyChord("up")
+    assert inverted.binding_for("jog_y_positive") == KeyChord("up")
+    assert inverted.binding_for("jog_y_negative") == KeyChord("down")
     assert inverted.default_for("jog_y_positive") == KeyChord("up")
     assert inverted.default_for("jog_y_negative") == KeyChord("down")
-    assert inverted.to_json() == ""
+    assert set(json.loads(inverted.to_json())["bindings"]) == {"jog_y_positive", "jog_y_negative"}
 
     inverted.reset_all()
     assert inverted.binding_for("jog_y_positive") == KeyChord("up")
     assert inverted.binding_for("jog_y_negative") == KeyChord("down")
     assert set(json.loads(inverted.to_json())["bindings"]) == {"jog_y_positive", "jog_y_negative"}
+
+
+def test_saved_shortcut_map_does_not_reseed_y_bindings_from_invert():
+    initialized = ShortcutBindings.from_json(INITIALIZED_EMPTY_JSON, invert_y_axis_jogging=True)
+    assert initialized.binding_for("jog_y_positive") == KeyChord("down")
+    assert initialized.binding_for("jog_y_negative") == KeyChord("up")
+    assert initialized.default_for("jog_y_positive") == KeyChord("up")
+    assert initialized.default_for("jog_y_negative") == KeyChord("down")
+    assert initialized.to_json() == INITIALIZED_EMPTY_JSON
+
+    customized = ShortcutBindings.from_json(
+        '{"version":1,"bindings":{"open_online_docs":{"key":"f2","modifiers":[]}}}',
+        invert_y_axis_jogging=True,
+    )
+    assert customized.binding_for("jog_y_positive") == KeyChord("down")
+    assert customized.binding_for("open_online_docs") == KeyChord("f2")
+
+
+def test_empty_config_is_uninitialized_and_versioned_empty_is_not():
+    assert ShortcutBindings.from_json("").to_json() == INITIALIZED_EMPTY_JSON
+    assert ShortcutBindings.from_json(None, invert_y_axis_jogging=True).binding_for("jog_y_positive") == KeyChord("up")
+    assert ShortcutBindings.from_json("", invert_y_axis_jogging=True).binding_for("jog_y_positive") == KeyChord("up")
 
 
 def test_sparse_round_trip_merges_with_defaults():
@@ -69,7 +93,7 @@ def test_invalid_config_falls_back_to_defaults(raw):
 
 def test_unknown_actions_are_ignored_for_forward_compatibility():
     raw = '{"version":1,"bindings":{"future_action":{"key":"f2","modifiers":[]}}}'
-    assert ShortcutBindings.from_json(raw).to_json() == ""
+    assert ShortcutBindings.from_json(raw).to_json() == INITIALIZED_EMPTY_JSON
 
 
 def test_conflicting_persisted_config_falls_back_to_defaults():
@@ -158,4 +182,4 @@ def test_unbind_and_reset():
     assert bindings.binding_for("open_online_docs") is None
     bindings.reset("open_online_docs")
     assert bindings.binding_for("open_online_docs") == KeyChord("f1")
-    assert bindings.to_json() == ""
+    assert bindings.to_json() == INITIALIZED_EMPTY_JSON

--- a/tests/unit/test_shortcuts.py
+++ b/tests/unit/test_shortcuts.py
@@ -17,8 +17,11 @@ def test_requested_defaults():
 
     assert bindings.binding_for("open_start_job") is None
     assert bindings.binding_for("open_online_docs") == KeyChord("f1")
+    assert bindings.binding_for("open_mdi") == KeyChord("m", ("ctrl",))
+    assert bindings.binding_for("open_gcode") == KeyChord("g", ("ctrl",))
     assert bindings.binding_for("open_file_browser") == KeyChord("o", ("ctrl",))
     assert bindings.binding_for("toggle_keyboard_jogging") == KeyChord("j", ("ctrl",))
+    assert bindings.binding_for("switch_jog_mode") == KeyChord("k", ("ctrl",))
     assert bindings.binding_for("mdi_send") == KeyChord("enter", ("ctrl",))
     assert bindings.binding_for("mdi_newline") == KeyChord("enter")
     assert bindings.binding_for("jog_x_positive") == KeyChord("right")
@@ -27,6 +30,9 @@ def test_requested_defaults():
     assert bindings.binding_for("jog_y_negative") == KeyChord("up")
     assert ACTION_BY_ID["jog_y_positive"].label == "Jog Y+"
     assert ACTION_BY_ID["jog_y_negative"].label == "Jog Y−"
+    assert ACTION_BY_ID["open_gcode"].label == "Open / Focus G-Code"
+    assert ACTION_BY_ID["switch_jog_mode"].label == "Switch Jog Mode"
+    assert ACTION_BY_ID["switch_jog_mode"].category == "Global"
 
     inverted = ShortcutBindings(invert_y_axis_jogging=True)
     assert inverted.binding_for("jog_y_positive") == KeyChord("down")

--- a/tests/unit/test_shortcuts.py
+++ b/tests/unit/test_shortcuts.py
@@ -1,0 +1,155 @@
+import json
+
+import pytest
+
+from carveracontroller.addons.keyboard_shortcuts.bindings import (
+    ACTION_BY_ID,
+    KeyChord,
+    ShortcutBindings,
+    chord_from_event,
+    format_chord,
+    format_chord_parts,
+)
+
+
+def test_requested_defaults():
+    bindings = ShortcutBindings()
+
+    assert bindings.binding_for("open_start_job") is None
+    assert bindings.binding_for("open_online_docs") == KeyChord("f1")
+    assert bindings.binding_for("open_file_browser") == KeyChord("o", ("ctrl",))
+    assert bindings.binding_for("toggle_keyboard_jogging") == KeyChord("j", ("ctrl",))
+    assert bindings.binding_for("mdi_send") == KeyChord("enter", ("ctrl",))
+    assert bindings.binding_for("mdi_newline") == KeyChord("enter")
+    assert bindings.binding_for("jog_x_positive") == KeyChord("right")
+    assert bindings.binding_for("jog_a_positive") is None
+    assert bindings.binding_for("jog_y_positive") == KeyChord("down")
+    assert bindings.binding_for("jog_y_negative") == KeyChord("up")
+    assert ACTION_BY_ID["jog_y_positive"].label == "Jog Y+"
+    assert ACTION_BY_ID["jog_y_negative"].label == "Jog Y−"
+
+    inverted = ShortcutBindings(invert_y_axis_jogging=True)
+    assert inverted.binding_for("jog_y_positive") == KeyChord("down")
+    assert inverted.binding_for("jog_y_negative") == KeyChord("up")
+    assert inverted.default_for("jog_y_positive") == KeyChord("up")
+    assert inverted.default_for("jog_y_negative") == KeyChord("down")
+    assert inverted.to_json() == ""
+
+    inverted.reset_all()
+    assert inverted.binding_for("jog_y_positive") == KeyChord("up")
+    assert inverted.binding_for("jog_y_negative") == KeyChord("down")
+    assert set(json.loads(inverted.to_json())["bindings"]) == {"jog_y_positive", "jog_y_negative"}
+
+
+def test_sparse_round_trip_merges_with_defaults():
+    bindings = ShortcutBindings()
+    bindings.assign("open_online_docs", KeyChord("d", ("ctrl", "shift")))
+    bindings.assign("jog_a_positive", KeyChord("]"))
+
+    raw = bindings.to_json()
+    payload = json.loads(raw)
+    assert set(payload["bindings"]) == {"jog_a_positive", "open_online_docs"}
+
+    restored = ShortcutBindings.from_json(raw)
+    assert restored.binding_for("open_online_docs") == KeyChord("d", ("ctrl", "shift"))
+    assert restored.binding_for("jog_a_positive") == KeyChord("]")
+    assert restored.binding_for("mdi_send") == KeyChord("enter", ("ctrl",))
+
+
+@pytest.mark.parametrize("raw", ["{", "[]", '{"version":99,"bindings":{}}', '{"version":1,"bindings":[]}'])
+def test_invalid_config_falls_back_to_defaults(raw):
+    assert ShortcutBindings.from_json(raw).binding_for("open_online_docs") == KeyChord("f1")
+
+
+def test_unknown_actions_are_ignored_for_forward_compatibility():
+    raw = '{"version":1,"bindings":{"future_action":{"key":"f2","modifiers":[]}}}'
+    assert ShortcutBindings.from_json(raw).to_json() == ""
+
+
+def test_conflicting_persisted_config_falls_back_to_defaults():
+    raw = '{"version":1,"bindings":{"open_start_job":{"key":"f1","modifiers":[]}}}'
+
+    bindings = ShortcutBindings.from_json(raw)
+
+    assert bindings.binding_for("open_start_job") is None
+    assert bindings.binding_for("open_online_docs") == KeyChord("f1")
+
+
+def test_invalid_persisted_action_does_not_discard_valid_overrides():
+    raw = (
+        '{"version":1,"bindings":{'
+        '"open_online_docs":{"key":"f2","modifiers":[]},'
+        '"jog_a_positive":{"key":"not-a-key","modifiers":[]}'
+        "}}"
+    )
+
+    bindings = ShortcutBindings.from_json(raw)
+
+    assert bindings.binding_for("open_online_docs") == KeyChord("f2")
+    assert bindings.binding_for("jog_a_positive") is None
+
+
+def test_event_normalisation_ignores_lock_modifiers_and_uses_physical_punctuation_key():
+    assert chord_from_event(44, ["ctrl", "capslock"], "<") == KeyChord(",", ("ctrl",))
+    assert chord_from_event(13, ["numlock"], "\r") == KeyChord("enter")
+    assert chord_from_event(271, ["ctrl"], "\r") == KeyChord("enter", ("ctrl",))
+
+
+@pytest.mark.parametrize(
+    "key,scancode,codepoint",
+    [
+        (305, 224, "i"),  # Kivy left Ctrl keycode
+        (306, 228, "ij"),  # Kivy right Ctrl keycode
+        (ord("i"), 224, "i"),  # SDL keycode quirk reported by some providers
+    ],
+)
+def test_modifier_keydown_is_not_misread_as_generated_text(key, scancode, codepoint):
+    assert chord_from_event(key, ["ctrl"], codepoint, scancode) is None
+
+
+def test_ctrl_then_enter_captures_the_complete_chord():
+    assert chord_from_event(13, ["ctrl"], "\r", 40) == KeyChord("enter", ("ctrl",))
+
+
+def test_modifier_only_chord_is_rejected_by_the_model():
+    with pytest.raises(ValueError, match="non-modifier"):
+        KeyChord("lctrl")
+
+
+def test_modifier_matching_is_exact():
+    bindings = ShortcutBindings()
+    assert bindings.action_for(KeyChord("enter", ("ctrl",)), "mdi").action_id == "mdi_send"
+    assert bindings.action_for(KeyChord("enter", ("ctrl", "shift")), "mdi") is None
+
+
+def test_primary_modifier_resolves_by_platform():
+    chord = KeyChord(",", ("primary",))
+    assert chord.matches(KeyChord(",", ("ctrl",)), platform="linux")
+    assert chord.matches(KeyChord(",", ("meta",)), platform="darwin")
+    assert not chord.matches(KeyChord(",", ("ctrl",)), platform="darwin")
+    assert format_chord_parts(chord, platform="linux") == ("Ctrl", ",")
+    assert format_chord_parts(chord, platform="darwin") == ("Cmd", ",")
+    assert format_chord(chord, platform="linux") == "Ctrl+,"
+    assert format_chord(chord, platform="darwin") == "Cmd+,"
+
+
+def test_conflicts_rejected_in_overlapping_contexts():
+    bindings = ShortcutBindings()
+    with pytest.raises(ValueError, match="Open Online Documentation"):
+        bindings.assign("open_start_job", KeyChord("f1"))
+
+
+def test_mdi_and_jogging_may_reuse_a_chord():
+    bindings = ShortcutBindings()
+    bindings.assign("jog_a_positive", KeyChord("enter"))
+    assert bindings.binding_for("jog_a_positive") == KeyChord("enter")
+    assert bindings.binding_for("mdi_newline") == KeyChord("enter")
+
+
+def test_unbind_and_reset():
+    bindings = ShortcutBindings()
+    bindings.assign("open_online_docs", None)
+    assert bindings.binding_for("open_online_docs") is None
+    bindings.reset("open_online_docs")
+    assert bindings.binding_for("open_online_docs") == KeyChord("f1")
+    assert bindings.to_json() == ""


### PR DESCRIPTION
This PR implements a new settings screen that allows to configure the following keyboard shortcuts:

| Category | Feature                 | Default shortcut                                   |
|----------|-------------------------|----------------------------------------------------|
| Global   | Open Start Job          | *(not set)*                                          |
| Global   | Open Online Doc         | F1                                                 |
| Global   | Open Settings           | Ctrl + ,                                           |
| Global   | Open & focus MDI        | Ctrl + M                                           |
| Global   | Open & focus G-Code        | Ctrl + G                                           |
| Global   | Open File Browser       | Ctrl + O                                           |
| Global   | Toggle Keyboard Jogging | Ctrl + J                                           |
| Global   | Switch Jog Mode | Ctrl + K                                           |
| Jogging  | Jog X+                  | Right                                              |
| Jogging  | Jog X-                  | Left                                               |
| Jogging  | Jog Y+                  | Down or Up (depending on the "inverted Y" setting) |
| Jogging  | Jog Y-                  | Up or Down (depending on the "inverted Y" setting) |
| Jogging  | Jog Z+                  | Pg Up                                              |
| Jogging  | Jog Z-                  | Pg Down                                            |
| Jogging  | Jog A+                  | *(not set)*                                          |
| Jogging  | Jog A-                  | *(not set)*                                          |
| MDI      | Send Command            | Ctrl + Enter                                       |
| MDI      | Inser New Line          | Enter                                              |

<br/>

Small note regarding the Jog Y+/Y-: they won't be changed by the "Invert Y-axis Jogging Buttons" anymore but that setting should be taken into account:
* when users start using the new version (if they had the invert setting enabled the default bindings will also be inversed)
* when clicking on the "Reset" button next to those two bindings or the "Reset All" button

<br/>

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/06a40720-4d58-48a3-93a6-27fbbbe63fd5" />