### PR TITLE
Release notes word wrap

### DIFF
--- a/carveracontroller/ui/updates/UpgradePopup.kv
+++ b/carveracontroller/ui/updates/UpgradePopup.kv
@@ -43,13 +43,17 @@
                 size: self.size
                 radius: [dp(4)]
     Label:
-        text: root.text
+        id: body
+        text: root.markup_text or root.text
+        markup: True
+        shorten: False
         font_size: root.body_font_size
         bold: root.body_bold
         color: root.body_color
         halign: 'left'
         valign: 'middle' if root.kind == 'heading' else 'top'
-        text_size: self.width, self.height
+        text_size: self.width, None
+        on_ref_press: root.open_note_link(args[1])
 
 <UpdateGithubLink@ButtonBehavior+BoxLayout>:
     orientation: 'horizontal'
@@ -169,27 +173,36 @@
                 on_release: root.set_tab('firmware')
         BoxLayout:
             size_hint_y: None
-            height: dp(52)
+            height: max(dp(52), status_copy.height)
             spacing: dp(8)
             BoxLayout:
+                id: status_copy
                 orientation: 'vertical'
+                size_hint_y: None
+                height: self.minimum_height
                 spacing: dp(2)
                 Label:
                     text: root.status_title
+                    size_hint_y: None
+                    height: self.texture_size[1]
                     bold: True
                     font_size: dp(16)
                     color: 50/255, 164/255, 206/255, 1
                     halign: 'left'
                     valign: 'middle'
-                    text_size: self.size
+                    text_size: self.width, None
+                    shorten: False
                 Label:
                     text: root.status_detail
+                    size_hint_y: None
+                    height: self.texture_size[1] if self.text else 0
+                    opacity: 1 if root.status_detail else 0
                     font_size: dp(13)
                     color: 180/255, 180/255, 180/255, 1
                     halign: 'left'
                     valign: 'middle'
-                    text_size: self.size
-                    shorten: True
+                    text_size: self.width, None
+                    shorten: False
             FileBrowserBadge:
                 text: root.channel_badge
                 pos_hint: {'center_y': 0.5}
@@ -268,14 +281,15 @@
                     text_size: self.size
         Label:
             size_hint_y: None
-            height: dp(32) if root.helper_text else 0
+            height: (self.texture_size[1] + dp(8)) if root.helper_text else 0
             opacity: 1 if root.helper_text else 0
             text: root.helper_text
             font_size: dp(13)
             color: 50/255, 164/255, 206/255, 1
             halign: 'left'
             valign: 'middle'
-            text_size: self.size
+            text_size: self.width, None
+            shorten: False
         BoxLayout:
             id: footer_bar
             size_hint_y: None

--- a/carveracontroller/ui/updates/UpgradePopup.py
+++ b/carveracontroller/ui/updates/UpgradePopup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import webbrowser
 from datetime import datetime, timezone
 
 from kivy.app import App
@@ -52,16 +53,23 @@ _BADGE_COLORS = {
 class UpdateNotesRow(RecycleDataViewBehavior, BoxLayout):
     kind = StringProperty("paragraph")
     text = StringProperty("")
+    markup_text = StringProperty("")
     badge = StringProperty("")
     badge_color = ListProperty([0.0, 0.0, 0.0, 0.0])
     show_bullet = BooleanProperty(False)
     body_font_size = NumericProperty(13)
     body_bold = BooleanProperty(False)
     body_color = ListProperty([220 / 255, 220 / 255, 220 / 255, 1])
+    links = ListProperty([])
 
     def __init__(self, **kwargs):
         kwargs.setdefault("size_hint_y", None)
         super().__init__(**kwargs)
+
+    def open_note_link(self, ref):
+        url = _url_from_ref(ref, self.links)
+        if url:
+            _open_http_url(url)
 
 
 class UpgradePopup(ModalView):
@@ -334,6 +342,7 @@ class UpgradePopup(ModalView):
             self.notes_empty_text = tr._("Release notes will appear here after a successful check.")
             return
         wrap_width = rv.width if rv.width > 80 else Window.width * 0.7
+        wrap_width = max(wrap_width - dp(8), dp(80))
         rows = format_release_notes(body)
         rv.data = [_note_view_data(row, _measure_note_height(row, wrap_width)) for row in rows]
         self.show_notes = bool(rv.data)
@@ -538,25 +547,34 @@ def _note_view_data(row, height: float) -> dict:
     return {
         "kind": row.kind,
         "text": row.text,
+        "markup_text": row.markup or row.text,
         "badge": row.badge,
         "badge_color": _BADGE_COLORS.get(row.kind, [0.0, 0.0, 0.0, 0.0]),
         "show_bullet": row.kind == "bullet",
-        "body_font_size": dp(16) if heading else (dp(14) if row.kind == "paragraph" else dp(13)),
+        "body_font_size": _note_font_size(row.kind),
         "body_bold": heading,
         "body_color": [50 / 255, 164 / 255, 206 / 255, 1] if heading else [220 / 255, 220 / 255, 220 / 255, 1],
+        "links": list(row.links),
         "height": height,
     }
 
 
+def _note_font_size(kind: str) -> float:
+    if kind == "heading":
+        return dp(16)
+    if kind == "paragraph":
+        return dp(14)
+    return dp(13)
+
+
 def _measure_note_height(row, wrap_width: float) -> float:
-    font_size = 16 if row.kind == "heading" else (14 if row.kind == "paragraph" else 13)
     reserved = dp(24)
     if row.badge:
-        reserved += dp(108)
+        reserved += dp(110)
     if row.kind == "bullet":
-        reserved += dp(18)
+        reserved += dp(24)
     inner = max(wrap_width - reserved, dp(80))
-    text_h = _text_height(row.text or " ", font_size, inner)
+    text_h = _text_height(row.text or " ", _note_font_size(row.kind), inner)
     pad = dp(28) if row.kind == "heading" else (dp(16) if row.kind == "paragraph" else dp(12))
     return max(text_h + pad, dp(36) if row.kind == "heading" else dp(28))
 
@@ -579,6 +597,27 @@ def _text_width(text: str) -> float:
 def _text_height(text: str, font_size: float, wrap_width: float) -> float:
     label = _core_label(text, font_size, text_size=(wrap_width, None), valign="top", halign="left")
     return float(label.content_size[1])
+
+
+def _url_from_ref(ref, links) -> str:
+    raw = "" if ref is None else str(ref).strip()
+    if not raw.isdigit():
+        return ""
+    index = int(raw)
+    if 0 <= index < len(links):
+        return str(links[index]).strip()
+    return ""
+
+
+def _open_http_url(url: str) -> None:
+    target = (url or "").strip()
+    if not (target.startswith("http://") or target.startswith("https://")):
+        return
+    makera = _makera()
+    if makera is not None:
+        makera.open_url(target)
+        return
+    webbrowser.open(target, new=2)
 
 
 if "UpdateNotesRow" not in Factory.classes:

--- a/carveracontroller/updater/notes.py
+++ b/carveracontroller/updater/notes.py
@@ -49,8 +49,6 @@ _CATEGORY_BADGE = {
 }
 _LINK_COLOR = "32a4ce"
 
-_Stored = list[tuple[str, str | None]]
-
 
 @dataclass(frozen=True)
 class NoteRow:
@@ -68,7 +66,7 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
 
     rows: list[NoteRow] = []
     paragraph: list[str] = []
-    stored: _Stored = []
+    stored: list[tuple[str, str | None]] = []
 
     def flush_paragraph() -> None:
         nonlocal paragraph
@@ -122,14 +120,14 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
     return rows if limit is None else rows[:limit]
 
 
-def _categorize(text: str, stored: _Stored) -> NoteRow | None:
+def _categorize(text: str, stored: list[tuple[str, str | None]]) -> NoteRow | None:
     categorized = _try_category(text, stored)
     if categorized is not None:
         return categorized
     return _note_row("bullet", text, stored)
 
 
-def _try_category(text: str, stored: _Stored) -> NoteRow | None:
+def _try_category(text: str, stored: list[tuple[str, str | None]]) -> NoteRow | None:
     if not text:
         return None
     match = _CATEGORY_RE.match(text)
@@ -141,7 +139,7 @@ def _try_category(text: str, stored: _Stored) -> NoteRow | None:
     return _note_row(kind, rest or text, stored, badge=badge)
 
 
-def _note_row(kind: str, tokenized: str, stored: _Stored, badge: str = "") -> NoteRow | None:
+def _note_row(kind: str, tokenized: str, stored: list[tuple[str, str | None]], badge: str = "") -> NoteRow | None:
     tokenized = tokenized.strip()
     if not tokenized:
         return None
@@ -151,7 +149,7 @@ def _note_row(kind: str, tokenized: str, stored: _Stored, badge: str = "") -> No
     return NoteRow(kind, text, badge=badge, markup=markup, links=links)
 
 
-def _parse_inline(text: str, stored: _Stored) -> str:
+def _parse_inline(text: str, stored: list[tuple[str, str | None]]) -> str:
     text = html.unescape(text or "")
 
     def stash(display: str, url: str | None, *, strip: bool = True) -> str:
@@ -199,7 +197,7 @@ def _parse_inline(text: str, stored: _Stored) -> str:
     return text.replace("\u0000", "").strip()
 
 
-def _expand_tokens(tokenized: str, stored: _Stored) -> tuple[str, str, tuple[str, ...]]:
+def _expand_tokens(tokenized: str, stored: list[tuple[str, str | None]]) -> tuple[str, str, tuple[str, ...]]:
     plain: list[str] = []
     markup: list[str] = []
     links: list[str] = []

--- a/carveracontroller/updater/notes.py
+++ b/carveracontroller/updater/notes.py
@@ -8,8 +8,21 @@ from dataclasses import dataclass
 
 _HTML_RE = re.compile(r"<[^>]+>")
 _BR_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
-_LINK_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)|\[([^\]]+)\]\([^)]+\)")
-_EMPHASIS_RE = re.compile(r"(\*\*|__|\*|_|`)(.+?)\1")
+_HTML_A_RE = re.compile(
+    r'<a\s[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+    re.IGNORECASE | re.DOTALL,
+)
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
+_MD_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
+_AUTOLINK_RE = re.compile(r"<(https?://[^>\s]+)>", re.IGNORECASE)
+_BARE_URL_RE = re.compile(r"https?://[^\s<>\[\]\"']+", re.IGNORECASE)
+# Strong markers and backticks are unambiguous. Single _ or * must sit on a
+# word boundary so identifiers like Carvera_Community_Firmware stay intact.
+_EMPHASIS_RE = re.compile(
+    r"(\*\*|__)(.+?)\1"
+    r"|(?<!\w)(\*|_)(?!\s)(.+?)(?<!\s)\3(?!\w)"
+    r"|`([^`]+)`"
+)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(.*)$")
 _NUMBERED_RE = re.compile(r"^\s*\d+\.\s+(.*)$")
@@ -17,6 +30,9 @@ _CATEGORY_RE = re.compile(
     r"^(Enhancement|Fixed|Fix|Change|Changed|Breaking)[:\s]+(.*)$",
     re.IGNORECASE,
 )
+# Private-use delimiters so placeholders survive str.strip(); ASCII RS (\x1e) is whitespace.
+_TOKEN_MARK = "\ue000"
+_TOKEN_RE = re.compile(_TOKEN_MARK + r"(\d+)" + _TOKEN_MARK)
 _CATEGORY_KIND = {
     "enhancement": "enhancement",
     "fixed": "fixed",
@@ -25,6 +41,15 @@ _CATEGORY_KIND = {
     "changed": "change",
     "breaking": "breaking",
 }
+_CATEGORY_BADGE = {
+    "enhancement": "Enhancement",
+    "fixed": "Fixed",
+    "change": "Changed",
+    "breaking": "Breaking",
+}
+_LINK_COLOR = "32a4ce"
+
+_Stored = list[tuple[str, str | None]]
 
 
 @dataclass(frozen=True)
@@ -32,6 +57,8 @@ class NoteRow:
     kind: str
     text: str
     badge: str = ""
+    markup: str = ""
+    links: tuple[str, ...] = ()
 
 
 def format_release_notes(body: str | None, *, limit: int | None = None) -> list[NoteRow]:
@@ -41,6 +68,7 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
 
     rows: list[NoteRow] = []
     paragraph: list[str] = []
+    stored: _Stored = []
 
     def flush_paragraph() -> None:
         nonlocal paragraph
@@ -48,14 +76,15 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
             return
         text = "\n".join(paragraph).strip()
         paragraph = []
-        if text:
-            rows.append(NoteRow("paragraph", text))
+        row = _note_row("paragraph", text, stored)
+        if row is not None:
+            rows.append(row)
 
     def at_limit() -> bool:
         return limit is not None and len(rows) >= limit
 
     for raw_line in body.replace("\r\n", "\n").split("\n"):
-        cleaned = _clean_inline(raw_line)
+        cleaned = _parse_inline(raw_line, stored)
         parts = cleaned.split("\n") if cleaned else [""]
         for line in parts:
             if at_limit():
@@ -69,16 +98,20 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
                 flush_paragraph()
                 title = heading.group(2).strip()
                 if title:
-                    rows.append(NoteRow("heading", title))
+                    row = _note_row("heading", title, stored)
+                    if row is not None:
+                        rows.append(row)
                 continue
             bullet = _BULLET_RE.match(line) or _NUMBERED_RE.match(line)
             if bullet:
                 flush_paragraph()
                 text = bullet.group(1).strip()
                 if text:
-                    rows.append(_categorize(text))
+                    row = _categorize(text, stored)
+                    if row is not None:
+                        rows.append(row)
                 continue
-            categorized = _try_category(line.strip())
+            categorized = _try_category(line.strip(), stored)
             if categorized is not None:
                 flush_paragraph()
                 rows.append(categorized)
@@ -89,35 +122,147 @@ def format_release_notes(body: str | None, *, limit: int | None = None) -> list[
     return rows if limit is None else rows[:limit]
 
 
-def _categorize(text: str) -> NoteRow:
-    categorized = _try_category(text)
+def _categorize(text: str, stored: _Stored) -> NoteRow | None:
+    categorized = _try_category(text, stored)
     if categorized is not None:
         return categorized
-    return NoteRow("bullet", text)
+    return _note_row("bullet", text, stored)
 
 
-def _try_category(text: str) -> NoteRow | None:
+def _try_category(text: str, stored: _Stored) -> NoteRow | None:
     if not text:
         return None
     match = _CATEGORY_RE.match(text)
     if match is None:
         return None
-    label = match.group(1)
+    kind = _CATEGORY_KIND.get(match.group(1).lower(), "bullet")
+    badge = _CATEGORY_BADGE.get(kind, "")
     rest = (match.group(2) or "").strip()
-    kind = _CATEGORY_KIND.get(label.lower(), "bullet")
-    badge = {
-        "enhancement": "Enhancement",
-        "fixed": "Fixed",
-        "change": "Changed",
-        "breaking": "Breaking",
-    }.get(kind, "")
-    return NoteRow(kind, rest or text, badge=badge)
+    return _note_row(kind, rest or text, stored, badge=badge)
 
 
-def _clean_inline(text: str) -> str:
-    text = html.unescape(text)
+def _note_row(kind: str, tokenized: str, stored: _Stored, badge: str = "") -> NoteRow | None:
+    tokenized = tokenized.strip()
+    if not tokenized:
+        return None
+    text, markup, links = _expand_tokens(tokenized, stored)
+    if not text:
+        return None
+    return NoteRow(kind, text, badge=badge, markup=markup, links=links)
+
+
+def _parse_inline(text: str, stored: _Stored) -> str:
+    text = html.unescape(text or "")
+
+    def stash(display: str, url: str | None, *, strip: bool = True) -> str:
+        stored.append((_strip_emphasis(display) if strip else display, url))
+        return f"{_TOKEN_MARK}{len(stored) - 1}{_TOKEN_MARK}"
+
+    text = _MD_IMAGE_RE.sub(lambda match: match.group(1) or "", text)
+
+    def md_link(match: re.Match[str]) -> str:
+        label = match.group(1)
+        url = _http_url(_md_destination(match.group(2)))
+        if url:
+            return stash(label, url)
+        return label
+
+    text = _MD_LINK_RE.sub(md_link, text)
+
+    def html_a(match: re.Match[str]) -> str:
+        inner = _strip_emphasis(_HTML_RE.sub("", html.unescape(match.group(2))))
+        url = _http_url(match.group(1))
+        if url:
+            return stash(inner, url)
+        return inner
+
+    text = _HTML_A_RE.sub(html_a, text)
+
+    def autolink(match: re.Match[str]) -> str:
+        url = _http_url(match.group(1))
+        if url:
+            return stash(url, url, strip=False)
+        return match.group(1)
+
+    def bare_url(match: re.Match[str]) -> str:
+        url, trailing = _split_trailing_punct(match.group(0))
+        http = _http_url(url)
+        if http:
+            return stash(http, http, strip=False) + trailing
+        return match.group(0)
+
+    text = _AUTOLINK_RE.sub(autolink, text)
     text = _BR_RE.sub("\n", text)
     text = _HTML_RE.sub("", text)
-    text = _LINK_RE.sub(lambda match: match.group(1) or match.group(2) or "", text)
-    text = _EMPHASIS_RE.sub(lambda match: match.group(2), text)
+    text = _BARE_URL_RE.sub(bare_url, text)
+    text = _strip_emphasis(text)
     return text.replace("\u0000", "").strip()
+
+
+def _expand_tokens(tokenized: str, stored: _Stored) -> tuple[str, str, tuple[str, ...]]:
+    plain: list[str] = []
+    markup: list[str] = []
+    links: list[str] = []
+    pos = 0
+    for match in _TOKEN_RE.finditer(tokenized):
+        if match.start() > pos:
+            chunk = tokenized[pos : match.start()]
+            plain.append(chunk)
+            markup.append(_escape_markup(chunk))
+        index = int(match.group(1))
+        if 0 <= index < len(stored):
+            display, url = stored[index]
+            if display:
+                plain.append(display)
+                escaped = _escape_markup(display)
+                if url:
+                    markup.append(f"[ref={len(links)}][color=#{_LINK_COLOR}][u]{escaped}[/u][/color][/ref]")
+                    links.append(url)
+                else:
+                    markup.append(escaped)
+        pos = match.end()
+    if pos < len(tokenized):
+        chunk = tokenized[pos:]
+        plain.append(chunk)
+        markup.append(_escape_markup(chunk))
+    return "".join(plain), "".join(markup), tuple(links)
+
+
+def _escape_markup(text: str) -> str:
+    return text.replace("&", "&amp;").replace("[", "&bl;").replace("]", "&br;")
+
+
+def _strip_emphasis(text: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        return match.group(2) or match.group(4) or match.group(5) or ""
+
+    return _EMPHASIS_RE.sub(repl, text)
+
+
+def _md_destination(raw: str) -> str:
+    text = (raw or "").strip()
+    if text.startswith("<") and ">" in text:
+        return text[1 : text.index(">")].strip()
+    if not text:
+        return ""
+    return text.split()[0]
+
+
+def _split_trailing_punct(text: str) -> tuple[str, str]:
+    url = text
+    trailing = ""
+    while url and url[-1] in ".,;:)]}>\"'":
+        trailing = url[-1] + trailing
+        url = url[:-1]
+    return url, trailing
+
+
+def _http_url(value: str | None) -> str | None:
+    url = (value or "").strip()
+    if url.startswith("<") and url.endswith(">"):
+        url = url[1:-1].strip()
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return None
+    if any(ord(char) < 32 for char in url):
+        return None
+    return url

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -183,7 +183,7 @@ def kivy_app():
     from carveracontroller.translation import tr
 
     # Replicate main() startup sequence (main.py:6470-6494)
-    translation.init(None)
+    translation.init("en")
     load_constants()
     set_config_defaults(tr.lang)
     load_app_configs()

--- a/tests/integration/test_update_center.py
+++ b/tests/integration/test_update_center.py
@@ -1,9 +1,11 @@
 """Smoke the Update Center tabs at normal and compact window sizes."""
 
 from kivy.core.window import Window
+from kivy.metrics import dp
 
-from carveracontroller.ui.updates.UpgradePopup import UpdateNotesRow
+from carveracontroller.ui.updates.UpgradePopup import UpdateNotesRow, _measure_note_height
 from carveracontroller.updater.github import FetchResult, parse_release
+from carveracontroller.updater.notes import format_release_notes
 from carveracontroller.updater.service import snapshot_from_fetches
 from tests.integration.conftest import pump_frames
 
@@ -93,7 +95,10 @@ def test_update_center_tabs_normal_and_compact(kivy_app, connected_idle_state):
         assert popup.notes_link_text == "View release on GitHub"
         notes = popup.ids.notes_list.data
         linked = next(item for item in notes if item.get("links"))
-        assert linked["height"] > 32
+        # Wide session window keeps this URL on one line (~dp(28) on density-1 CI).
+        assert linked["height"] >= dp(28)
+        row = next(item for item in format_release_notes(snapshot.controller.latest.body) if item.links)
+        assert _measure_note_height(row, dp(120)) > _measure_note_height(row, dp(2000))
         assert linked["links"][0].startswith("https://")
         assert "[ref=0]" in linked["markup_text"]
         opened = []

--- a/tests/integration/test_update_center.py
+++ b/tests/integration/test_update_center.py
@@ -2,6 +2,7 @@
 
 from kivy.core.window import Window
 
+from carveracontroller.ui.updates.UpgradePopup import UpdateNotesRow
 from carveracontroller.updater.github import FetchResult, parse_release
 from carveracontroller.updater.service import snapshot_from_fetches
 from tests.integration.conftest import pump_frames
@@ -13,7 +14,11 @@ def _snapshot():
             "tag_name": "v2.2.0",
             "name": "v2.2.0",
             "html_url": "https://github.com/Carvera-Community/Carvera_Controller/releases/tag/v2.2.0",
-            "body": "## Added\n- Update Center",
+            "body": (
+                "## Added\n"
+                "- Update Center\n"
+                "- See https://github.com/Carvera-Community/Carvera_Controller/wiki/long-path-name-that-should-wrap"
+            ),
             "published_at": "2024-05-01T00:00:00Z",
             "prerelease": False,
             "draft": False,
@@ -86,6 +91,17 @@ def test_update_center_tabs_normal_and_compact(kivy_app, connected_idle_state):
         assert not popup.compact
         assert "Current version" in popup.controller_tab_path
         assert popup.notes_link_text == "View release on GitHub"
+        notes = popup.ids.notes_list.data
+        linked = next(item for item in notes if item.get("links"))
+        assert linked["height"] > 32
+        assert linked["links"][0].startswith("https://")
+        assert "[ref=0]" in linked["markup_text"]
+        opened = []
+        root.open_url = opened.append
+        note_row = UpdateNotesRow()
+        note_row.links = list(linked["links"])
+        note_row.open_note_link("0")
+        assert opened == [linked["links"][0]]
         assert all(
             "Check for updates" not in getattr(child, "btn_text", "") for child in popup.ids.footer_actions.children
         )

--- a/tests/unit/test_halt_estop_note.py
+++ b/tests/unit/test_halt_estop_note.py
@@ -34,6 +34,13 @@ class _Popup:
         self.lb_content = _Label(content)
 
 
+@pytest.fixture(autouse=True)
+def identity_translations():
+    # Full-suite runs can leave tr on the host locale after integration setup.
+    with patch("carveracontroller.main.tr._", side_effect=lambda s: s):
+        yield
+
+
 @pytest.fixture
 def halt_host():
     return SimpleNamespace(

--- a/tests/unit/test_shortcut_dispatch.py
+++ b/tests/unit/test_shortcut_dispatch.py
@@ -40,6 +40,10 @@ def _manager(root=None):
     return manager
 
 
+def _primary_modifiers():
+    return list(KeyChord(",", ("primary",)).resolved_modifiers())
+
+
 def test_global_documentation_shortcut_is_dispatched_and_consumed():
     manager = _manager()
     assert manager.on_key_down(None, 282, 0, "", []) is True
@@ -71,7 +75,7 @@ def test_global_action_stops_active_keyboard_jog():
 def test_global_settings_and_mdi_shortcuts_dispatch_when_available():
     manager = _manager()
 
-    assert manager.on_key_down(None, 44, 54, ",", ["ctrl"]) is True
+    assert manager.on_key_down(None, 44, 54, ",", _primary_modifiers()) is True
     manager.root.config_popup.open.assert_called_once_with()
     assert manager.on_key_up(None, 44) is True
 
@@ -357,7 +361,7 @@ def test_blocked_global_shortcut_is_not_consumed():
     manager = _manager()
     manager.root._is_popup_open.return_value = True
 
-    assert manager.on_key_down(None, 44, 0, ",", ["ctrl"]) is False
+    assert manager.on_key_down(None, 44, 0, ",", _primary_modifiers()) is False
     manager.root.config_popup.open.assert_not_called()
     assert manager.on_key_down(None, ord("g"), 0, "g", ["ctrl"]) is False
     manager.root.open_gcode.assert_not_called()

--- a/tests/unit/test_updater_core.py
+++ b/tests/unit/test_updater_core.py
@@ -152,10 +152,7 @@ def test_format_release_notes_strips_trailing_url_punctuation():
 
 
 def test_format_release_notes_keeps_underscores_in_urls_and_names():
-    url = (
-        "https://github.com/Carvera-Community/Carvera_Community_Firmware/"
-        "compare/v2.2.0c-RC2...v2.2.0c-RC3"
-    )
+    url = "https://github.com/Carvera-Community/Carvera_Community_Firmware/compare/v2.2.0c-RC2...v2.2.0c-RC3"
     rows = format_release_notes(f"**Full Changelog**: {url}\n- Carvera_Community_Firmware")
     changelog = next(row for row in rows if row.kind == "paragraph")
     assert changelog.links == (url,)

--- a/tests/unit/test_updater_core.py
+++ b/tests/unit/test_updater_core.py
@@ -79,7 +79,10 @@ Paragraph one.
     assert any(row.text == "Added" for row in rows if row.kind == "heading")
     assert "Bold item with a link" in texts
     assert all("<script>" not in row.text for row in rows)
-    assert all("http" not in row.text for row in rows)
+    link_row = next(row for row in rows if row.text == "Bold item with a link")
+    assert link_row.links == ("https://example.test",)
+    assert "[ref=0]" in link_row.markup
+    assert "https://example.test" not in link_row.text
 
 
 def test_format_release_notes_categorizes_changelog_prefixes():
@@ -114,6 +117,52 @@ def test_format_release_notes_does_not_truncate_long_changelogs():
     assert len(rows) == 91
     assert rows[0].kind == "heading"
     assert rows[-1].text == "item 89"
+
+
+def test_format_release_notes_linkifies_http_urls():
+    rows = format_release_notes(
+        "See https://github.com/Carvera-Community/Carvera_Controller/pull/42 for details.\n"
+        "- Enhancement: Docs at <https://example.test/guide>\n"
+        '- Also <a href="https://example.test/a">the appendix</a>.\n'
+        "- Ignore [file](file:///tmp/x) and [js](javascript:alert(1))"
+    )
+    paragraph = next(row for row in rows if row.kind == "paragraph")
+    assert paragraph.links == ("https://github.com/Carvera-Community/Carvera_Controller/pull/42",)
+    assert "https://github.com/Carvera-Community/Carvera_Controller/pull/42" in paragraph.text
+    assert "[u]" in paragraph.markup
+
+    autolink = next(row for row in rows if row.kind == "enhancement")
+    assert autolink.links == ("https://example.test/guide",)
+    assert autolink.text == "Docs at https://example.test/guide"
+
+    appendix = next(row for row in rows if "appendix" in row.text)
+    assert appendix.links == ("https://example.test/a",)
+    assert appendix.text == "Also the appendix."
+
+    ignored = next(row for row in rows if "Ignore" in row.text)
+    assert ignored.links == ()
+    assert "file" in ignored.text
+    assert "js" in ignored.text
+
+
+def test_format_release_notes_strips_trailing_url_punctuation():
+    rows = format_release_notes("Read https://example.test/foo.")
+    assert rows[0].links == ("https://example.test/foo",)
+    assert rows[0].text.endswith("foo.")
+
+
+def test_format_release_notes_keeps_underscores_in_urls_and_names():
+    url = (
+        "https://github.com/Carvera-Community/Carvera_Community_Firmware/"
+        "compare/v2.2.0c-RC2...v2.2.0c-RC3"
+    )
+    rows = format_release_notes(f"**Full Changelog**: {url}\n- Carvera_Community_Firmware")
+    changelog = next(row for row in rows if row.kind == "paragraph")
+    assert changelog.links == (url,)
+    assert url in changelog.text
+    assert "CarveraCommunityFirmware" not in changelog.text
+    name = next(row for row in rows if row.kind == "bullet")
+    assert name.text == "Carvera_Community_Firmware"
 
 
 def test_detect_platform_keys():


### PR DESCRIPTION
# Summary

Update viewer release notes would get truncated if they didn't fit on a single line on display with >1 DPI scaling. Now they word wrap. Also links now can be clicked and will open in the local web browser.

Latest stable/RC notes were viewed as part of testing and now render as expected.

Before:

<img width="959" height="721" alt="Screenshot 2026-09-12 at 7 29 55 am" src="https://github.com/user-attachments/assets/eff54338-9c26-4988-a15b-896837be0837" />

<img width="958" height="717" alt="Screenshot 2026-09-12 at 7 30 24 am" src="https://github.com/user-attachments/assets/e8a1320d-fd45-4e14-845d-29e60b80f01f" />


After:
<img width="974" height="716" alt="Screenshot 2026-09-12 at 7 27 23 am" src="https://github.com/user-attachments/assets/9db6c57a-024e-4449-b1b1-65231ce38f0f" />

<img width="986" height="734" alt="Screenshot 2026-09-12 at 7 27 53 am" src="https://github.com/user-attachments/assets/42959f82-c8a5-45c0-b902-0921a6abc425" />


AI Assistance was used, model:cursor-grok-4.6-high 

# Contributor checklist

- [x] I am a human submitting this pull request.
- [x] I have read and understand every changed line, and I take responsibility
      for the complete change.
- [x] Pre-commit checks (`poetry run pre-commit run --all-files`) passes with no errors.
- [x] The changes have been tested with real hardware.
- [x] I have read and understood the [contributions guidelines](https://github.com/Carvera-Community/Carvera_Controller/blob/develop/CONTRIBUTING.md)
